### PR TITLE
fix: improved online detector

### DIFF
--- a/apps/native/src/lib/canvass-events.ts
+++ b/apps/native/src/lib/canvass-events.ts
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useState } from "react";
 import type { CanvassEventPayload } from "@field-tools/db/schema";
 import { createdByNameAtom } from "@/lib/atoms/created-by-name";
 import { syncIntervalAtom } from "@/lib/atoms/sync";
+import { FixedReactNativeOnlineDetector } from "@/lib/online-detector";
 import { queryClient } from "@/lib/query-client";
 import { client } from "@/rpc/client";
 
@@ -184,6 +185,10 @@ function createTurfContext(turfId: string): TurfContext {
   const executor = startOfflineExecutor({
     collections: { events: collection as never },
     storage: new AsyncStorageAdapter(),
+    // Workaround for TanStack/db#1490 — upstream RN detector has races
+    // that strand the outbox after airplane-mode-off. Drop the override
+    // (and the file) when upstream ships a fix.
+    onlineDetector: new FixedReactNativeOnlineDetector(),
     mutationFns: {
       appendEvent: async ({ transaction }) => {
         for (const mutation of transaction.mutations) {

--- a/apps/native/src/lib/online-detector.ts
+++ b/apps/native/src/lib/online-detector.ts
@@ -1,0 +1,76 @@
+import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
+import { AppState, type AppStateStatus } from "react-native";
+import type { OnlineDetector } from "@tanstack/offline-transactions";
+
+// Replacement for `@tanstack/offline-transactions`' ReactNativeOnlineDetector,
+// which has two race conditions on its internal `wasConnected` field that
+// leave the offline executor's outbox stuck after airplane-mode-off
+// (upstream issue TanStack/db#1490). Symptom: pending transactions don't
+// retry on reconnect until something else triggers `executeAll` — a new
+// recordEvent call, app foreground (AppState.active), or app restart.
+//
+// This implementation mirrors the upstream WebOnlineDetector's design:
+//   - notify on every "online" event from the source (no edge detection)
+//   - no async state probe at startup (no `NetInfo.fetch()` race)
+//   - subscribers (the executor) dedupe via their internal `isExecuting`
+//
+// RN can't fully match WebOnlineDetector — `NetInfo` has no synchronous
+// `isOnline()` equivalent, so we still cache `connected`. The discipline
+// is to update the cache *before* notifying and not rely on it for
+// transition detection. Drop this file and the `onlineDetector:` override
+// in `canvass-events.ts` when upstream ships a fix.
+export class FixedReactNativeOnlineDetector implements OnlineDetector {
+  private listeners = new Set<() => void>();
+  private netInfoUnsubscribe: (() => void) | null = null;
+  private appStateSubscription: { remove: () => void } | null = null;
+  // Optimistic until the first NetInfo event arrives. Matches upstream.
+  // We deliberately skip NetInfo.fetch() — that's the cause of the
+  // async-overwrite race in #1490.
+  private connected = true;
+
+  constructor() {
+    this.netInfoUnsubscribe = NetInfo.addEventListener((state) => {
+      const next = toConnectivityState(state);
+      this.connected = next;
+      if (next) this.notify();
+    });
+    this.appStateSubscription = AppState.addEventListener("change", (s: AppStateStatus) => {
+      if (s === "active") this.notify();
+    });
+  }
+
+  isOnline(): boolean {
+    return this.connected;
+  }
+
+  notifyOnline(): void {
+    this.notify();
+  }
+
+  subscribe(callback: () => void): () => void {
+    this.listeners.add(callback);
+    return () => {
+      this.listeners.delete(callback);
+    };
+  }
+
+  dispose(): void {
+    this.netInfoUnsubscribe?.();
+    this.appStateSubscription?.remove();
+    this.listeners.clear();
+  }
+
+  private notify(): void {
+    for (const cb of this.listeners) {
+      try {
+        cb();
+      } catch (err) {
+        console.warn("FixedReactNativeOnlineDetector listener error:", err);
+      }
+    }
+  }
+}
+
+function toConnectivityState(state: NetInfoState): boolean {
+  return !!state.isConnected && state.isInternetReachable !== false;
+}


### PR DESCRIPTION
We encountered an issue very similar to the one described [here](https://github.com/TanStack/db/issues/1490) where in rare circumstances the OnlineDetector fails to pick up on an offline to online transition (for example, while turning wifi on and off). In these scenarios, pending mutations wouldn't fire after coming back online until some other event required a network connection. This PR swaps out the built-in OnlineDetector for one that avoids at least two potential race conditions. Similar solution to the one proposed on the upstream Issue, and in practice seems to work (the problem only occured occasionally, but with this change I have been unable to reproduce it).