### PR TITLE
feat: small matching improvements

### DIFF
--- a/apps/data/.gitignore
+++ b/apps/data/.gitignore
@@ -16,11 +16,15 @@ wheels/
 
 # Local DuckLake dev data
 *.ducklake
+*.ducklake.wal
 local_data/
 geo_local_data/
 
 # TIGER shapefile cache
 tiger_cache/
+
+# OSM PBF cache (~700 MB; ad-hoc spike work, regeneratable via Geofabrik).
+osm_cache/
 
 # Large fixture files: only commit the ED-level subsets and the 10k NYC
 # sample. Larger samples (50k, 1M, full statewide) are regeneratable via
@@ -35,7 +39,10 @@ qwdata/
 # Old stuff
 old/**
 
-# Local-only one-off scripts (samplers, fixture generators, ad-hoc
-# diagnostics). Not part of the production pipeline; kept out of git
-# so the commit story stays clean.
+# Local-only one-off scripts (ad-hoc diagnostics, experiments). Not
+# part of the production pipeline; kept out of git so the commit story
+# stays clean. Exception: `sample_voter_file.py` produces the canonical
+# NYC fixture from the remote NYS voter file and is the only documented
+# way to regenerate fixtures — committed so collaborators can run it.
 scripts/
+!scripts/sample_voter_file.py

--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -8,13 +8,13 @@ from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from src.tables import resolve
 from src.dsl.compile import boundary_key_expr_for, cascade_sql, criteria_to_where
 from src.dsl.criteria import Criteria, KeyFilter
 from src.duckdb import get_connection
 from src.job_runner import JobManager
 from src.publish_turfs import PublishTurfsRequest, publish_turfs
 from src.settings import get_settings
+from src.tables import resolve
 
 logger = logging.getLogger("uvicorn")
 

--- a/apps/data/src/address_tokens.py
+++ b/apps/data/src/address_tokens.py
@@ -17,8 +17,7 @@ EQUIVALENT_TOKEN_GROUPS: list[list[str]] = [
     ["nw", "northwest"],
     ["se", "southeast"],
     ["sw", "southwest"],
-    # Street types
-    ["st", "street"],
+    ["st", "street", "saint"],
     ["ave", "avenue", "av"],
     ["rd", "road"],
     ["dr", "drive"],
@@ -27,6 +26,7 @@ EQUIVALENT_TOKEN_GROUPS: list[list[str]] = [
     ["pl", "place"],
     ["blvd", "boulevard"],
     ["pkwy", "parkway"],
+    ["expy", "expressway"],
     ["hwy", "highway"],
     ["cir", "circle"],
     ["ter", "terrace"],
@@ -47,13 +47,13 @@ EQUIVALENT_TOKEN_GROUPS: list[list[str]] = [
     ["park"],
     ["gardens", "gdns"],
     ["heights", "hts"],
-    # Building/unit types
+    ["ft", "fort"],
+    ["mt", "mount"],
     ["apt", "apartment"],
     ["unit"],
     ["ste", "suite"],
     ["fl", "floor"],
     ["bldg", "building"],
-    # Ordinal numbers (important for numbered streets like "42nd St")
     ["1st", "first"],
     ["2nd", "second"],
     ["3rd", "third"],

--- a/apps/data/src/cli.py
+++ b/apps/data/src/cli.py
@@ -1,5 +1,6 @@
 """CLI entrypoints for the data package."""
 
+import argparse
 from pathlib import Path
 
 from hamilton import driver
@@ -8,7 +9,7 @@ from src.dags import aggregate, boundaries, geocode, quickwit, tiger, voter_file
 from src.duckdb import get_connection
 from src.models import TableRef
 from src.settings import get_settings
-from src.tables import PERSON_CATALOG
+from src.tables import PERSON_CATALOG, drop_org_schema, ensure_org_schema
 from src.transformations import nys_sboe_transformation_query
 
 
@@ -53,13 +54,25 @@ def seed_boundaries() -> None:
     blocks where voters tagged with each distinct key live. Output goes
     to ``geo_ducklake.boundaries.{key_group}``.
 
-    Requires ``seed_persons`` to have run first — we read from the
-    organisation's geocoded persons table for the keys + coordinates.
+    Requires ``seed-persons`` to have run first — we read from
+    ``ducklake.<org>.persons_geocoded`` for the keys + coordinates.
+    Pair `--org-slug` here with whatever you passed to `seed-persons`
+    if you used a non-default schema:
+
+        uv run seed-boundaries --org-slug sample_10k
 
     Add a new entry to ``key_group_sources`` to seed another key group;
     each entry is the destination key-group name plus the SQL expression
     that produces the key from a row of the persons table.
     """
+    parser = argparse.ArgumentParser(prog="seed-boundaries", description=seed_boundaries.__doc__)
+    parser.add_argument(
+        "--org-slug",
+        default=_DEFAULT_ORG_SLUG,
+        help=f"Org schema to read persons from (default: {_DEFAULT_ORG_SLUG!r}).",
+    )
+    args = parser.parse_args()
+
     key_group_sources = [
         {
             "key_group": "nyc_eds",
@@ -86,7 +99,7 @@ def seed_boundaries() -> None:
     # every key group; only `key_group` and `key_expression` vary.
     persons_ref = TableRef(
         catalog=PERSON_CATALOG,
-        schema=_DEFAULT_ORG_SLUG,
+        schema=args.org_slug,
         table="persons_geocoded",
         version=0,
     )
@@ -131,15 +144,36 @@ _DEFAULT_ORG_SLUG = "default"
 
 
 def seed_persons() -> None:
-    """Run voter_file_loader → tiger → geocode → aggregate against the
-    voter file fixture configured in settings.
+    """Run voter_file_loader → tiger → geocode → aggregate against a
+    voter file fixture.
 
-    Fixture path is `{fixtures_dir}/{voter_file_fixture}` (defaults
-    `apps/data/fixtures/ny-voters-2026-03-08-nyc.parquet`). If it
-    isn't present, prints a download hint and exits — fixtures aren't
-    checked into the repo because they're large.
+    Defaults to `{fixtures_dir}/{voter_file_fixture}` (configured in
+    settings — usually `apps/data/fixtures/ny-voters-2026-03-08-nyc.parquet`)
+    and writes into the `default` org schema (matching `slug: "default"`
+    in `packages/db/src/mock.ts` so the web app finds it).
 
-    Final outputs (under ``ducklake."{org}"``):
+    Override either with flags:
+
+        uv run seed-persons --fixture ny-voters-2026-03-08-10k-sample.parquet
+        uv run seed-persons --fixture <sample> --org-slug sample_10k
+
+    Using a non-default org slug writes to a separate DuckLake schema
+    (`ducklake.<slug>.persons_geocoded`), so iterating on samples doesn't
+    overwrite the default schema the web app reads from.
+
+    Most intermediate DAG nodes are incremental (`CREATE TABLE IF NOT
+    EXISTS` + `WHERE external_id NOT IN (...)`), which is fast on
+    re-runs but means schema changes inside the pipeline don't
+    auto-apply. Pass `--reset` to drop the org's DuckLake schema
+    before running so the next pipeline run rebuilds every table from
+    scratch:
+
+        uv run seed-persons --reset
+
+    If the fixture is missing, prints a hint pointing at the source URL
+    and the script that materialises it.
+
+    Final outputs (under ``ducklake.<org>``):
     - ``persons_geocoded`` — canonical "person record": Person fields
       with canonicalized addresses, lat/lng, blockface match metadata,
       derived `building_id` and `door_id`.
@@ -151,16 +185,44 @@ def seed_persons() -> None:
     on a fresh machine); subsequent runs reuse the on-disk cache and are
     fast.
     """
+    parser = argparse.ArgumentParser(prog="seed-persons", description=seed_persons.__doc__)
+    parser.add_argument(
+        "--fixture",
+        default=None,
+        help="Fixture filename inside `fixtures_dir` (default: settings.voter_file_fixture).",
+    )
+    parser.add_argument(
+        "--org-slug",
+        default=_DEFAULT_ORG_SLUG,
+        help=f"Target DuckLake schema (default: {_DEFAULT_ORG_SLUG!r}).",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Drop the org's DuckLake schema before running. Use after a pipeline schema change.",
+    )
+    args = parser.parse_args()
+
     settings = get_settings()
     conn = get_connection(settings)
 
-    fixture_path = _fixtures_dir(settings) / settings.voter_file_fixture
+    if args.reset:
+        print(f"Dropping schema ducklake.{args.org_slug}…")
+        drop_org_schema(conn, args.org_slug)
+        ensure_org_schema(conn, args.org_slug)
+
+    fixture_name = args.fixture or settings.voter_file_fixture
+    fixture_path = _fixtures_dir(settings) / fixture_name
     if not fixture_path.exists():
         print(f"Voter file fixture not found at {fixture_path}.")
-        print(f"Download from {settings.voter_file_url} and place it at that path.")
+        print(
+            f"Materialise it from {settings.voter_file_url} via "
+            "`uv run python scripts/sample_voter_file.py` "
+            "(see the script for sampling options)."
+        )
         return
 
-    print(f"Seeding persons from {fixture_path} (org={_DEFAULT_ORG_SLUG})…")
+    print(f"Seeding persons from {fixture_path} (org={args.org_slug})…")
     print(f"  TIGER counties: {settings.tiger_county_fips} (cache: {settings.tiger_data_dir})")
 
     dr = driver.Builder().with_modules(voter_file_loader, tiger, geocode, aggregate).build()
@@ -173,7 +235,7 @@ def seed_persons() -> None:
         ],
         inputs={
             "voter_file_url": str(fixture_path),
-            "organization_slug": _DEFAULT_ORG_SLUG,
+            "organization_slug": args.org_slug,
             # Curated transformation: passes all rows in the fixture (no
             # county filter) since the fixture is already NYC-only.
             "transformation_query": nys_sboe_transformation_query(),

--- a/apps/data/src/dags/geocode.py
+++ b/apps/data/src/dags/geocode.py
@@ -83,6 +83,7 @@ def persons_decomposed(
             external_id         VARCHAR,
             house_number        INTEGER,
             house_num_prefix    VARCHAR,
+            half_code           VARCHAR,
             street_name_raw     VARCHAR,
             street_name_tokens  VARCHAR[],
             number_type         VARCHAR,
@@ -96,6 +97,7 @@ def persons_decomposed(
             SELECT
                 external_id,
                 zip5,
+                half_code,
                 address_line_1,
                 -- Extract any leading non-numeric prefix from the house number
                 -- e.g. "34-12 Broadway" -> prefix="34-", house_num=12
@@ -124,6 +126,7 @@ def persons_decomposed(
             external_id,
             house_number,
             house_num_prefix,
+            half_code,
             street_name_raw,
             list_distinct(list_sort(list_filter(
                 list_concat(
@@ -238,6 +241,26 @@ def persons_candidates(
             OR p.house_number BETWEEN b.to_house_num   AND b.from_house_num
          )
          AND len(list_intersect(p.street_name_tokens, b.street_name_tokens)) >= 2
+         -- Reject blockfaces whose directional contradicts the voter's.
+         -- Voter tokens are raw (so we check both `n` and `north` forms);
+         -- blockface tokens are equivalence-expanded so checking the
+         -- short form alone is sufficient on that side. Voter without a
+         -- directional or blockface without a directional always passes
+         -- through; only opposing cardinal pairs are rejected.
+         AND NOT (
+              ((list_contains(p.street_name_tokens, 'n')
+                OR list_contains(p.street_name_tokens, 'north'))
+               AND list_contains(b.street_name_tokens, 's'))
+           OR ((list_contains(p.street_name_tokens, 's')
+                OR list_contains(p.street_name_tokens, 'south'))
+               AND list_contains(b.street_name_tokens, 'n'))
+           OR ((list_contains(p.street_name_tokens, 'e')
+                OR list_contains(p.street_name_tokens, 'east'))
+               AND list_contains(b.street_name_tokens, 'w'))
+           OR ((list_contains(p.street_name_tokens, 'w')
+                OR list_contains(p.street_name_tokens, 'west'))
+               AND list_contains(b.street_name_tokens, 'e'))
+         )
         WHERE p.external_id NOT IN (SELECT external_id FROM {fqn})
     """)
 
@@ -592,13 +615,13 @@ def canonical_addresses(
     on purpose so an OSM-derived canonical-address node could return the
     same shape and slot in or replace this one.
 
-    Incremental: skips external_ids already present.
+    Half-coded addresses are preserved with the "1/2" in canonical
+    address_line_1, so building_id door_id naturally distinguish them
+    from the non-half neighbour. The half-code is kept out of
+    `persons_decomposed.street_name_tokens` upstream so it can't
+    generate spurious matches.
 
-    Known limitations:
-    - Half-coded addresses ("111 1/2 E 14TH ST") collapse with their
-      non-half neighbors ("111 E 14TH ST"). 0% in current NYC samples;
-      addressable by extending persons_decomposed to surface a half_code
-      column if it ever matters
+    Incremental: skips external_ids already present.
     """
     table_suffix = "canonical_addresses"
     ensure_org_schema(conn, organization_slug)
@@ -619,6 +642,9 @@ def canonical_addresses(
         SELECT
             m.external_id,
             COALESCE(d.house_num_prefix, '') || CAST(d.house_number AS VARCHAR)
+              || CASE WHEN d.half_code IS NOT NULL AND d.half_code != ''
+                      THEN ' ' || d.half_code
+                      ELSE '' END
               || ' ' || UPPER(m.full_name)                  AS address_line_1,
             list_distinct(list_filter(
               list_concat(

--- a/apps/data/src/models.py
+++ b/apps/data/src/models.py
@@ -98,6 +98,7 @@ class Person(BaseModel):
     # Address fields
     address_line_1: str
     address_line_2: str | None = None
+    half_code: str | None = None
     city: str
     state: str
     zip5: str

--- a/apps/data/src/tables.py
+++ b/apps/data/src/tables.py
@@ -53,20 +53,31 @@ class UnknownAbstractTableError(KeyError):
     """A placeholder referenced a name not in `QUERYABLE_TABLES`."""
 
 
-def org_fqn(slug: str, table: str) -> str:
-    """Fully-qualified name for `table` in org `slug`'s schema.
+def org_schema_fqn(slug: str) -> str:
+    """Fully-qualified name for org `slug`'s schema (no table).
 
     Schema is quoted only when necessary (see `models.quote_ident`), so
     plain slugs (`default`) stay readable and slugs with hyphens
     (`nyc-dsa`) still produce valid SQL.
     """
-    return f"{PERSON_CATALOG}.{quote_ident(slug)}.{table}"
+    return f"{PERSON_CATALOG}.{quote_ident(slug)}"
+
+
+def org_fqn(slug: str, table: str) -> str:
+    """Fully-qualified name for `table` in org `slug`'s schema."""
+    return f"{org_schema_fqn(slug)}.{table}"
 
 
 def ensure_org_schema(conn: "duckdb.DuckDBPyConnection", slug: str) -> None:
     """Idempotently create the per-org schema. Call once before any DAG
     node writes to a tenant's tables."""
-    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {PERSON_CATALOG}.{quote_ident(slug)}")
+    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {org_schema_fqn(slug)}")
+
+
+def drop_org_schema(conn: "duckdb.DuckDBPyConnection", slug: str) -> None:
+    """Drop the per-org schema and every table in it. Use after a
+    pipeline schema change forces a rebuild from scratch."""
+    conn.execute(f"DROP SCHEMA IF EXISTS {org_schema_fqn(slug)} CASCADE")
 
 
 def resolve(sql: str, slug: str) -> str:

--- a/apps/data/src/transformations.py
+++ b/apps/data/src/transformations.py
@@ -48,7 +48,6 @@ SELECT
     concat_ws(
         ' ',
         nullif(raw.res_house_number, ''),
-        nullif(CAST(raw.res_half_code AS VARCHAR), ''),
         nullif(CAST(raw.res_pre_direction AS VARCHAR), ''),
         nullif(raw.res_street_name, ''),
         nullif(CAST(raw.res_post_direction AS VARCHAR), '')
@@ -62,6 +61,10 @@ SELECT
         )
         ELSE NULL
     END AS address_line_2,
+    -- Kept out of address_line_1 so street-name tokenisation doesn't see
+    -- the "1/2" digits as match material (they'd cross-match "1st St" /
+    -- "2nd St"). Reassembled into the canonical address downstream.
+    nullif(CAST(raw.res_half_code AS VARCHAR), '') AS half_code,
     raw.res_city AS city,
     'NY' AS state,
     raw.res_zip5 AS zip5,

--- a/apps/data/tests/test_boroughs.py
+++ b/apps/data/tests/test_boroughs.py
@@ -50,7 +50,6 @@ SELECT
     concat_ws(
         ' ',
         nullif(raw.res_house_number, ''),
-        nullif(raw.res_half_code, ''),
         nullif(raw.res_pre_direction, ''),
         nullif(raw.res_street_name, ''),
         nullif(raw.res_post_direction, '')
@@ -60,6 +59,7 @@ SELECT
         THEN concat_ws(' ', nullif(raw.res_apartment_type, ''), raw.res_apartment)
         ELSE NULL
     END AS address_line_2,
+    nullif(raw.res_half_code, '') AS half_code,
     raw.res_city AS city,
     'NY' AS state,
     raw.res_zip5 AS zip5,

--- a/apps/data/tests/test_hamilton_graphs.py
+++ b/apps/data/tests/test_hamilton_graphs.py
@@ -37,7 +37,6 @@ SELECT
     concat_ws(
         ' ',
         nullif(raw.res_house_number, ''),
-        nullif(raw.res_half_code, ''),
         nullif(raw.res_pre_direction, ''),
         nullif(raw.res_street_name, ''),
         nullif(raw.res_post_direction, '')
@@ -47,6 +46,7 @@ SELECT
         THEN concat_ws(' ', nullif(raw.res_apartment_type, ''), raw.res_apartment)
         ELSE NULL
     END AS address_line_2,
+    nullif(raw.res_half_code, '') AS half_code,
     raw.res_city AS city,
     'NY' AS state,
     raw.res_zip5 AS zip5,

--- a/apps/data/tests/test_quickwit_dag.py
+++ b/apps/data/tests/test_quickwit_dag.py
@@ -49,7 +49,6 @@ SELECT
     concat_ws(
         ' ',
         nullif(raw.res_house_number, ''),
-        nullif(raw.res_half_code, ''),
         nullif(raw.res_pre_direction, ''),
         nullif(raw.res_street_name, ''),
         nullif(raw.res_post_direction, '')
@@ -59,6 +58,7 @@ SELECT
         THEN concat_ws(' ', nullif(raw.res_apartment_type, ''), raw.res_apartment)
         ELSE NULL
     END AS address_line_2,
+    nullif(raw.res_half_code, '') AS half_code,
     raw.res_city AS city,
     'NY' AS state,
     raw.res_zip5 AS zip5,


### PR DESCRIPTION
A few small improvements to the address matching in this PR.

- Half codes are now surfaced instead of concatenating into address_line_1, which was leading to some false positives (e.g. "37 1/2 St Marks Pl" mis-matching to "E 1st St" or "E 2nd St")
- Expanded equivalent token groups, like "expy" for "expressway" and "ft" for "fort"
- Explicit rejection for directional-antonym candidates, so that voters with tokens with "north" or "n" can't match to "south" or "s" (even if other tokens match), and same for east and west, this was causing a small number of erroneous matches

Also did some light cleanup of `cli` to make it easier to run experiments.