### PR TITLE
chore: rename rpc routes from admin to web

### DIFF
--- a/apps/web/src/lib/queries/boundaries.ts
+++ b/apps/web/src/lib/queries/boundaries.ts
@@ -7,7 +7,7 @@ export const boundariesGeoJsonQuery = (keyGroup: string, updatedAt: Date | strin
   queryOptions({
     queryKey: ["boundaries-geojson", keyGroup, updatedAt] as const,
     queryFn: async (): Promise<FeatureCollection> => {
-      const url = `/api/admin/boundaries/${keyGroup}/geojson?v=${new Date(updatedAt).getTime()}`;
+      const url = `/api/web/boundaries/${keyGroup}/geojson?v=${new Date(updatedAt).getTime()}`;
       const res = await fetch(url);
       if (!res.ok) throw new Error(`boundaries fetch failed: ${res.status}`);
       return (await res.json()) as FeatureCollection;

--- a/apps/web/src/lib/queries/segments.ts
+++ b/apps/web/src/lib/queries/segments.ts
@@ -57,7 +57,7 @@ export async function fetchSegmentPoints(input: {
   criteria: unknown;
   keyFilter?: { keyGroup: string; keys: string[] } | null;
 }): Promise<Float32Array> {
-  const res = await fetch("/api/admin/segment-points", {
+  const res = await fetch("/api/web/segment-points", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({

--- a/apps/web/src/lib/server/session.ts
+++ b/apps/web/src/lib/server/session.ts
@@ -8,7 +8,7 @@ export type SessionUser = { id: string; email: string; name: string | null };
 
 // Lookup the active session for the incoming request. Returns null when no
 // session exists. `AUTH_DISABLED=1` short-circuits to the seeded admin
-// (loaded from the DB so the values agree with `buildAdminContext`).
+// (loaded from the DB so the values agree with `buildWebContext`).
 //
 // Authenticated SSR responses are marked `Cache-Control: no-store` so the
 // browser opts out of bfcache on these pages.

--- a/apps/web/src/routes/api/web.boundaries.$keyGroup.geojson.ts
+++ b/apps/web/src/routes/api/web.boundaries.$keyGroup.geojson.ts
@@ -7,7 +7,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { db } from "@field-tools/db";
 import { dataFetch, passthrough } from "~/lib/server/data-proxy";
-import { buildAdminContext } from "~/rpc/context";
+import { buildWebContext } from "~/rpc/context";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -15,18 +15,18 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
-export const Route = createFileRoute("/api/admin/boundaries/$keyGroup/geojson")({
+export const Route = createFileRoute("/api/web/boundaries/$keyGroup/geojson")({
   server: {
     handlers: {
       OPTIONS: () => new Response(null, { status: 204, headers: corsHeaders }),
       GET: async ({ request }) => {
         try {
-          await buildAdminContext(db, request.headers);
+          await buildWebContext(db, request.headers);
         } catch {
           return new Response("Unauthorized", { status: 401, headers: corsHeaders });
         }
         const url = new URL(request.url);
-        const match = url.pathname.match(/^\/api\/admin\/boundaries\/([^/]+)\/geojson$/);
+        const match = url.pathname.match(/^\/api\/web\/boundaries\/([^/]+)\/geojson$/);
         const keyGroup = match?.[1];
         if (!keyGroup) {
           return new Response("Not Found", { status: 404, headers: corsHeaders });

--- a/apps/web/src/routes/api/web.rpc.$.ts
+++ b/apps/web/src/routes/api/web.rpc.$.ts
@@ -1,10 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { RPCHandler } from "@orpc/server/fetch";
 import { db } from "@field-tools/db";
-import { adminRouter } from "../../rpc";
-import { buildAdminContext } from "../../rpc/context";
+import { webRouter } from "../../rpc";
+import { buildWebContext } from "../../rpc/context";
 
-const handler = new RPCHandler(adminRouter);
+const handler = new RPCHandler(webRouter);
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -12,7 +12,7 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
-export const Route = createFileRoute("/api/admin/rpc/$")({
+export const Route = createFileRoute("/api/web/rpc/$")({
   server: {
     handlers: {
       ANY: async ({ request }) => {
@@ -20,9 +20,9 @@ export const Route = createFileRoute("/api/admin/rpc/$")({
           return new Response(null, { status: 204, headers: corsHeaders });
         }
 
-        const context = await buildAdminContext(db, request.headers);
+        const context = await buildWebContext(db, request.headers);
         const { response } = await handler.handle(request, {
-          prefix: "/api/admin/rpc",
+          prefix: "/api/web/rpc",
           context,
         });
 

--- a/apps/web/src/routes/api/web.segment-points.ts
+++ b/apps/web/src/routes/api/web.segment-points.ts
@@ -8,7 +8,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { db } from "@field-tools/db";
 import { dataFetch, passthrough } from "~/lib/server/data-proxy";
-import { buildAdminContext } from "~/rpc/context";
+import { buildWebContext } from "~/rpc/context";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -16,14 +16,14 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
-export const Route = createFileRoute("/api/admin/segment-points")({
+export const Route = createFileRoute("/api/web/segment-points")({
   server: {
     handlers: {
       OPTIONS: () => new Response(null, { status: 204, headers: corsHeaders }),
       POST: async ({ request }) => {
         let context;
         try {
-          context = await buildAdminContext(db, request.headers);
+          context = await buildWebContext(db, request.headers);
         } catch {
           return new Response("Unauthorized", { status: 401, headers: corsHeaders });
         }

--- a/apps/web/src/routes/segments/$segmentId.tsx
+++ b/apps/web/src/routes/segments/$segmentId.tsx
@@ -47,7 +47,7 @@ import {
   segmentSampleQuery,
   segmentsListQuery,
 } from "~/lib/queries/segments";
-import type { CascadeStep } from "~/rpc/admin/segments";
+import type { CascadeStep } from "~/rpc/web/segments";
 import { cn, toTitleCase } from "~/lib/utils";
 import { client } from "~/rpc/client";
 

--- a/apps/web/src/routes/zones/$zoneGroupId.tsx
+++ b/apps/web/src/routes/zones/$zoneGroupId.tsx
@@ -428,7 +428,7 @@ function ZoneGroupEditor() {
           className="h-full"
           boundariesUrl={
             activeGroup
-              ? `/api/admin/boundaries/${activeGroup.keyGroup}/geojson?v=${new Date(activeGroup.updatedAt).getTime()}`
+              ? `/api/web/boundaries/${activeGroup.keyGroup}/geojson?v=${new Date(activeGroup.updatedAt).getTime()}`
               : undefined
           }
           coloringByKey={coloringByKey}

--- a/apps/web/src/rpc/client.ts
+++ b/apps/web/src/rpc/client.ts
@@ -5,23 +5,23 @@ import { createRouterClient } from "@orpc/server";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
 import { db } from "@field-tools/db";
-import { adminRouter, type AdminRouter } from ".";
-import { buildAdminContext } from "./context";
+import { webRouter, type WebRouter } from ".";
+import { buildWebContext } from "./context";
 
 const getClient = createIsomorphicFn()
   .server(() =>
-    createRouterClient(adminRouter, {
+    createRouterClient(webRouter, {
       context: async () => {
         const headers = new Headers(getRequestHeaders());
-        return buildAdminContext(db, headers);
+        return buildWebContext(db, headers);
       },
     }),
   )
   .client(() => {
     const link = new RPCLink({
-      url: `${window.location.origin}/api/admin/rpc`,
+      url: `${window.location.origin}/api/web/rpc`,
     });
     return createORPCClient(link);
   });
 
-export const client = getClient() as RouterClient<AdminRouter>;
+export const client = getClient() as RouterClient<WebRouter>;

--- a/apps/web/src/rpc/context.ts
+++ b/apps/web/src/rpc/context.ts
@@ -5,9 +5,9 @@ import { auth } from "~/lib/auth";
 
 export type User = typeof users.$inferSelect;
 
-// --- Admin tier: authenticated, scoped to a single membership/org ---
+// --- Web tier: authenticated, scoped to a single membership/org ---
 
-export type AdminContext = {
+export type WebContext = {
   db: Db;
   user: User;
   organizationId: string;
@@ -15,14 +15,14 @@ export type AdminContext = {
   role: string;
 };
 
-// Resolve the (user, org, role) for an incoming admin call. Throws
+// Resolve the (user, org, role) for an incoming web call. Throws
 // UNAUTHORIZED when no valid session exists or the user has no membership.
 //
 // `AUTH_DISABLED=1` short-circuits to the seeded admin + its owner membership
 // — for local dev when you don't want to exercise the magic-link flow.
-export async function buildAdminContext(db: Db, headers: Headers): Promise<AdminContext> {
+export async function buildWebContext(db: Db, headers: Headers): Promise<WebContext> {
   if (process.env.AUTH_DISABLED === "1") {
-    const ctx = await loadAdminFromUserId(db, SEEDED_ADMIN_USER_ID);
+    const ctx = await loadFromUserId(db, SEEDED_ADMIN_USER_ID);
     if (!ctx) {
       throw new Error("AUTH_DISABLED=1 but seeded admin not found; run `pnpm db:mock`.");
     }
@@ -31,12 +31,12 @@ export async function buildAdminContext(db: Db, headers: Headers): Promise<Admin
 
   const session = await auth.api.getSession({ headers });
   if (!session) throw new ORPCError("UNAUTHORIZED");
-  const ctx = await loadAdminFromUserId(db, session.user.id);
+  const ctx = await loadFromUserId(db, session.user.id);
   if (!ctx) throw new ORPCError("UNAUTHORIZED");
   return ctx;
 }
 
-async function loadAdminFromUserId(db: Db, userId: string): Promise<AdminContext | null> {
+async function loadFromUserId(db: Db, userId: string): Promise<WebContext | null> {
   const userRow = (await db.select().from(users).where(eq(users.id, userId)))[0];
   if (!userRow) return null;
   const row = (
@@ -60,9 +60,9 @@ async function loadAdminFromUserId(db: Db, userId: string): Promise<AdminContext
   };
 }
 
-export const adminBase = os.$context<AdminContext>();
-export const adminPub = adminBase.route({ method: "GET" });
-export const adminMut = adminBase.route({ method: "POST" });
+export const webBase = os.$context<WebContext>();
+export const webPub = webBase.route({ method: "GET" });
+export const webMut = webBase.route({ method: "POST" });
 
 // --- Native tier: anonymous, capability-based per turfId ---
 

--- a/apps/web/src/rpc/index.ts
+++ b/apps/web/src/rpc/index.ts
@@ -1,19 +1,19 @@
 import { z } from "zod";
-import { adminPub, nativePub } from "./context";
-import * as campaigns from "./admin/campaigns";
-import * as organizations from "./admin/organizations";
-import * as script from "./admin/script";
-import * as segments from "./admin/segments";
-import * as turfDrafts from "./admin/turf-drafts";
-import * as adminTurfs from "./admin/turfs";
-import * as zoneGroups from "./admin/zone-groups";
-import * as zones from "./admin/zones";
+import { webPub, nativePub } from "./context";
+import * as campaigns from "./web/campaigns";
+import * as organizations from "./web/organizations";
+import * as script from "./web/script";
+import * as segments from "./web/segments";
+import * as turfDrafts from "./web/turf-drafts";
+import * as webTurfs from "./web/turfs";
+import * as zoneGroups from "./web/zone-groups";
+import * as zones from "./web/zones";
 import * as canvass from "./native/canvass";
 import * as nativeScript from "./native/script";
 import * as nativeTurfs from "./native/turfs";
 
-export const adminRouter = {
-  healthcheck: adminPub.input(z.object({}).optional()).handler(async ({ context }) => {
+export const webRouter = {
+  healthcheck: webPub.input(z.object({}).optional()).handler(async ({ context }) => {
     await context.db.execute("SELECT 1 as ok");
     return { status: "ok", db: "connected" };
   }),
@@ -64,10 +64,10 @@ export const adminRouter = {
     removeAllInGroup: zones.removeAllInGroup,
   },
   turfs: {
-    listForOrg: adminTurfs.listForOrg,
-    countForCampaign: adminTurfs.countForCampaign,
-    statsForCampaign: adminTurfs.statsForCampaign,
-    publish: adminTurfs.publish,
+    listForOrg: webTurfs.listForOrg,
+    countForCampaign: webTurfs.countForCampaign,
+    statsForCampaign: webTurfs.statsForCampaign,
+    publish: webTurfs.publish,
   },
   turfDrafts: {
     list: turfDrafts.list,
@@ -100,5 +100,5 @@ export const nativeRouter = {
   },
 };
 
-export type AdminRouter = typeof adminRouter;
+export type WebRouter = typeof webRouter;
 export type NativeRouter = typeof nativeRouter;

--- a/apps/web/src/rpc/web/campaigns.ts
+++ b/apps/web/src/rpc/web/campaigns.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq } from "@field-tools/db";
 import { campaigns } from "@field-tools/db/schema";
 import { z } from "zod";
-import { adminPub as pub } from "../context";
+import { webPub as pub } from "../context";
 
 const campaignSelect = {
   campaignId: campaigns.campaignId,

--- a/apps/web/src/rpc/web/organizations.ts
+++ b/apps/web/src/rpc/web/organizations.ts
@@ -1,7 +1,7 @@
 import { eq } from "@field-tools/db";
 import { organizations } from "@field-tools/db/schema";
 import { z } from "zod";
-import { adminPub as pub } from "../context";
+import { webPub as pub } from "../context";
 
 // Current organization for the logged-in user. Used by the breadcrumb.
 export const getCurrent = pub.input(z.object({}).optional()).handler(async ({ context }) => {

--- a/apps/web/src/rpc/web/script.ts
+++ b/apps/web/src/rpc/web/script.ts
@@ -1,7 +1,7 @@
 import { asc } from "@field-tools/db";
 import { scripts } from "@field-tools/db/schema";
 import { z } from "zod";
-import { adminPub as pub } from "../context";
+import { webPub as pub } from "../context";
 
 // List all scripts, oldest first. Used by the campaign editor's script
 // dropdown.

--- a/apps/web/src/rpc/web/segments.ts
+++ b/apps/web/src/rpc/web/segments.ts
@@ -2,7 +2,7 @@ import { and, asc, eq } from "@field-tools/db";
 import { campaigns, segments } from "@field-tools/db/schema";
 import { z } from "zod";
 import { dataPostJson } from "~/lib/server/data-proxy";
-import { adminPub as pub } from "../context";
+import { webPub as pub } from "../context";
 
 // Wire shapes returned by the data service. Kept here (next to the
 // handlers that produce them) rather than at the query layer so the

--- a/apps/web/src/rpc/web/turf-drafts.ts
+++ b/apps/web/src/rpc/web/turf-drafts.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq } from "@field-tools/db";
 import { campaigns, turfDrafts } from "@field-tools/db/schema";
 import { z } from "zod";
-import { adminPub as pub } from "../context";
+import { webPub as pub } from "../context";
 
 // GeoJSON Polygon validator. We don't enforce ring-closure here —
 // the cutter naturally produces closed rings, and the publish path

--- a/apps/web/src/rpc/web/turfs.ts
+++ b/apps/web/src/rpc/web/turfs.ts
@@ -3,7 +3,7 @@ import { and, asc, eq, sql } from "@field-tools/db";
 import { campaigns, segments, turfDrafts, turfs, zones } from "@field-tools/db/schema";
 import { z } from "zod";
 import { DataServiceError, dataPostJson } from "~/lib/server/data-proxy";
-import { adminMut as mut, adminPub as pub } from "../context";
+import { webMut as mut, webPub as pub } from "../context";
 
 // Admin-scoped turf list: all turfs within the current user's org,
 // optionally filtered by campaign. The `segments` and `zones` joins

--- a/apps/web/src/rpc/web/zone-groups.ts
+++ b/apps/web/src/rpc/web/zone-groups.ts
@@ -2,7 +2,7 @@ import { and, asc, eq } from "@field-tools/db";
 import { campaigns, segments as segmentsTable, zoneGroups, zones } from "@field-tools/db/schema";
 import { z } from "zod";
 import { dataPostJson } from "~/lib/server/data-proxy";
-import { adminPub as pub } from "../context";
+import { webPub as pub } from "../context";
 
 const zoneGroupSelect = {
   zoneGroupId: zoneGroups.zoneGroupId,

--- a/apps/web/src/rpc/web/zones.ts
+++ b/apps/web/src/rpc/web/zones.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq } from "@field-tools/db";
 import { zoneGroups, zones } from "@field-tools/db/schema";
 import { z } from "zod";
-import { adminPub as pub } from "../context";
+import { webPub as pub } from "../context";
 
 const zoneSelect = {
   zoneId: zones.zoneId,

--- a/apps/web/tests/rpc.setup.ts
+++ b/apps/web/tests/rpc.setup.ts
@@ -3,8 +3,8 @@ import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { SEEDED_ADMIN_USER_ID, SEEDED_ORG_ID, type Db } from "@field-tools/db";
 import { test } from "vite-plus/test";
-import { adminRouter } from "../src/rpc";
-import type { AdminContext, User } from "../src/rpc/context";
+import { webRouter } from "../src/rpc";
+import type { WebContext, User } from "../src/rpc/context";
 
 export async function getTestClient() {
   // Each test gets a fresh in-memory database. Tests that need real schema
@@ -23,7 +23,7 @@ export async function getTestClient() {
     updatedAt: new Date(),
   };
 
-  const context: AdminContext = {
+  const context: WebContext = {
     db,
     user,
     organizationId: SEEDED_ORG_ID,
@@ -31,7 +31,7 @@ export async function getTestClient() {
     role: "owner",
   };
 
-  const caller = createRouterClient(adminRouter, { context });
+  const caller = createRouterClient(webRouter, { context });
 
   const stop = async () => {
     await pglite.close();


### PR DESCRIPTION
Simple renaming PR for the newly split RPC contexts and routes (`admin` was too close to a user role, and `web` and `native` better matches the app layout).