### PR TITLE
feat: voter file import

### DIFF
--- a/apps/data/import_voter_file.py
+++ b/apps/data/import_voter_file.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+import duckdb
+
+
+def get_next_version(conn: duckdb.DuckDBPyConnection, voter_file_id: str) -> int:
+    """Get the next voter_file_version for a given voter_file_id."""
+    result = conn.execute(
+        "SELECT COALESCE(MAX(voter_file_version), 0) FROM voter_file WHERE voter_file_id = ?",
+        [voter_file_id],
+    ).fetchone()
+    return (result[0] if result else 0) + 1
+
+
+def import_voter_file(conn: duckdb.DuckDBPyConnection, file_path: str, voter_file_id: str = "nys_boe") -> dict:
+    """Import a raw voter file parquet into DuckLake tables.
+
+    All transformations run in DuckDB SQL for performance on large files.
+    """
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Voter file not found: {file_path}")
+
+    version = get_next_version(conn, voter_file_id)
+    state = "NY"  # TODO: derive from voter_file_id
+
+    # Helper SQL for deterministic address hashing via md5 → UUID
+    # Normalizes: uppercase, trim, collapse whitespace, join with pipe separator
+    def addr_hash(*cols: str) -> str:
+        normalized = ["UPPER(TRIM(COALESCE(CAST(" + c + " AS VARCHAR), '')))" for c in cols]
+        concatenated = " || '|' || ".join(normalized)
+        return "CAST(md5(" + concatenated + ") AS UUID)"
+
+    building_hash = addr_hash("res_house_number", "res_street_name", "res_city", "'" + state + "'", "res_zip5")
+    door_hash = addr_hash(
+        "res_house_number", "res_street_name", "res_apartment", "res_city", "'" + state + "'", "res_zip5"
+    )
+
+    # Helper for date parsing: YYYYMMDD string → DATE
+    def parse_date(col: str) -> str:
+        cast = f"CAST({col} AS VARCHAR)"
+        return f"""
+            CASE
+                WHEN {cast} IS NOT NULL AND length({cast}) = 8 AND {cast} ~ '^[0-9]{{8}}$'
+                THEN CAST(substr({cast}, 1, 4) || '-' || substr({cast}, 5, 2) || '-' || substr({cast}, 7, 2) AS DATE)
+                ELSE NULL
+            END
+        """
+
+    # Insert into voter_file with column mapping
+    conn.execute(f"""
+        INSERT INTO voter_file
+        SELECT
+            sboe_id AS voter_id,
+            '{voter_file_id}' AS voter_file_id,
+            {version} AS voter_file_version,
+            {door_hash} AS door_id,
+            {building_hash} AS building_id,
+            first_name,
+            last_name,
+            middle_name,
+            name_suffix,
+            {parse_date("date_of_birth")} AS date_of_birth,
+            gender,
+            enrollment AS party,
+            status,
+            CAST(county_code AS VARCHAR) AS county_code,
+            CAST(election_district AS INTEGER) AS precinct,
+            CAST(congressional_district AS INTEGER) AS congressional_district,
+            CAST(senate_district AS INTEGER) AS senate_district,
+            CAST(assembly_district AS INTEGER) AS assembly_district,
+            CAST(res_city AS VARCHAR) AS city,
+            '{state}' AS state,
+            CAST(res_zip5 AS VARCHAR) AS zip,
+            CAST(ward AS VARCHAR) AS ward,
+            {parse_date("registration_date")} AS registration_date,
+            {parse_date("last_voted_date")} AS last_voted_date,
+            voter_history,
+            CAST(res_house_number AS VARCHAR) AS house_number,
+            CAST(res_street_name AS VARCHAR) AS street_name,
+            CAST(res_apartment AS VARCHAR) AS unit,
+            NULL::DOUBLE AS latitude,
+            NULL::DOUBLE AS longitude
+        FROM '{file_path}'
+    """)
+
+    total_rows = conn.execute(
+        "SELECT count(*) FROM voter_file WHERE voter_file_id = ? AND voter_file_version = ?",
+        [voter_file_id, version],
+    ).fetchone()[0]
+
+    # Extract unique buildings and insert (skip existing)
+    conn.execute(f"""
+        INSERT INTO buildings
+        SELECT DISTINCT ON (building_id)
+            building_id, house_number, street_name, city, state, zip,
+            NULL::DOUBLE AS latitude, NULL::DOUBLE AS longitude
+        FROM voter_file
+        WHERE voter_file_id = '{voter_file_id}'
+          AND voter_file_version = {version}
+          AND building_id NOT IN (SELECT building_id FROM buildings)
+    """)
+
+    building_count = conn.execute(
+        "SELECT count(DISTINCT building_id) FROM voter_file WHERE voter_file_id = ? AND voter_file_version = ?",
+        [voter_file_id, version],
+    ).fetchone()[0]
+
+    # Extract unique doors and insert (skip existing)
+    conn.execute(f"""
+        INSERT INTO doors
+        SELECT DISTINCT ON (door_id)
+            door_id, building_id, house_number, street_name, unit, city, state, zip,
+            NULL::DOUBLE AS latitude, NULL::DOUBLE AS longitude
+        FROM voter_file
+        WHERE voter_file_id = '{voter_file_id}'
+          AND voter_file_version = {version}
+          AND door_id NOT IN (SELECT door_id FROM doors)
+    """)
+
+    door_count = conn.execute(
+        "SELECT count(DISTINCT door_id) FROM voter_file WHERE voter_file_id = ? AND voter_file_version = ?",
+        [voter_file_id, version],
+    ).fetchone()[0]
+
+    return {
+        "voter_file_id": voter_file_id,
+        "voter_file_version": version,
+        "voters_imported": total_rows,
+        "buildings": building_count,
+        "doors": door_count,
+    }

--- a/apps/data/import_voter_file.py
+++ b/apps/data/import_voter_file.py
@@ -2,6 +2,76 @@ from pathlib import Path
 
 import duckdb
 
+# ── SQL helpers (generic) ─────────────────────────────────────────
+
+
+def _addr_hash(*cols: str) -> str:
+    """SQL expression for deterministic address hashing via md5 → UUID."""
+    normalized = ["UPPER(TRIM(COALESCE(CAST(" + c + " AS VARCHAR), '')))" for c in cols]
+    concatenated = " || '|' || ".join(normalized)
+    return "CAST(md5(" + concatenated + ") AS UUID)"
+
+
+def _parse_date(col: str) -> str:
+    """SQL expression to parse YYYYMMDD string → DATE."""
+    cast = f"CAST({col} AS VARCHAR)"
+    return f"""
+        CASE
+            WHEN {cast} IS NOT NULL AND length({cast}) = 8 AND {cast} ~ '^[0-9]{{8}}$'
+            THEN CAST(substr({cast}, 1, 4) || '-' || substr({cast}, 5, 2) || '-' || substr({cast}, 7, 2) AS DATE)
+            ELSE NULL
+        END
+    """
+
+
+# ── State-specific mappers ────────────────────────────────────────
+
+
+def _map_nys(conn: duckdb.DuckDBPyConnection, file_path: str) -> None:
+    """Map NY State BOE voter file columns to a generic schema.
+
+    Creates a temp table `staged_voters` with columns matching the voter_file schema
+    (minus voter_file_id, voter_file_version, door_id, building_id, latitude, longitude
+    which are added by the generic importer).
+    """
+    conn.execute(f"""
+        CREATE OR REPLACE TEMP TABLE staged_voters AS
+        SELECT
+            sboe_id AS voter_id,
+            first_name,
+            last_name,
+            middle_name,
+            name_suffix,
+            {_parse_date("date_of_birth")} AS date_of_birth,
+            gender,
+            enrollment AS party,
+            status,
+            CAST(county_code AS VARCHAR) AS county_code,
+            CAST(election_district AS INTEGER) AS precinct,
+            CAST(congressional_district AS INTEGER) AS congressional_district,
+            CAST(senate_district AS INTEGER) AS senate_district,
+            CAST(assembly_district AS INTEGER) AS assembly_district,
+            CAST(res_city AS VARCHAR) AS city,
+            'NY' AS state,
+            CAST(res_zip5 AS VARCHAR) AS zip,
+            CAST(ward AS VARCHAR) AS ward,
+            {_parse_date("registration_date")} AS registration_date,
+            {_parse_date("last_voted_date")} AS last_voted_date,
+            voter_history,
+            CAST(res_house_number AS VARCHAR) AS house_number,
+            CAST(res_street_name AS VARCHAR) AS street_name,
+            CAST(res_apartment AS VARCHAR) AS unit
+        FROM '{file_path}'
+    """)
+
+
+MAPPERS = {
+    "nys_boe": _map_nys,
+}
+
+
+# ── Generic importer ──────────────────────────────────────────────
+
 
 def get_next_version(conn: duckdb.DuckDBPyConnection, voter_file_id: str) -> int:
     """Get the next voter_file_version for a given voter_file_id."""
@@ -15,73 +85,42 @@ def get_next_version(conn: duckdb.DuckDBPyConnection, voter_file_id: str) -> int
 def import_voter_file(conn: duckdb.DuckDBPyConnection, file_path: str, voter_file_id: str = "nys_boe") -> dict:
     """Import a raw voter file parquet into DuckLake tables.
 
-    All transformations run in DuckDB SQL for performance on large files.
+    1. State-specific mapper normalizes raw columns into staged_voters temp table
+    2. Generic importer hashes addresses, assigns version, inserts into DuckLake tables
     """
     path = Path(file_path)
     if not path.exists():
         raise FileNotFoundError(f"Voter file not found: {file_path}")
 
+    # Step 1: State-specific column mapping → staged_voters temp table
+    mapper = MAPPERS.get(voter_file_id)
+    if mapper is None:
+        raise ValueError(f"No mapper registered for voter_file_id: {voter_file_id}")
+    mapper(conn, file_path)
+
+    # Step 2: Generic import from staged_voters
     version = get_next_version(conn, voter_file_id)
-    state = "NY"  # TODO: derive from voter_file_id
 
-    # Helper SQL for deterministic address hashing via md5 → UUID
-    # Normalizes: uppercase, trim, collapse whitespace, join with pipe separator
-    def addr_hash(*cols: str) -> str:
-        normalized = ["UPPER(TRIM(COALESCE(CAST(" + c + " AS VARCHAR), '')))" for c in cols]
-        concatenated = " || '|' || ".join(normalized)
-        return "CAST(md5(" + concatenated + ") AS UUID)"
+    building_hash = _addr_hash("house_number", "street_name", "city", "state", "zip")
+    door_hash = _addr_hash("house_number", "street_name", "unit", "city", "state", "zip")
 
-    building_hash = addr_hash("res_house_number", "res_street_name", "res_city", "'" + state + "'", "res_zip5")
-    door_hash = addr_hash(
-        "res_house_number", "res_street_name", "res_apartment", "res_city", "'" + state + "'", "res_zip5"
-    )
-
-    # Helper for date parsing: YYYYMMDD string → DATE
-    def parse_date(col: str) -> str:
-        cast = f"CAST({col} AS VARCHAR)"
-        return f"""
-            CASE
-                WHEN {cast} IS NOT NULL AND length({cast}) = 8 AND {cast} ~ '^[0-9]{{8}}$'
-                THEN CAST(substr({cast}, 1, 4) || '-' || substr({cast}, 5, 2) || '-' || substr({cast}, 7, 2) AS DATE)
-                ELSE NULL
-            END
-        """
-
-    # Insert into voter_file with column mapping
     conn.execute(f"""
         INSERT INTO voter_file
         SELECT
-            sboe_id AS voter_id,
+            voter_id,
             '{voter_file_id}' AS voter_file_id,
             {version} AS voter_file_version,
             {door_hash} AS door_id,
             {building_hash} AS building_id,
-            first_name,
-            last_name,
-            middle_name,
-            name_suffix,
-            {parse_date("date_of_birth")} AS date_of_birth,
-            gender,
-            enrollment AS party,
-            status,
-            CAST(county_code AS VARCHAR) AS county_code,
-            CAST(election_district AS INTEGER) AS precinct,
-            CAST(congressional_district AS INTEGER) AS congressional_district,
-            CAST(senate_district AS INTEGER) AS senate_district,
-            CAST(assembly_district AS INTEGER) AS assembly_district,
-            CAST(res_city AS VARCHAR) AS city,
-            '{state}' AS state,
-            CAST(res_zip5 AS VARCHAR) AS zip,
-            CAST(ward AS VARCHAR) AS ward,
-            {parse_date("registration_date")} AS registration_date,
-            {parse_date("last_voted_date")} AS last_voted_date,
-            voter_history,
-            CAST(res_house_number AS VARCHAR) AS house_number,
-            CAST(res_street_name AS VARCHAR) AS street_name,
-            CAST(res_apartment AS VARCHAR) AS unit,
+            first_name, last_name, middle_name, name_suffix,
+            date_of_birth, gender, party, status, county_code,
+            precinct, congressional_district, senate_district, assembly_district,
+            city, state, zip, ward,
+            registration_date, last_voted_date, voter_history,
+            house_number, street_name, unit,
             NULL::DOUBLE AS latitude,
             NULL::DOUBLE AS longitude
-        FROM '{file_path}'
+        FROM staged_voters
     """)
 
     total_rows = conn.execute(
@@ -89,7 +128,7 @@ def import_voter_file(conn: duckdb.DuckDBPyConnection, file_path: str, voter_fil
         [voter_file_id, version],
     ).fetchone()[0]
 
-    # Extract unique buildings and insert (skip existing)
+    # Extract unique buildings (skip existing)
     conn.execute(f"""
         INSERT INTO buildings
         SELECT DISTINCT ON (building_id)
@@ -106,7 +145,7 @@ def import_voter_file(conn: duckdb.DuckDBPyConnection, file_path: str, voter_fil
         [voter_file_id, version],
     ).fetchone()[0]
 
-    # Extract unique doors and insert (skip existing)
+    # Extract unique doors (skip existing)
     conn.execute(f"""
         INSERT INTO doors
         SELECT DISTINCT ON (door_id)
@@ -122,6 +161,9 @@ def import_voter_file(conn: duckdb.DuckDBPyConnection, file_path: str, voter_fil
         "SELECT count(DISTINCT door_id) FROM voter_file WHERE voter_file_id = ? AND voter_file_version = ?",
         [voter_file_id, version],
     ).fetchone()[0]
+
+    # Clean up
+    conn.execute("DROP TABLE IF EXISTS staged_voters")
 
     return {
         "voter_file_id": voter_file_id,

--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -1,9 +1,11 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
 from db import create_tables, get_connection
+from import_voter_file import import_voter_file
 from settings import get_settings
 
 logger = logging.getLogger("uvicorn")
@@ -40,4 +42,41 @@ async def ducklake_status():
     return {
         "status": "ok",
         "tables": table_info,
+    }
+
+
+class ImportRequest(BaseModel):
+    file_path: str
+    voter_file_id: str = "nys_boe"
+
+
+@app.post("/voter-file/import")
+async def import_voter_file_endpoint(request: ImportRequest):
+    conn = get_connection(settings)
+    try:
+        result = import_voter_file(conn, request.file_path, request.voter_file_id)
+        return result
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    finally:
+        conn.close()
+
+
+@app.get("/voter-file/{voter_file_id}/versions")
+async def list_versions(voter_file_id: str):
+    conn = get_connection(settings)
+    versions = conn.execute(
+        """
+        SELECT voter_file_version, count(*) as voter_count
+        FROM voter_file
+        WHERE voter_file_id = ?
+        GROUP BY voter_file_version
+        ORDER BY voter_file_version
+        """,
+        [voter_file_id],
+    ).fetchall()
+    conn.close()
+    return {
+        "voter_file_id": voter_file_id,
+        "versions": [{"version": v[0], "voter_count": v[1]} for v in versions],
     }

--- a/apps/data/tests/conftest.py
+++ b/apps/data/tests/conftest.py
@@ -1,0 +1,19 @@
+import tempfile
+
+import duckdb
+import pytest
+
+
+@pytest.fixture()
+def conn():
+    """Create an isolated DuckLake connection using a temp directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = duckdb.connect()
+        c.install_extension("ducklake")
+        c.load_extension("ducklake")
+        catalog = f"{tmpdir}/test.ducklake"
+        data_dir = f"{tmpdir}/data/"
+        c.execute(f"ATTACH 'ducklake:{catalog}' AS ducklake (DATA_PATH '{data_dir}')")
+        c.execute("USE ducklake")
+        yield c
+        c.close()

--- a/apps/data/tests/test_db.py
+++ b/apps/data/tests/test_db.py
@@ -1,10 +1,7 @@
-from db import create_tables, get_connection
-from settings import Settings
+from db import create_tables
 
 
-def test_ducklake_tables_created():
-    settings = Settings()
-    conn = get_connection(settings)
+def test_ducklake_tables_created(conn):
     create_tables(conn)
 
     tables = conn.execute("SHOW TABLES").fetchall()
@@ -15,16 +12,10 @@ def test_ducklake_tables_created():
     assert "doors" in table_names
     assert "universe_members" in table_names
 
-    conn.close()
 
-
-def test_ducklake_tables_idempotent():
-    settings = Settings()
-    conn = get_connection(settings)
+def test_ducklake_tables_idempotent(conn):
     create_tables(conn)
     create_tables(conn)
 
     tables = conn.execute("SHOW TABLES").fetchall()
     assert len(tables) == 4
-
-    conn.close()

--- a/apps/data/tests/test_import.py
+++ b/apps/data/tests/test_import.py
@@ -1,0 +1,49 @@
+import os
+
+from db import create_tables
+from import_voter_file import import_voter_file
+
+FIXTURE_PATH = os.path.join(os.path.dirname(__file__), "..", "fixtures", "nys-voters-2026-03-08-ad-65-ed-39.parquet")
+
+
+def test_import_voter_file(conn):
+    create_tables(conn)
+
+    result = import_voter_file(conn, FIXTURE_PATH, "nys_boe")
+
+    assert result["voter_file_id"] == "nys_boe"
+    assert result["voter_file_version"] == 1
+    assert result["voters_imported"] == 537
+    assert result["buildings"] == 41
+    assert result["doors"] == 390
+
+    # Verify data is in the tables
+    voter_count = conn.execute("SELECT count(*) FROM voter_file").fetchone()[0]
+    assert voter_count == 537
+
+    # Check column mapping
+    sample = conn.execute("SELECT voter_id, party, precinct, city, state FROM voter_file LIMIT 1").fetchone()
+    assert sample[0] is not None  # voter_id (was sboe_id)
+    assert sample[3] is not None  # city (was res_city)
+    assert sample[4] == "NY"  # state was added
+
+    # Check building/door IDs are UUIDs
+    bid = conn.execute("SELECT building_id FROM voter_file LIMIT 1").fetchone()[0]
+    assert len(bid) == 36 and bid.count("-") == 4  # UUID format
+
+    # Check dates were parsed
+    dob = conn.execute("SELECT date_of_birth FROM voter_file WHERE date_of_birth IS NOT NULL LIMIT 1").fetchone()
+    assert dob is not None
+
+
+def test_import_increments_version(conn):
+    create_tables(conn)
+
+    result1 = import_voter_file(conn, FIXTURE_PATH, "nys_boe")
+    result2 = import_voter_file(conn, FIXTURE_PATH, "nys_boe")
+
+    assert result1["voter_file_version"] == 1
+    assert result2["voter_file_version"] == 2
+
+    total = conn.execute("SELECT count(*) FROM voter_file WHERE voter_file_id = 'nys_boe'").fetchone()[0]
+    assert total == 537 * 2

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:web": "pnpm db:setup && vp run web#dev",
     "dev:native": "pnpm --filter native dev",
     "dev:data": "cd apps/data && uv run uvicorn main:app --reload --port 8000",
-    "check": "pnpm exec vp check --fix && cd apps/data && uv run ruff check . && uv run ruff format --check .",
+    "check": "pnpm exec vp check --fix && cd apps/data && uv run ruff check --fix . && uv run ruff format .",
     "test": "pnpm --filter web exec vp test && cd apps/data && uv run pytest",
     "data:clear": "rm -f apps/data/ducklake.ducklake && rm -rf apps/data/local_data",
     "db:setup": "pnpm db:push && pnpm db:seed",


### PR DESCRIPTION
This PR adds basic scaffolding for voter file import, including field renaming and casting for the NYS sample data, and then more general hashing of address partials to unique doors and buildings. New tests validate the parsing and hashing for the fixture data.