### PR TITLE
chore: rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Turf
+# Field Tools
 
 Open source field organizing and canvassing platform. Very much a work in progress.
 
@@ -17,7 +17,7 @@ You'll need to have these installed to run the development environment.
 Once the above are installed, run this to install both Node and Python dependencies.
 
 ```bash
-pnpm setup
+pnpm bootstrap
 ```
 
 ## Architecture

--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -24,7 +24,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="Turf Data Service", lifespan=lifespan)
+app = FastAPI(title="Data Service", lifespan=lifespan)
 
 
 class ImportRequest(BaseModel):

--- a/apps/native/app.json
+++ b/apps/native/app.json
@@ -1,17 +1,17 @@
 {
   "expo": {
-    "name": "turf-native",
-    "slug": "turf-native",
+    "name": "field-tools-native",
+    "slug": "field-tools-native",
     "version": "1.0.0",
-    "scheme": "turf",
+    "scheme": "field-tools",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.turf.native"
+      "bundleIdentifier": "tools.field.native"
     },
     "android": {
-      "package": "com.turf.nativeapp"
+      "package": "tools.field.nativeapp"
     },
     "web": {
       "bundler": "metro"

--- a/apps/native/src/app/_layout.tsx
+++ b/apps/native/src/app/_layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout() {
           headerBackTitle: "",
         }}
       >
-        <Stack.Screen name="index" options={{ title: "Turf" }} />
+        <Stack.Screen name="index" options={{ title: "Field Tools" }} />
         <Stack.Screen name="map" options={{ title: "Map" }} />
       </Stack>
     </QueryClientProvider>

--- a/apps/native/src/app/index.tsx
+++ b/apps/native/src/app/index.tsx
@@ -20,7 +20,7 @@ export default function HomeScreen() {
         className="mb-2 text-3xl text-foreground dark:text-foreground-dark"
         style={{ fontFamily: "Geist_700Bold", transform: [{ skewX: "-12deg" }] }}
       >
-        Turf
+        Field Tools
       </Text>
       <Text
         className="mb-8 text-center text-lg text-muted-foreground dark:text-muted-foreground-dark"

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,3 +1,3 @@
 VITE_BASE_URL=http://localhost:3000
 
-DATABASE_URL="postgresql://postgres:password@localhost:5432/turf"
+DATABASE_URL="postgresql://postgres:password@localhost:5432/field_tools"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@field-tools/db": "workspace:*",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.7",
     "@orpc/client": "^1.13.13",
@@ -23,7 +24,6 @@
     "@tanstack/react-query": "^5.96.1",
     "@tanstack/react-router": "^1",
     "@tanstack/react-start": "^1",
-    "@turf/db": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "beta",

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -18,7 +18,7 @@ export const Route = createRootRoute({
         content: "width=device-width, initial-scale=1",
       },
       {
-        title: "Turf",
+        title: "Field Tools",
       },
     ],
     links: [{ rel: "stylesheet", href: appCss }],

--- a/apps/web/src/routes/api/rpc.$.ts
+++ b/apps/web/src/routes/api/rpc.$.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { RPCHandler } from "@orpc/server/fetch";
-import { db } from "@turf/db";
+import { db } from "@field-tools/db";
 import { router } from "../../rpc";
 
 const handler = new RPCHandler(router);

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -24,7 +24,7 @@ function Home() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <div className="text-center">
-        <h1 className="mb-8 text-4xl font-bold italic">Turf</h1>
+        <h1 className="mb-8 text-4xl font-bold italic">Field Tools</h1>
         <p className="text-md text-muted-foreground">
           RPC status: <span className="font-mono">{isLoading ? "loading..." : data?.status}</span>
         </p>

--- a/apps/web/src/rpc/client.ts
+++ b/apps/web/src/rpc/client.ts
@@ -4,7 +4,7 @@ import type { RouterClient } from "@orpc/server";
 import { createRouterClient } from "@orpc/server";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
-import { db } from "@turf/db";
+import { db } from "@field-tools/db";
 import { router, type Router } from ".";
 
 const getClient = createIsomorphicFn()

--- a/apps/web/src/rpc/context.ts
+++ b/apps/web/src/rpc/context.ts
@@ -1,5 +1,5 @@
 import { os } from "@orpc/server";
-import type { Db } from "@turf/db";
+import type { Db } from "@field-tools/db";
 
 export type ORPCContext = {
   db: Db;

--- a/apps/web/tests/rpc.setup.ts
+++ b/apps/web/tests/rpc.setup.ts
@@ -1,7 +1,7 @@
 import { createRouterClient } from "@orpc/server";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
-import type { Db } from "@turf/db";
+import type { Db } from "@field-tools/db";
 import { test } from "vite-plus/test";
 import { router } from "../src/rpc";
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     port: 3000,
   },
   ssr: {
-    noExternal: ["@turf/db", "@electric-sql/pglite"],
+    noExternal: ["@field-tools/db", "@electric-sql/pglite"],
   },
   plugins: isTest
     ? []

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "turf",
+  "name": "field-tools",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "setup": "pnpm install && cd apps/data && uv sync",
+    "bootstrap": "pnpm install && cd apps/data && uv sync",
     "ready": "vp fmt && vp lint && vp run test -r && vp run build -r",
     "dev": "concurrently -n web,native,data,search -c blue,green,yellow,magenta \"pnpm run dev:web\" \"pnpm run dev:native\" \"pnpm run dev:data\" \"pnpm run dev:search\"",
     "dev:ios": "concurrently -n web,native,data,search -c blue,green,yellow,magenta \"pnpm run dev:web\" \"pnpm --filter native run ios\" \"pnpm run dev:data\" \"pnpm run dev:search\"",
@@ -20,9 +20,9 @@
     "data:clear": "rm -f apps/data/ducklake.ducklake && rm -rf apps/data/local_data && rm -rf apps/data/qwdata && mkdir -p apps/data/qwdata",
     "db:setup": "pnpm db:push && pnpm db:seed",
     "db:clear": "rm -rf packages/db/local_db",
-    "db:seed": "pnpm --filter @turf/db run seed",
+    "db:seed": "pnpm --filter @field-tools/db run seed",
     "db:push": "pnpm db push",
-    "db": "pnpm --filter @turf/db run db",
+    "db": "pnpm --filter @field-tools/db run db",
     "prepare": "vp config"
   },
   "devDependencies": {

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,2 +1,2 @@
 # For drizzle-kit migrations
-DATABASE_URL="postgresql://postgres:password@localhost:5432/turf"
+DATABASE_URL="postgresql://postgres:password@localhost:5432/field_tools"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@turf/db",
+  "name": "@field-tools/db",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -26,7 +26,7 @@ async function seed() {
     await db.insert(users).values({
       userId: USER_ID,
       organizationId: ORG_ID,
-      email: "admin@turf.tools",
+      email: "admin@field.tools",
       firstName: "Admin",
       lastName: "User",
       role: "admin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.1.17)(react-dom@19.2.4)(react@19.2.4)
+      '@field-tools/db':
+        specifier: workspace:*
+        version: link:../../packages/db
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
@@ -151,9 +154,6 @@ importers:
       '@tanstack/react-start':
         specifier: ^1
         version: 1.167.12(@voidzero-dev/vite-plus-core@0.1.14)(react-dom@19.2.4)(react@19.2.4)
-      '@turf/db':
-        specifier: workspace:*
-        version: link:../../packages/db
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
Rename from `Turf` to `Field Tools`. The eventual URL will be `https://field.tools` and the app will be `Field Tools`.