### PR TITLE
feat: segment composition

### DIFF
--- a/apps/data/src/dsl/compile.py
+++ b/apps/data/src/dsl/compile.py
@@ -27,6 +27,7 @@ from .criteria import (
     FieldDef,
     Filter,
     KeyFilter,
+    NestedFilter,
     TextFieldDef,
     TextFilter,
     VotingHistoryFieldDef,
@@ -179,6 +180,10 @@ def _filter_clause(f: Filter, params: list[Any]) -> str:
         if field_def is None:
             raise CriteriaError(f"Unknown field: {f.key}")
         return _address_clause(f, field_def, params)
+    if isinstance(f, NestedFilter):
+        # Empty inner → 1=1 to match the standalone "empty segment matches everyone" semantic.
+        inner = _criteria_bool_expr(f.criteria, params)
+        return f"({inner})" if inner else "1=1"
     raise CriteriaError(f"Unknown filter kind: {type(f).__name__}")
 
 

--- a/apps/data/src/dsl/criteria.py
+++ b/apps/data/src/dsl/criteria.py
@@ -81,8 +81,26 @@ class AddressFilter(BaseModel):
     zip: str  # noqa: A003
 
 
+class NestedFilter(BaseModel):
+    """Wraps a complete sub-criteria as a single filter. Produced by the
+    web layer when expanding segment references; the data server never
+    sees segment ids — only resolved nested criteria. Compiles to a
+    parenthesised boolean expression that the outer step's verb composes
+    in the usual way."""
+
+    kind: Literal["nested"]
+    criteria: "Criteria"
+
+
 Filter = Annotated[
-    AllFilter | EnumFilter | AgeRangeFilter | TextFilter | DateRangeFilter | VotingHistoryFilter | AddressFilter,
+    AllFilter
+    | EnumFilter
+    | AgeRangeFilter
+    | TextFilter
+    | DateRangeFilter
+    | VotingHistoryFilter
+    | AddressFilter
+    | NestedFilter,
     Field(discriminator="kind"),
 ]
 
@@ -111,6 +129,10 @@ class Step(BaseModel):
 
 class Criteria(BaseModel):
     steps: list[Step] = []
+
+
+# NestedFilter forward-references Criteria; resolve once both exist.
+NestedFilter.model_rebuild()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/data/tests/test_compile.py
+++ b/apps/data/tests/test_compile.py
@@ -17,6 +17,7 @@ from src.dsl.criteria import (
     DateRangeFilter,
     EnumFilter,
     KeyFilter,
+    NestedFilter,
     Step,
     TextFilter,
     VotingHistoryFilter,
@@ -500,3 +501,128 @@ def test_column_expr_for_promoted_field() -> None:
 def test_boundary_key_expr_for_known_groups() -> None:
     assert boundary_key_expr_for("nyc_zips") == "zip5"
     assert boundary_key_expr_for("nyc_eds") == "precinct"
+
+
+# ---------------------------------------------------------------------------
+# NestedFilter — produced by the web layer when expanding segment refs.
+# Compiles to a parenthesised boolean of the inner criteria; the outer
+# step's verb composes it like any other filter.
+# ---------------------------------------------------------------------------
+
+
+def _inner_dem() -> NestedFilter:
+    return NestedFilter(
+        kind="nested",
+        criteria=_narrow(EnumFilter(kind="enum", key="enrollment", values=["democratic"])),
+    )
+
+
+def test_nested_filter_narrow_composes_as_and() -> None:
+    params: list = []
+    where = criteria_to_where(
+        Criteria(
+            steps=[
+                Step(verb="narrow", filter=TextFilter(kind="text", key="zip5", value="11201")),
+                Step(verb="narrow", filter=_inner_dem()),
+            ],
+        ),
+        None,
+        params,
+    )
+    assert where == "WHERE (zip5 = ?) AND ((enrollment IN (?)))"
+    assert params == ["11201", "democratic"]
+
+
+def test_nested_filter_add_composes_as_or() -> None:
+    params: list = []
+    where = criteria_to_where(
+        Criteria(
+            steps=[
+                Step(verb="narrow", filter=TextFilter(kind="text", key="zip5", value="11201")),
+                Step(verb="add", filter=_inner_dem()),
+            ],
+        ),
+        None,
+        params,
+    )
+    assert where == "WHERE (zip5 = ?) OR ((enrollment IN (?)))"
+    assert params == ["11201", "democratic"]
+
+
+def test_nested_filter_remove_composes_as_and_not() -> None:
+    params: list = []
+    where = criteria_to_where(
+        Criteria(
+            steps=[
+                Step(verb="narrow", filter=TextFilter(kind="text", key="zip5", value="11201")),
+                Step(verb="remove", filter=_inner_dem()),
+            ],
+        ),
+        None,
+        params,
+    )
+    assert where == "WHERE (zip5 = ?) AND NOT ((enrollment IN (?)))"
+    assert params == ["11201", "democratic"]
+
+
+def test_empty_nested_filter_matches_universe() -> None:
+    # An empty segment matches everyone standalone (no WHERE), so an
+    # empty NestedFilter must compile to 1=1 — letting "add: empty-seg"
+    # after "remove: Everyone" correctly produce everyone.
+    params: list = []
+    where = criteria_to_where(
+        Criteria(
+            steps=[
+                Step(verb="remove", filter=AllFilter(kind="all")),
+                Step(verb="add", filter=NestedFilter(kind="nested", criteria=Criteria())),
+            ],
+        ),
+        None,
+        params,
+    )
+    assert where == "WHERE (NOT (1=1)) OR (1=1)"
+    assert params == []
+
+
+def test_nested_filter_with_internal_verbs_preserves_composition() -> None:
+    # Inner criteria uses both narrow and add internally; the parenthesised
+    # OR group must be wrapped intact when the outer step ANDs it in.
+    inner = Criteria(
+        steps=[
+            Step(verb="narrow", filter=EnumFilter(kind="enum", key="enrollment", values=["democratic"])),
+            Step(verb="add", filter=EnumFilter(kind="enum", key="enrollment", values=["working_families"])),
+        ],
+    )
+    params: list = []
+    where = criteria_to_where(
+        Criteria(
+            steps=[
+                Step(verb="narrow", filter=TextFilter(kind="text", key="zip5", value="11201")),
+                Step(verb="narrow", filter=NestedFilter(kind="nested", criteria=inner)),
+            ],
+        ),
+        None,
+        params,
+    )
+    assert where == "WHERE (zip5 = ?) AND (((enrollment IN (?)) OR (enrollment IN (?))))"
+    assert params == ["11201", "democratic", "working_families"]
+
+
+def test_nested_filter_compiles_recursively() -> None:
+    # Nested-inside-nested — what a chain of segment references produces.
+    leaf = NestedFilter(
+        kind="nested",
+        criteria=_narrow(EnumFilter(kind="enum", key="enrollment", values=["democratic"])),
+    )
+    middle = NestedFilter(
+        kind="nested",
+        criteria=Criteria(steps=[Step(verb="narrow", filter=leaf)]),
+    )
+    params: list = []
+    where = criteria_to_where(
+        Criteria(steps=[Step(verb="narrow", filter=middle)]),
+        None,
+        params,
+    )
+    assert where == "WHERE ((enrollment IN (?)))"
+    assert params == ["democratic"]

--- a/apps/web/src/lib/expand-segment-refs.ts
+++ b/apps/web/src/lib/expand-segment-refs.ts
@@ -1,0 +1,107 @@
+import type { Criteria, Step } from "~/lib/filters";
+
+// Resolves SegmentFilter references in a criteria tree by inlining the
+// referenced segment's criteria as a NestedFilter. The data server never
+// sees segment ids — only nested criteria, which it compiles as a
+// parenthesized boolean expression.
+//
+// Throws on cycles and on nesting deeper than MAX_DEPTH. References to
+// missing or null segment ids are dropped from the output entirely
+// (see the comment in `expand` for why).
+
+const MAX_DEPTH = 8;
+
+export class SegmentRefError extends Error {
+  readonly kind: "cycle" | "depth";
+  constructor(message: string, kind: "cycle" | "depth") {
+    super(message);
+    this.name = "SegmentRefError";
+    this.kind = kind;
+  }
+}
+
+export type SegmentLike = { segmentId: string; name: string; criteria: Criteria };
+
+export function expandSegmentRefs(
+  criteria: Criteria,
+  segmentsById: ReadonlyMap<string, SegmentLike>,
+): Criteria {
+  return expand(criteria, segmentsById, new Set(), 0);
+}
+
+// Returns the ids that would form a cycle if added to the chain
+// ending in `targetId`. Used by the editor to disable cyclic choices
+// in the dropdown. Walks transitively via segment refs in stored
+// criteria.
+export function findCyclicSegmentIds(
+  targetId: string,
+  segmentsById: ReadonlyMap<string, SegmentLike>,
+): Set<string> {
+  const result = new Set<string>();
+  for (const id of segmentsById.keys()) {
+    if (id === targetId) {
+      result.add(id);
+      continue;
+    }
+    if (referencesTransitively(id, targetId, segmentsById, new Set())) {
+      result.add(id);
+    }
+  }
+  return result;
+}
+
+function expand(
+  criteria: Criteria,
+  segmentsById: ReadonlyMap<string, SegmentLike>,
+  visiting: Set<string>,
+  depth: number,
+): Criteria {
+  if (depth > MAX_DEPTH) {
+    throw new SegmentRefError(`Segment nesting deeper than ${MAX_DEPTH}`, "depth");
+  }
+  // Steps referencing a missing or null segment are dropped entirely.
+  // Inlining them as empty NestedFilters would let the data server
+  // interpret them as "match universe" — fine for `narrow`, destructive
+  // for `add` (becomes everyone) and `remove` (empties the set).
+  // Dropping makes a broken reference indistinguishable from "step
+  // doesn't exist", which is the least-surprising no-op.
+  const steps: Step[] = [];
+  for (const step of criteria.steps) {
+    const f = step.filter;
+    if (f.kind !== "segment") {
+      steps.push(step);
+      continue;
+    }
+    const id = f.segmentId;
+    if (id == null) continue;
+    if (visiting.has(id)) {
+      throw new SegmentRefError(`Segment reference cycle through ${id}`, "cycle");
+    }
+    const referenced = segmentsById.get(id);
+    if (!referenced) continue;
+    const next = new Set(visiting);
+    next.add(id);
+    const inner = expand(referenced.criteria, segmentsById, next, depth + 1);
+    steps.push({ ...step, filter: { kind: "nested", criteria: inner } });
+  }
+  return { steps };
+}
+
+function referencesTransitively(
+  fromId: string,
+  toId: string,
+  segmentsById: ReadonlyMap<string, SegmentLike>,
+  visited: Set<string>,
+): boolean {
+  if (visited.has(fromId)) return false;
+  visited.add(fromId);
+  const seg = segmentsById.get(fromId);
+  if (!seg) return false;
+  for (const step of seg.criteria.steps) {
+    const f = step.filter;
+    if (f.kind !== "segment" || f.segmentId == null) continue;
+    if (f.segmentId === toId) return true;
+    if (referencesTransitively(f.segmentId, toId, segmentsById, visited)) return true;
+  }
+  return false;
+}

--- a/apps/web/src/lib/filters.ts
+++ b/apps/web/src/lib/filters.ts
@@ -52,6 +52,24 @@ export type AddressFilter = {
   zip: string;
 };
 
+// Reference to another segment by id. Authored form — what the user
+// composes and what we persist. Resolved to NestedFilter (below) by
+// `expandSegmentRefs` before any query reaches the data server.
+export type SegmentFilter = {
+  kind: "segment";
+  key: "segment";
+  segmentId: string | null;
+};
+
+// Result of expanding a SegmentFilter: carries the referenced
+// segment's full criteria inline. The data server compiles this as a
+// parenthesized boolean expression (see apps/data/src/dsl/compile.py).
+// Never persisted — only on the wire.
+export type NestedFilter = {
+  kind: "nested";
+  criteria: Criteria;
+};
+
 export type Filter =
   | AllFilter
   | EnumFilter
@@ -59,7 +77,9 @@ export type Filter =
   | TextFilter
   | DateRangeFilter
   | VotingHistoryFilter
-  | AddressFilter;
+  | AddressFilter
+  | SegmentFilter
+  | NestedFilter;
 
 // Criteria — ordered sequence of steps with verbs.
 export type Verb = "add" | "narrow" | "remove";
@@ -108,13 +128,19 @@ export type FilterDef =
       kind: "address";
       key: "address";
       label: string;
+    }
+  | {
+      kind: "segment";
+      key: "segment";
+      label: string;
     };
 
 // Catalog organized into sections — the editor's "add filter" dropdown
 // renders a separator between each group. Keep the flat FILTERS export
 // derived from this so other consumers (definitionFor, etc.) don't care.
 export const FILTER_SECTIONS: ReadonlyArray<ReadonlyArray<FilterDef>> = [
-  // Special — only `narrow` shows this section (handled in the dropdown).
+  // Universal — the empty / "everyone" filter, useful under every verb
+  // (narrow to universe, add everyone, or remove everyone to start fresh).
   [{ kind: "all", key: "all", label: "Everyone" }],
   // Identity + demographics
   [
@@ -215,13 +241,17 @@ export const FILTER_SECTIONS: ReadonlyArray<ReadonlyArray<FilterDef>> = [
       source: "column",
     },
   ],
+  // Composite — reference another segment by id.
+  [{ kind: "segment", key: "segment", label: "Segment" }],
 ] as const;
 
 export const FILTERS: ReadonlyArray<FilterDef> = FILTER_SECTIONS.flatMap((s) => s);
 
 // Helpers
 export function filterKey(f: Filter): string {
-  return f.kind === "all" ? "all" : f.key;
+  if (f.kind === "all") return "all";
+  if (f.kind === "nested") return "nested";
+  return f.key;
 }
 
 export function definitionFor(key: string): FilterDef | undefined {
@@ -236,6 +266,7 @@ export function emptyFilterFor(def: FilterDef): Filter {
   if (def.kind === "date-range") return { kind: "date-range", key: def.key, min: null, max: null };
   if (def.kind === "address")
     return { kind: "address", key: "address", line1: "", city: "", state: "", zip: "" };
+  if (def.kind === "segment") return { kind: "segment", key: "segment", segmentId: null };
   // Voting history default: "voted in 1+ recent primaries" (single prime).
   return {
     kind: "voting-history-count",
@@ -261,6 +292,8 @@ export function isActiveFilter(f: Filter): boolean {
       f.state.trim().length > 0 ||
       f.zip.trim().length > 0
     );
+  if (f.kind === "segment") return f.segmentId != null;
+  if (f.kind === "nested") return f.criteria.steps.length > 0;
   // voting-history-count: active when window and count are non-degenerate.
   return f.windowYears > 0 && f.count >= 0;
 }

--- a/apps/web/src/lib/use-expanded-criteria.ts
+++ b/apps/web/src/lib/use-expanded-criteria.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { expandSegmentRefs, type SegmentLike } from "~/lib/expand-segment-refs";
+import type { Criteria } from "~/lib/filters";
+import { segmentsListQuery } from "~/lib/queries/segments";
+
+// Resolves segment refs in `criteria` using the org's segments list
+// (cached by TanStack). Cycle / depth errors fall through to an empty
+// criteria — the editor prevents that state, this is a safety net.
+export function useExpandedCriteria(criteria: Criteria | null | undefined): Criteria | null {
+  const { data: segments } = useQuery(segmentsListQuery());
+  return useMemo(() => {
+    if (!criteria) return null;
+    const map = new Map<string, SegmentLike>(
+      (segments ?? []).map((s) => [
+        s.segmentId,
+        { segmentId: s.segmentId, name: s.name, criteria: s.criteria as Criteria },
+      ]),
+    );
+    try {
+      return expandSegmentRefs(criteria, map);
+    } catch {
+      return { steps: [] };
+    }
+  }, [criteria, segments]);
+}

--- a/apps/web/src/routes/campaigns/$campaignId/cut.$zoneId.tsx
+++ b/apps/web/src/routes/campaigns/$campaignId/cut.$zoneId.tsx
@@ -24,6 +24,8 @@ import { campaignDetailQuery } from "~/lib/queries/campaigns";
 import { cutterBuildingsQuery, segmentDetailQuery } from "~/lib/queries/segments";
 import { turfDraftsQuery } from "~/lib/queries/turf-drafts";
 import { zoneGroupsQuery, zonesQuery } from "~/lib/queries/zones";
+import { useExpandedCriteria } from "~/lib/use-expanded-criteria";
+import type { Criteria } from "~/lib/filters";
 import { useFadeOnce } from "~/lib/use-fade-once";
 import { parseHexRgb } from "~/lib/utils";
 import { colorFor } from "~/lib/zone-colors";
@@ -87,13 +89,16 @@ function Cutter({ campaignId, zoneId }: { campaignId: string; zoneId: string }) 
     enabled: !!zoneGroup,
   });
 
+  const expandedSegmentCriteria = useExpandedCriteria(
+    segmentDetail?.criteria as Criteria | null | undefined,
+  );
   const { data: buildingsResult } = useQuery({
     ...cutterBuildingsQuery(
       zoneId,
-      segmentDetail?.criteria,
+      expandedSegmentCriteria,
       zoneGroup && zone ? { keyGroup: zoneGroup.keyGroup, keys: zone.keys } : undefined,
     ),
-    enabled: !!segmentDetail?.criteria && !!zone,
+    enabled: !!expandedSegmentCriteria && !!zone,
   });
   const buildings = buildingsResult?.buildings;
 

--- a/apps/web/src/routes/campaigns/$campaignId/index.tsx
+++ b/apps/web/src/routes/campaigns/$campaignId/index.tsx
@@ -19,6 +19,8 @@ import {
 import { type SegmentCriteria, segmentDetailQuery } from "~/lib/queries/segments";
 import { turfStatsForCampaignQuery } from "~/lib/queries/turfs";
 import { zoneGroupsQuery, zonesQuery } from "~/lib/queries/zones";
+import { useExpandedCriteria } from "~/lib/use-expanded-criteria";
+import type { Criteria } from "~/lib/filters";
 import { cn } from "~/lib/utils";
 import { client } from "~/rpc/client";
 import { colorFor } from "~/lib/zone-colors";
@@ -125,19 +127,25 @@ function CampaignEditor() {
     [activeZoneGroup, zones],
   );
 
+  // Resolve any segment-ref filters in the campaign's segment before
+  // sending criteria to the data server.
+  const expandedSegmentCriteria = useExpandedCriteria(
+    segmentDetail?.criteria as Criteria | null | undefined,
+  );
+
   const { data: pointsBuffer, isPlaceholderData: pointsStale } = useQuery({
-    ...(segmentDetail?.criteria && keyFilter
-      ? campaignPointsQuery(segmentDetail.criteria, keyFilter)
+    ...(expandedSegmentCriteria && keyFilter
+      ? campaignPointsQuery(expandedSegmentCriteria, keyFilter)
       : campaignPointsQuery({} as SegmentCriteria, null)),
-    enabled: !!segmentDetail?.criteria && !!keyFilter,
+    enabled: !!expandedSegmentCriteria && !!keyFilter,
     placeholderData: keepPreviousData,
   });
 
   const { data: keyCountsResult, isPlaceholderData: countsStale } = useQuery({
-    ...(segmentDetail?.criteria && keyFilter
-      ? campaignKeyCountsQuery(segmentDetail.criteria, keyFilter.keyGroup, keyFilter.keys)
+    ...(expandedSegmentCriteria && keyFilter
+      ? campaignKeyCountsQuery(expandedSegmentCriteria, keyFilter.keyGroup, keyFilter.keys)
       : campaignKeyCountsQuery({} as SegmentCriteria, "", [])),
-    enabled: !!segmentDetail?.criteria && !!keyFilter,
+    enabled: !!expandedSegmentCriteria && !!keyFilter,
     placeholderData: keepPreviousData,
   });
   const perKeyCounts = keyCountsResult?.counts ?? null;

--- a/apps/web/src/routes/segments/$segmentId.tsx
+++ b/apps/web/src/routes/segments/$segmentId.tsx
@@ -1,8 +1,10 @@
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { Reorder, useDragControls } from "motion/react";
+import { toast } from "sonner";
 import {
   Calendar as CalendarIcon,
+  ChevronDown,
   Filter as FilterIcon,
   GripVertical,
   Minus,
@@ -47,12 +49,14 @@ import {
   FILTER_SECTIONS,
   isActiveStep,
   type Criteria,
+  type SegmentFilter,
   type Step,
   type TextFilter,
   type Verb,
   type VotingHistoryFilter,
   VERB_META,
 } from "~/lib/filters";
+import { findCyclicSegmentIds, type SegmentLike } from "~/lib/expand-segment-refs";
 import {
   segmentCascadeQuery,
   segmentCountsQuery,
@@ -61,6 +65,7 @@ import {
   segmentSampleQuery,
   segmentsListQuery,
 } from "~/lib/queries/segments";
+import { useExpandedCriteria } from "~/lib/use-expanded-criteria";
 import type { CascadeStep } from "~/rpc/web/segments";
 import { cn, toTitleCase } from "~/lib/utils";
 import { client } from "~/rpc/client";
@@ -86,6 +91,11 @@ function SegmentEditor() {
     ...segmentDetailQuery(segmentId),
   });
 
+  // The full org segments list — already prefetched in the loader. The
+  // segment-ref filter editor reads this both to populate its dropdown
+  // and to detect cycles transitively.
+  const { data: allSegments } = useQuery(segmentsListQuery());
+
   const stepsRaw = (activeSegmentDetail?.criteria as Criteria | null)?.steps ?? [];
   const stepsIdRef = useRef<string[]>([]);
   while (stepsIdRef.current.length < stepsRaw.length) stepsIdRef.current.push(crypto.randomUUID());
@@ -98,10 +108,30 @@ function SegmentEditor() {
   const displaySteps = draft ?? steps;
 
   // Only steps with active filters drive queries — adding an empty step
-  // doesn't trigger a refetch.
-  const effectiveCriteria = useMemo<Criteria>(
+  // doesn't trigger a refetch. Segment-ref filters are resolved here so
+  // queries hit the cache as authored-form changes flow through.
+  const authoredCriteria = useMemo<Criteria>(
     () => ({ steps: steps.filter(isActiveStep) }),
     [steps],
+  );
+  const effectiveCriteria = useExpandedCriteria(authoredCriteria) ?? authoredCriteria;
+
+  // Segment id -> row lookup, used by the cascade panel to render
+  // segment refs as "Segment: <name>" and to mirror the expansion's
+  // drop-on-missing behaviour so the panel's steps align 1:1 with the
+  // count-cascade response.
+  const segmentsById = useMemo(
+    () => new globalThis.Map((allSegments ?? []).map((s) => [s.segmentId, s])),
+    [allSegments],
+  );
+  const displayCriteriaSteps = useMemo(
+    () =>
+      authoredCriteria.steps.filter(
+        (s) =>
+          s.filter.kind !== "segment" ||
+          (s.filter.segmentId != null && segmentsById.has(s.filter.segmentId)),
+      ),
+    [authoredCriteria.steps, segmentsById],
   );
 
   const [view, setView] = useState<"map" | "list" | "waterfall">("map");
@@ -162,23 +192,37 @@ function SegmentEditor() {
     stableCascadeRef.current = cascade ?? stableCascadeRef.current;
 
   const stableCriteriaStepsRef = useRef<Step[]>([]);
-  if (!stale && view === "waterfall") stableCriteriaStepsRef.current = effectiveCriteria.steps;
+  if (!stale && view === "waterfall") stableCriteriaStepsRef.current = displayCriteriaSteps;
 
-  // Optimistic update: write Criteria into the ["segment", id] cache.
+  // Optimistic update: write Criteria into both the detail cache and the
+  // list cache. The list carries criteria for every org segment so the
+  // segment-ref filter editor can resolve cross-references; without
+  // syncing the list, edits to X show up in X's own queries but referrers
+  // (Y → Segment: X) keep expanding against the stale list copy until a
+  // refetch lands.
   const updateCriteriaMutation = useMutation({
     mutationFn: (input: { segmentId: string; criteria: Criteria }) =>
       client.segments.updateCriteria({ segmentId: input.segmentId, criteria: input.criteria }),
     onMutate: async ({ segmentId: id, criteria }) => {
       await queryClient.cancelQueries({ queryKey: ["segment", id] });
-      const previous = queryClient.getQueryData(["segment", id]);
+      await queryClient.cancelQueries({ queryKey: ["segments"] });
+      const previousDetail = queryClient.getQueryData(["segment", id]);
+      const previousList = queryClient.getQueryData(["segments"]);
       queryClient.setQueryData(["segment", id], (old: { criteria: unknown } | null | undefined) =>
         old ? { ...old, criteria } : old,
       );
-      return { previous };
+      queryClient.setQueryData(
+        ["segments"],
+        (old: ReadonlyArray<{ segmentId: string; criteria: unknown }> | undefined) =>
+          old?.map((s) => (s.segmentId === id ? { ...s, criteria } : s)),
+      );
+      return { previousDetail, previousList };
     },
     onError: (e, { segmentId: id }, ctx) => {
       console.error("segments.updateCriteria failed", e);
-      if (ctx?.previous) queryClient.setQueryData(["segment", id], ctx.previous);
+      toast.error(e.message);
+      if (ctx?.previousDetail) queryClient.setQueryData(["segment", id], ctx.previousDetail);
+      if (ctx?.previousList) queryClient.setQueryData(["segments"], ctx.previousList);
     },
   });
 
@@ -254,6 +298,8 @@ function SegmentEditor() {
                     onChange={(next) => updateStep(serverIdx, { ...step, filter: next })}
                     onRemove={() => removeStep(serverIdx)}
                     onDragEnd={handleDragEnd}
+                    currentSegmentId={segmentId}
+                    allSegments={allSegments ?? []}
                   />
                 );
               })}
@@ -279,6 +325,7 @@ function SegmentEditor() {
               <WaterfallPanel
                 steps={stableCascadeRef.current?.steps ?? []}
                 criteriaSteps={stableCriteriaStepsRef.current}
+                segmentsById={segmentsById}
                 firstLoad={stableCascadeRef.current === undefined}
               />
             )}
@@ -361,10 +408,12 @@ function SamplePanel({
 function WaterfallPanel({
   steps,
   criteriaSteps,
+  segmentsById,
   firstLoad,
 }: {
   steps: CascadeStep[];
   criteriaSteps: Step[];
+  segmentsById: ReadonlyMap<string, { name: string }>;
   firstLoad: boolean;
 }) {
   const [anchor, setAnchor] = useState(0);
@@ -394,12 +443,17 @@ function WaterfallPanel({
             const criteriaStep = criteriaSteps[i - 1];
             const verb = criteriaStep?.verb;
             const verbMeta = verb ? VERB_META[verb] : null;
-            const filterDef = criteriaStep
-              ? criteriaStep.filter.kind === "all"
-                ? { label: "Everyone" }
-                : definitionFor(filterKey(criteriaStep.filter))
-              : null;
-            const label = i === 0 ? "All" : (filterDef?.label ?? "—");
+            const stepLabel = (() => {
+              if (!criteriaStep) return null;
+              const f = criteriaStep.filter;
+              if (f.kind === "all") return "Everyone";
+              if (f.kind === "segment") {
+                const name = f.segmentId ? segmentsById.get(f.segmentId)?.name : null;
+                return name ? `Segment: ${name}` : "Segment";
+              }
+              return definitionFor(filterKey(f))?.label ?? null;
+            })();
+            const label = i === 0 ? "All" : (stepLabel ?? "—");
             const isAnchor = i === effectiveAnchor;
             const above = i < effectiveAnchor;
             const prevCount = steps[i - 1]?.count ?? 0;
@@ -536,19 +590,23 @@ function StepRow({
   onChange,
   onRemove,
   dragControls,
+  currentSegmentId,
+  allSegments,
 }: {
   number: number;
   step: Step;
   onChange: (next: Filter) => void;
   onRemove: () => void;
   dragControls?: ReturnType<typeof useDragControls>;
+  currentSegmentId: string;
+  allSegments: ReadonlyArray<{ segmentId: string; name: string; criteria: unknown }>;
 }) {
   const { filter, verb } = step;
   const { color, label: verbLabel } = VERB_META[verb];
   const def =
     filter.kind === "all"
       ? { kind: "all" as const, key: "all", label: "Everyone" }
-      : definitionFor((filter as Exclude<Filter, { kind: "all" }>).key);
+      : definitionFor(filterKey(filter));
 
   return (
     <div className="rounded-md border border-border bg-card p-3">
@@ -601,6 +659,14 @@ function StepRow({
       ) : null}
       {filter.kind === "address" && def?.kind === "address" ? (
         <AddressFilterEditor filter={filter} onChange={onChange} />
+      ) : null}
+      {filter.kind === "segment" && def?.kind === "segment" ? (
+        <SegmentFilterEditor
+          filter={filter}
+          onChange={onChange}
+          currentSegmentId={currentSegmentId}
+          allSegments={allSegments}
+        />
       ) : null}
     </div>
   );
@@ -979,6 +1045,68 @@ function VotingHistoryFilterEditor({
   );
 }
 
+function SegmentFilterEditor({
+  filter,
+  onChange,
+  currentSegmentId,
+  allSegments,
+}: {
+  filter: SegmentFilter;
+  onChange: (next: Filter) => void;
+  currentSegmentId: string;
+  allSegments: ReadonlyArray<{ segmentId: string; name: string; criteria: unknown }>;
+}) {
+  // Segments that would form a cycle if selected — current segment plus
+  // any that transitively reference it. The set is content-dependent;
+  // re-derive whenever the segments list changes.
+  const cyclic = useMemo<Set<string>>(() => {
+    const entries: Array<[string, SegmentLike]> = allSegments.map((s) => [
+      s.segmentId,
+      { segmentId: s.segmentId, name: s.name, criteria: s.criteria as Criteria },
+    ]);
+    return findCyclicSegmentIds(currentSegmentId, new globalThis.Map(entries));
+  }, [allSegments, currentSegmentId]);
+
+  const selectable = [...allSegments]
+    .filter((s) => !cyclic.has(s.segmentId))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const selected = filter.segmentId
+    ? allSegments.find((s) => s.segmentId === filter.segmentId)
+    : null;
+  const triggerLabel = selected
+    ? selected.name
+    : filter.segmentId
+      ? "(deleted)"
+      : "Select segment…";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={<Button variant="outline" className="w-full justify-between font-normal" />}
+      >
+        <span className={cn("truncate", !selected ? "text-muted-foreground" : null)}>
+          {triggerLabel}
+        </span>
+        <ChevronDown className="text-muted-foreground" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-48 max-h-[291px] overflow-y-auto">
+        {selectable.length === 0 ? (
+          <DropdownMenuItem disabled>No other segments available</DropdownMenuItem>
+        ) : (
+          selectable.map((s) => (
+            <DropdownMenuItem
+              key={s.segmentId}
+              onClick={() => onChange({ ...filter, segmentId: s.segmentId })}
+            >
+              {s.name}
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function AddStepMenu({
   sections,
   isFirstStep,
@@ -1001,10 +1129,7 @@ function AddStepMenu({
       {allVerbs.map((verb) => {
         const { label } = VERB_META[verb];
         const disabled = isFirstStep && verb === "add"; // add only makes sense after a first step
-        // `Everyone` (kind:"all") only makes sense for `narrow` — hide it for add/remove.
-        const visibleSections = sections
-          .map((s) => s.filter((d) => verb === "narrow" || d.kind !== "all"))
-          .filter((s) => s.length > 0);
+        const visibleSections = sections;
         return (
           <div key={verb} className="flex-1">
             <DropdownMenu>
@@ -1026,7 +1151,7 @@ function AddStepMenu({
                     {sectionIdx > 0 ? <DropdownMenuSeparator /> : null}
                     {section.map((def) => (
                       <DropdownMenuItem key={def.key} onClick={() => onAdd(verb, def)}>
-                        {def.label}
+                        {def.kind === "segment" ? "Other Segment" : def.label}
                       </DropdownMenuItem>
                     ))}
                   </Fragment>

--- a/apps/web/src/rpc/web/segments.ts
+++ b/apps/web/src/rpc/web/segments.ts
@@ -1,6 +1,8 @@
-import { and, asc, eq } from "@field-tools/db";
+import { and, asc, eq, ne } from "@field-tools/db";
 import { campaigns, segments } from "@field-tools/db/schema";
 import { z } from "zod";
+import { expandSegmentRefs, SegmentRefError, type SegmentLike } from "~/lib/expand-segment-refs";
+import type { Criteria } from "~/lib/filters";
 import { dataPostJson } from "~/lib/server/data-proxy";
 import { webPub as pub } from "../context";
 
@@ -50,9 +52,11 @@ const segmentSelect = {
 };
 
 // List segments in the current user's organization, oldest first.
+// Criteria is included so the segment-ref filter editor can resolve
+// references and detect cycles without an extra round trip.
 export const list = pub.input(z.object({}).optional()).handler(async ({ context }) => {
   const rows = await context.db
-    .select(segmentSelect)
+    .select({ ...segmentSelect, criteria: segments.criteria })
     .from(segments)
     .where(eq(segments.organizationId, context.organizationId))
     .orderBy(asc(segments.createdAt));
@@ -208,8 +212,9 @@ export const countCampaigns = pub
   });
 
 // Replace a segment's criteria. Used by the segment editor's save flow.
-// The criteria shape is opaque at this layer — the editor and the data
-// service interpret it; the web RPC just stores and returns it.
+// The criteria shape is otherwise opaque at this layer, but segment
+// references are walked here to reject cycles before they persist —
+// the editor prevents them in the UI, this is a backstop.
 export const updateCriteria = pub
   .input(
     z.object({
@@ -230,6 +235,44 @@ export const updateCriteria = pub
     if (owned.length === 0) {
       throw new Error("Segment not found");
     }
+
+    const incoming = input.criteria as Criteria;
+    const others = await context.db
+      .select({
+        segmentId: segments.segmentId,
+        name: segments.name,
+        criteria: segments.criteria,
+      })
+      .from(segments)
+      .where(
+        and(
+          eq(segments.organizationId, context.organizationId),
+          ne(segments.segmentId, input.segmentId),
+        ),
+      );
+    // Build an org map containing the incoming criteria for the segment
+    // being saved (in place of its stored criteria). Expanding the
+    // incoming criteria then walks all transitive refs, and any path
+    // that loops back to the segment under edit trips the cycle check.
+    const segmentsById = new Map<string, SegmentLike>(
+      others.map((s) => [
+        s.segmentId,
+        { segmentId: s.segmentId, name: s.name, criteria: s.criteria as Criteria },
+      ]),
+    );
+    segmentsById.set(input.segmentId, {
+      segmentId: input.segmentId,
+      name: "(self)",
+      criteria: incoming,
+    });
+    try {
+      expandSegmentRefs(incoming, segmentsById);
+    } catch (err) {
+      if (err instanceof SegmentRefError)
+        throw new Error(`Invalid segment references: ${err.message}`);
+      throw err;
+    }
+
     await context.db
       .update(segments)
       .set({ criteria: input.criteria as object, updatedAt: new Date() })

--- a/apps/web/tests/expand-segment-refs.test.ts
+++ b/apps/web/tests/expand-segment-refs.test.ts
@@ -1,0 +1,183 @@
+import { test, expect } from "vite-plus/test";
+import type { Criteria } from "../src/lib/filters";
+import {
+  expandSegmentRefs,
+  findCyclicSegmentIds,
+  SegmentRefError,
+  type SegmentLike,
+} from "../src/lib/expand-segment-refs";
+
+const seg = (segmentId: string, name: string, criteria: Criteria): SegmentLike => ({
+  segmentId,
+  name,
+  criteria,
+});
+
+function mapOf(...segments: SegmentLike[]): ReadonlyMap<string, SegmentLike> {
+  return new Map(segments.map((s) => [s.segmentId, s]));
+}
+
+test("expands a SegmentFilter to a NestedFilter inline", () => {
+  const a = seg("a", "A", {
+    steps: [
+      {
+        id: "s1",
+        verb: "narrow",
+        filter: { kind: "text", key: "first_name", value: "Joe" },
+      },
+    ],
+  });
+  const outer: Criteria = {
+    steps: [
+      { id: "x", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "a" } },
+    ],
+  };
+  const expanded = expandSegmentRefs(outer, mapOf(a));
+  expect(expanded.steps[0]!.filter).toEqual({
+    kind: "nested",
+    criteria: a.criteria,
+  });
+});
+
+test("expands nested references recursively", () => {
+  const a = seg("a", "A", {
+    steps: [
+      { id: "s1", verb: "narrow", filter: { kind: "text", key: "first_name", value: "Joe" } },
+    ],
+  });
+  const b = seg("b", "B", {
+    steps: [
+      { id: "s2", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "a" } },
+    ],
+  });
+  const outer: Criteria = {
+    steps: [
+      { id: "x", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "b" } },
+    ],
+  };
+  const expanded = expandSegmentRefs(outer, mapOf(a, b));
+  const outerNested = expanded.steps[0]!.filter;
+  expect(outerNested.kind).toBe("nested");
+  if (outerNested.kind !== "nested") throw new Error("unreachable");
+  const innerNested = outerNested.criteria.steps[0]!.filter;
+  expect(innerNested).toEqual({ kind: "nested", criteria: a.criteria });
+});
+
+test("detects a direct cycle (A -> A)", () => {
+  const a = seg("a", "A", {
+    steps: [
+      { id: "s1", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "a" } },
+    ],
+  });
+  const outer: Criteria = {
+    steps: [
+      { id: "x", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "a" } },
+    ],
+  };
+  expect(() => expandSegmentRefs(outer, mapOf(a))).toThrow(SegmentRefError);
+});
+
+test("detects an indirect cycle (A -> B -> A)", () => {
+  const a = seg("a", "A", {
+    steps: [
+      { id: "s1", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "b" } },
+    ],
+  });
+  const b = seg("b", "B", {
+    steps: [
+      { id: "s2", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "a" } },
+    ],
+  });
+  const outer: Criteria = {
+    steps: [
+      { id: "x", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "a" } },
+    ],
+  };
+  expect(() => expandSegmentRefs(outer, mapOf(a, b))).toThrow(SegmentRefError);
+});
+
+test("missing referenced segment is dropped from criteria", () => {
+  const outer: Criteria = {
+    steps: [
+      { id: "x", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "ghost" } },
+    ],
+  };
+  const expanded = expandSegmentRefs(outer, mapOf());
+  expect(expanded.steps).toEqual([]);
+});
+
+test("null segmentId is dropped from criteria", () => {
+  const outer: Criteria = {
+    steps: [
+      { id: "x", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: null } },
+    ],
+  };
+  const expanded = expandSegmentRefs(outer, mapOf());
+  expect(expanded.steps).toEqual([]);
+});
+
+test("depth cap fires on long chains", () => {
+  // Chain of 10 segments, each referencing the next. Exceeds MAX_DEPTH=8.
+  const segments: SegmentLike[] = [];
+  for (let i = 0; i < 10; i++) {
+    const next = i < 9 ? `s${i + 1}` : null;
+    segments.push(
+      seg(`s${i}`, `S${i}`, {
+        steps:
+          next == null
+            ? [
+                {
+                  id: `f${i}`,
+                  verb: "narrow",
+                  filter: { kind: "text", key: "first_name", value: "x" },
+                },
+              ]
+            : [
+                {
+                  id: `f${i}`,
+                  verb: "narrow",
+                  filter: { kind: "segment", key: "segment", segmentId: next },
+                },
+              ],
+      }),
+    );
+  }
+  const outer: Criteria = {
+    steps: [
+      { id: "x", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "s0" } },
+    ],
+  };
+  expect(() => expandSegmentRefs(outer, mapOf(...segments))).toThrow(SegmentRefError);
+});
+
+test("leaves non-segment filters untouched", () => {
+  const outer: Criteria = {
+    steps: [
+      { id: "x", verb: "narrow", filter: { kind: "text", key: "first_name", value: "Joe" } },
+      {
+        id: "y",
+        verb: "add",
+        filter: { kind: "enum", key: "enrollment", values: ["democratic"] },
+      },
+    ],
+  };
+  expect(expandSegmentRefs(outer, mapOf())).toEqual(outer);
+});
+
+test("findCyclicSegmentIds reports self + transitive ancestors", () => {
+  // A -> B -> C. From C's editor, picking A or B (or C) would cycle.
+  const a = seg("a", "A", {
+    steps: [
+      { id: "s1", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "b" } },
+    ],
+  });
+  const b = seg("b", "B", {
+    steps: [
+      { id: "s2", verb: "narrow", filter: { kind: "segment", key: "segment", segmentId: "c" } },
+    ],
+  });
+  const c = seg("c", "C", { steps: [] });
+  const d = seg("d", "D", { steps: [] });
+  const cyclic = findCyclicSegmentIds("c", mapOf(a, b, c, d));
+  expect([...cyclic].sort()).toEqual(["a", "b", "c"]);
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,7 +6,7 @@ import * as schema from "./schema";
 
 // Re-export drizzle query helpers so consumers share the same drizzle-orm instance
 // as this package's schema (avoids type mismatches across pnpm peer-dep variants).
-export { and, asc, desc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
+export { and, asc, desc, eq, gt, inArray, isNull, ne, sql } from "drizzle-orm";
 
 export * from "./ids";
 


### PR DESCRIPTION
This PR allows Segments to reference other Segments. With this composition, and the Add / Remove / Narrow verbs, nearly all common universe definitions are now possible. The implementation is robust, with checks for cyclical dependencies, handling of deleting Segments, and a cap on levels of nesting (currently set to 8). Performance should be essentially the same as adding additional filters, because referencing Segments just compiles to additional clauses in the same flat WHERE predicate, with no extra database round-trips, subqueries, or joins.