### PR TITLE
feat: set up oprc context and add testing

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.4.2",
     "@tailwindcss/vite": "^4",
     "@types/node": "^22",
     "@types/react": "^19",

--- a/apps/web/src/routes/api/rpc.$.ts
+++ b/apps/web/src/routes/api/rpc.$.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { RPCHandler } from "@orpc/server/fetch";
+import { db } from "@turf/db";
 import { router } from "../../rpc";
 
 const handler = new RPCHandler(router);
@@ -20,7 +21,7 @@ export const Route = createFileRoute("/api/rpc/$")({
 
         const { response } = await handler.handle(request, {
           prefix: "/api/rpc",
-          context: {},
+          context: { db, request },
         });
 
         const res = response ?? new Response("Not Found", { status: 404 });

--- a/apps/web/src/rpc/client.ts
+++ b/apps/web/src/rpc/client.ts
@@ -4,13 +4,17 @@ import type { RouterClient } from "@orpc/server";
 import { createRouterClient } from "@orpc/server";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
+import { db } from "@turf/db";
 import { router, type Router } from ".";
 
 const getClient = createIsomorphicFn()
   .server(() =>
     createRouterClient(router, {
       context: async () => ({
-        headers: getRequestHeaders(),
+        db,
+        request: new Request("http://localhost", {
+          headers: getRequestHeaders(),
+        }),
       }),
     }),
   )

--- a/apps/web/src/rpc/context.ts
+++ b/apps/web/src/rpc/context.ts
@@ -1,0 +1,13 @@
+import { os } from "@orpc/server";
+import type { Db } from "@turf/db";
+
+export type ORPCContext = {
+  db: Db;
+  request?: Request;
+};
+
+// Base procedure with context — all procedures build on this
+export const base = os.$context<ORPCContext>();
+
+// Public procedure (no auth required)
+export const pub = base.route({ method: "GET" });

--- a/apps/web/src/rpc/index.ts
+++ b/apps/web/src/rpc/index.ts
@@ -1,14 +1,9 @@
-import { os } from "@orpc/server";
-import { db } from "@turf/db";
-
 import { z } from "zod";
-
-// Base procedure — all procedures will build on this
-const pub = os.route({ method: "GET" });
+import { pub } from "./context";
 
 export const router = {
-  healthcheck: pub.input(z.object({}).optional()).handler(async () => {
-    await db.execute("SELECT 1 as ok");
+  healthcheck: pub.input(z.object({}).optional()).handler(async ({ context }) => {
+    await context.db.execute("SELECT 1 as ok");
     return { status: "ok", db: "connected" };
   }),
 };

--- a/apps/web/tests/healthcheck.test.ts
+++ b/apps/web/tests/healthcheck.test.ts
@@ -1,0 +1,9 @@
+import { expect } from "vite-plus/test";
+import { rpcTest } from "./rpc.setup";
+
+rpcTest("healthcheck returns ok with db connected", async ({ rpc }) => {
+  const result = await rpc.caller.healthcheck();
+
+  expect(result.status).toBe("ok");
+  expect(result.db).toBe("connected");
+});

--- a/apps/web/tests/rpc.setup.ts
+++ b/apps/web/tests/rpc.setup.ts
@@ -1,0 +1,33 @@
+import { createRouterClient } from "@orpc/server";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import type { Db } from "@turf/db";
+import { test } from "vite-plus/test";
+import { router } from "../src/rpc";
+
+export async function getTestClient() {
+  // Each test gets a fresh in-memory database
+  const pglite = new PGlite();
+  const db = drizzle({ client: pglite, casing: "snake_case" }) as unknown as Db;
+
+  const caller = createRouterClient(router, {
+    context: { db },
+  });
+
+  const stop = async () => {
+    await pglite.close();
+  };
+
+  return { caller, db, stop };
+}
+
+export const rpcTest = test.extend<{
+  rpc: Awaited<ReturnType<typeof getTestClient>>;
+}>({
+  // eslint-disable-next-line no-empty-pattern
+  rpc: async ({}, use) => {
+    const testClient = await getTestClient();
+    await use(testClient);
+    await testClient.stop();
+  },
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,6 +4,8 @@ import react from "@vitejs/plugin-react";
 import { nitro } from "nitro/vite";
 import { defineConfig } from "vite-plus";
 
+const isTest = process.env.NODE_ENV === "test" || !!process.env.VITEST;
+
 export default defineConfig({
   resolve: {
     tsconfigPaths: true,
@@ -14,12 +16,14 @@ export default defineConfig({
   ssr: {
     noExternal: ["@turf/db", "@electric-sql/pglite"],
   },
-  plugins: [
-    tanstackStart(),
-    // https://tanstack.com/start/latest/docs/framework/react/guide/hosting
-    nitro(),
-    // React's Vite plugin must come after Start's Vite plugin
-    react(),
-    tailwindcss(),
-  ],
+  plugins: isTest
+    ? []
+    : [
+        tanstackStart(),
+        // https://tanstack.com/start/latest/docs/framework/react/guide/hosting
+        nitro(),
+        // React's Vite plugin must come after Start's Vite plugin
+        react(),
+        tailwindcss(),
+      ],
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev:web": "vp run web#dev",
     "dev:native": "pnpm --filter native dev",
     "dev:data": "cd apps/data && uv run uvicorn main:app --reload --port 8000",
+    "check": "pnpm exec vp check --fix",
+    "test": "pnpm --filter web exec vp test",
     "db": "pnpm --filter @turf/db run db",
     "prepare": "vp config"
   },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12,7 +12,9 @@ const casing = "snake_case" as const;
 const pkgDir = path.dirname(fileURLToPath(import.meta.url));
 const localDbPath = path.join(pkgDir, "..", "local_db");
 
-export const db: PgAsyncDatabase<PgQueryResultHKT> = process.env.DATABASE_URL
+export type Db = PgAsyncDatabase<PgQueryResultHKT>;
+
+export const db: Db = process.env.DATABASE_URL
   ? drizzlePostgres({
       client: postgres(process.env.DATABASE_URL),
       schema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 55.1.6(expo@55.0.11)
       expo-router:
         specifier: ~55.0.10
-        version: 55.0.10(@expo/log-box@55.0.10)(@expo/metro-runtime@55.0.9)(@types/react@19.2.14)(expo-constants@55.0.11)(expo-font@55.0.4)(expo-linking@55.0.11)(expo@55.0.11)(react-dom@19.2.0)(react-native-gesture-handler@2.30.1)(react-native-reanimated@4.2.1)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0)
+        version: 55.0.10(@expo/log-box@55.0.10)(@expo/metro-runtime@55.0.9)(@types/react@19.2.14)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-linking@55.0.11)(expo@55.0.11)(react-dom@19.2.0)(react-native-gesture-handler@2.30.1)(react-native-reanimated@4.2.1)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0)
       expo-status-bar:
         specifier: ~55.0.5
         version: 55.0.5(react-native@0.83.4)(react@19.2.0)
@@ -135,7 +135,7 @@ importers:
         version: link:../../packages/db
       drizzle-orm:
         specifier: beta
-        version: 1.0.0-beta.20(@types/mssql@9.1.11)(mssql@11.0.1)(zod@4.3.6)
+        version: 1.0.0-beta.20(@electric-sql/pglite@0.4.2)(@types/mssql@9.1.11)(mssql@11.0.1)(zod@4.3.6)
       react:
         specifier: ^19
         version: 19.2.4
@@ -146,6 +146,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.4.2
+        version: 0.4.2
       '@tailwindcss/vite':
         specifier: ^4
         version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.14)
@@ -163,7 +166,7 @@ importers:
         version: 4.7.0(@voidzero-dev/vite-plus-core@0.1.14)
       nitro:
         specifier: ^3.0.260311-beta
-        version: 3.0.260311-beta(@voidzero-dev/vite-plus-core@0.1.14)(drizzle-orm@1.0.0-beta.20)
+        version: 3.0.260311-beta(@electric-sql/pglite@0.4.2)(@voidzero-dev/vite-plus-core@0.1.14)(drizzle-orm@1.0.0-beta.20)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -1400,7 +1403,6 @@ packages:
 
   /@electric-sql/pglite@0.4.2:
     resolution: {integrity: sha512-1GUUl/MZpy5QWgWisD3Epho3GkJrZ1MzVgQpo2pifQWUs96F9rXKZxeVLPhkwFYck34CH/kQ8lis6wX9ifn3kg==}
-    dev: false
 
   /@emnapi/core@1.9.1:
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -1944,7 +1946,7 @@ packages:
       debug: 4.4.3
       dnssd-advertise: 1.1.4
       expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.0)(react-native@0.83.4)(react@19.2.0)(typescript@5.9.3)
-      expo-router: 55.0.10(@expo/log-box@55.0.10)(@expo/metro-runtime@55.0.9)(@types/react@19.2.14)(expo-constants@55.0.11)(expo-font@55.0.4)(expo-linking@55.0.11)(expo@55.0.11)(react-dom@19.2.0)(react-native-gesture-handler@2.30.1)(react-native-reanimated@4.2.1)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0)
+      expo-router: 55.0.10(@expo/log-box@55.0.10)(@expo/metro-runtime@55.0.9)(@types/react@19.2.14)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-linking@55.0.11)(expo@55.0.11)(react-dom@19.2.0)(react-native-gesture-handler@2.30.1)(react-native-reanimated@4.2.1)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0)
       expo-server: 55.0.7
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -2302,7 +2304,7 @@ packages:
       expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.0)(react-native@0.83.4)(react@19.2.0)(typescript@5.9.3)
       expo-constants: 55.0.11(expo@55.0.11)(react-native@0.83.4)(typescript@5.9.3)
       expo-font: 55.0.6(expo@55.0.11)(react-native@0.83.4)(react@19.2.0)
-      expo-router: 55.0.10(@expo/log-box@55.0.10)(@expo/metro-runtime@55.0.9)(@types/react@19.2.14)(expo-constants@55.0.11)(expo-font@55.0.4)(expo-linking@55.0.11)(expo@55.0.11)(react-dom@19.2.0)(react-native-gesture-handler@2.30.1)(react-native-reanimated@4.2.1)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0)
+      expo-router: 55.0.10(@expo/log-box@55.0.10)(@expo/metro-runtime@55.0.9)(@types/react@19.2.14)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-linking@55.0.11)(expo@55.0.11)(react-dom@19.2.0)(react-native-gesture-handler@2.30.1)(react-native-reanimated@4.2.1)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0)
       expo-server: 55.0.7
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -5912,7 +5914,7 @@ packages:
   /csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  /db0@0.3.4(drizzle-orm@1.0.0-beta.20):
+  /db0@0.3.4(@electric-sql/pglite@0.4.2)(drizzle-orm@1.0.0-beta.20):
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
     peerDependencies:
       '@electric-sql/pglite': '*'
@@ -5935,7 +5937,8 @@ packages:
       sqlite3:
         optional: true
     dependencies:
-      drizzle-orm: 1.0.0-beta.20(@types/mssql@9.1.11)(mssql@11.0.1)(zod@4.3.6)
+      '@electric-sql/pglite': 0.4.2
+      drizzle-orm: 1.0.0-beta.20(@electric-sql/pglite@0.4.2)(@types/mssql@9.1.11)(mssql@11.0.1)(zod@4.3.6)
     dev: true
 
   /debounce@2.2.0:
@@ -6204,7 +6207,7 @@ packages:
       postgres: 3.4.8
     dev: false
 
-  /drizzle-orm@1.0.0-beta.20(@types/mssql@9.1.11)(mssql@11.0.1)(zod@4.3.6):
+  /drizzle-orm@1.0.0-beta.20(@electric-sql/pglite@0.4.2)(@types/mssql@9.1.11)(mssql@11.0.1)(zod@4.3.6):
     resolution: {integrity: sha512-7qiuw+Z6yGr+ywt3PS5dP6UCfdymIuFT/ni6GnPGzLhkBIolNBTo4ByMBWTxJ7dW/Ya6d73GtkeuKfcVcriVHA==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
@@ -6319,6 +6322,7 @@ packages:
       zod:
         optional: true
     dependencies:
+      '@electric-sql/pglite': 0.4.2
       '@types/mssql': 9.1.11(@azure/core-client@1.10.1)
       mssql: 11.0.1(@azure/core-client@1.10.1)
       zod: 4.3.6
@@ -6546,18 +6550,6 @@ packages:
       expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.0)(react-native@0.83.4)(react@19.2.0)(typescript@5.9.3)
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
-  /expo-font@55.0.4(expo@55.0.11)(react-native@0.83.4)(react@19.2.0):
-    resolution: {integrity: sha512-ZKeGTFffPygvY5dM/9ATM2p7QDkhsaHopH7wFAWgP2lKzqUMS9B/RxCvw5CaObr9Ro7x9YptyeRKX2HmgmMfrg==}
-    peerDependencies:
-      expo: '*'
-      react: '*'
-      react-native: '*'
-    dependencies:
-      expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.0)(react-native@0.83.4)(react@19.2.0)(typescript@5.9.3)
-      fontfaceobserver: 2.3.0
-      react: 19.2.0
-      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
-
   /expo-font@55.0.6(expo@55.0.11)(react-native@0.83.4)(react@19.2.0):
     resolution: {integrity: sha512-x9czUA3UQWjIwa0ZUEs/eWJNqB4mAue/m4ltESlNPLZhHL0nWWqIfsyHmklTLFH7mVfcHSJvew6k+pR2FE1zVw==}
     peerDependencies:
@@ -6653,7 +6645,7 @@ packages:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
-  /expo-router@55.0.10(@expo/log-box@55.0.10)(@expo/metro-runtime@55.0.9)(@types/react@19.2.14)(expo-constants@55.0.11)(expo-font@55.0.4)(expo-linking@55.0.11)(expo@55.0.11)(react-dom@19.2.0)(react-native-gesture-handler@2.30.1)(react-native-reanimated@4.2.1)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0):
+  /expo-router@55.0.10(@expo/log-box@55.0.10)(@expo/metro-runtime@55.0.9)(@types/react@19.2.14)(expo-constants@55.0.11)(expo-font@55.0.6)(expo-linking@55.0.11)(expo@55.0.11)(react-dom@19.2.0)(react-native-gesture-handler@2.30.1)(react-native-reanimated@4.2.1)(react-native-safe-area-context@5.6.2)(react-native-screens@4.23.0)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0):
     resolution: {integrity: sha512-8aWTcWtuYN4vriMSWINMXC1rPVBGkHD4r4wWSAWX8e5RuSnXfy8RUcsC5L5Ewq4i7lo04VM2RJZAH6UYFFRKrQ==}
     peerDependencies:
       '@expo/log-box': 55.0.10
@@ -6705,7 +6697,7 @@ packages:
       expo-image: 55.0.8(expo@55.0.11)(react-native-web@0.21.2)(react-native@0.83.4)(react@19.2.0)
       expo-linking: 55.0.11(expo@55.0.11)(react-native@0.83.4)(react@19.2.0)(typescript@5.9.3)
       expo-server: 55.0.7
-      expo-symbols: 55.0.7(expo-font@55.0.4)(expo@55.0.11)(react-native@0.83.4)(react@19.2.0)
+      expo-symbols: 55.0.7(expo-font@55.0.6)(expo@55.0.11)(react-native@0.83.4)(react@19.2.0)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.11
@@ -6748,7 +6740,7 @@ packages:
       react-native-is-edge-to-edge: 1.3.1(react-native@0.83.4)(react@19.2.0)
     dev: false
 
-  /expo-symbols@55.0.7(expo-font@55.0.4)(expo@55.0.11)(react-native@0.83.4)(react@19.2.0):
+  /expo-symbols@55.0.7(expo-font@55.0.6)(expo@55.0.11)(react-native@0.83.4)(react@19.2.0):
     resolution: {integrity: sha512-y4ALLbncSGQzhFLw1PaIBbO39xzaw3ie249HmK6zK/WLJYfw4Z/9UU4iPKO3KCE4FyCKIzd+yRsvzvlri23YrQ==}
     peerDependencies:
       expo: '*'
@@ -6758,7 +6750,7 @@ packages:
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.27
       expo: 55.0.11(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.10)(react-dom@19.2.0)(react-native@0.83.4)(react@19.2.0)(typescript@5.9.3)
-      expo-font: 55.0.4(expo@55.0.11)(react-native@0.83.4)(react@19.2.0)
+      expo-font: 55.0.6(expo@55.0.11)(react-native@0.83.4)(react@19.2.0)
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
       sf-symbols-typescript: 2.2.0
@@ -8102,7 +8094,7 @@ packages:
     resolution: {integrity: sha512-MjG9u/IlvSq5txxY0oug1sjrGZ2l37IuhExI1iPuwV4S3RcyRNGoy6xLwznH3ATK6PUAM4fbQVb4Rzy1L1nlzw==}
     dev: true
 
-  /nitro@3.0.260311-beta(@voidzero-dev/vite-plus-core@0.1.14)(drizzle-orm@1.0.0-beta.20):
+  /nitro@3.0.260311-beta(@electric-sql/pglite@0.4.2)(@voidzero-dev/vite-plus-core@0.1.14)(drizzle-orm@1.0.0-beta.20):
     resolution: {integrity: sha512-0o0fJ9LUh4WKUqJNX012jyieUOtMCnadkNDWr0mHzdraoHpJP/1CGNefjRyZyMXSpoJfwoWdNEZu2iGf35TUvQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
@@ -8132,7 +8124,7 @@ packages:
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.13)
-      db0: 0.3.4(drizzle-orm@1.0.0-beta.20)
+      db0: 0.3.4(@electric-sql/pglite@0.4.2)(drizzle-orm@1.0.0-beta.20)
       env-runner: 0.1.6
       h3: 2.0.1-rc.20(crossws@0.4.4)
       hookable: 6.1.0
@@ -9841,7 +9833,7 @@ packages:
       uploadthing:
         optional: true
     dependencies:
-      db0: 0.3.4(drizzle-orm@1.0.0-beta.20)
+      db0: 0.3.4(@electric-sql/pglite@0.4.2)(drizzle-orm@1.0.0-beta.20)
       ofetch: 2.0.0-alpha.3
     dev: true
 


### PR DESCRIPTION
As suggested by @ben-pr-p defines an `ORPCContext` that wraps a `db` and `Request` to make it possible to write tests for the RPC procedures each with a separate PGlite instance, also included a super simple test to show that it's working