### PR TITLE
fix: eliminate webgl points jitter

### DIFF
--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -370,11 +370,18 @@ class _BuildingsPointsRequest(_WireBaseModel):
 
 @app.post("/buildings/points")
 async def buildings_points(req: _BuildingsPointsRequest):
-    """Binary lng/lat pairs (Float32, row-major) for buildings whose
-    contained persons match the criteria.
+    """Binary mercator-delta pairs for buildings whose contained persons
+    match the criteria.
 
-    Designed for direct upload into a GPU buffer on the browser — no
-    JSON envelope, no per-byte decode work.
+    Wire format: 16-byte header of two fp64 (origin_x, origin_y in
+    MapLibre [0,1] mercator), then N*8 bytes of fp32 (dx, dy) where each
+    pair is the building's mercator coord minus the origin.
+
+    The origin is the centroid of the returned points, kept at fp64 so
+    the browser-side `cameraMerc - origin` subtraction stays precise.
+    Storing deltas (not absolute mercator) lets fp32 spend its full
+    mantissa on intra-cluster precision. Gives millimeter-scale at z20
+    instead of meter-scale.
     """
     conn = get_connection(settings, read_only=True)
     criteria = resolve_criteria(req.criteria, conn, settings, req.org_slug)
@@ -382,20 +389,35 @@ async def buildings_points(req: _BuildingsPointsRequest):
     where = criteria_to_where(criteria, req.key_filter, params)
     sql = resolve(
         f"""
-        SELECT longitude, latitude
-        FROM {{buildings_geocoded}}
-        WHERE building_id IN (
-            SELECT DISTINCT building_id FROM {{persons_geocoded}} {where}
-        )
+        WITH pts AS (
+            SELECT
+                (b.longitude + 180.0) / 360.0 AS mx,
+                0.5 - ln(tan(pi()/4 + radians(b.latitude)/2)) / (2*pi()) AS my
+            FROM {{buildings_geocoded}} b
+            WHERE b.building_id IN (
+                SELECT DISTINCT building_id FROM {{persons_geocoded}} {where}
+            )
+        ),
+        o AS (SELECT avg(mx) AS ox, avg(my) AS oy FROM pts)
+        SELECT pts.mx - o.ox, pts.my - o.oy, o.ox, o.oy
+        FROM pts, o
         """,
         slug=req.org_slug,
     )
     cursor = conn.execute(sql, params)
-    arr = array.array("f")
-    for lng, lat in cursor.fetchall():
-        arr.append(lng)
-        arr.append(lat)
-    return Response(content=arr.tobytes(), media_type="application/octet-stream")
+    rows = cursor.fetchall()
+    header = array.array("d", [0.0, 0.0])
+    deltas = array.array("f")
+    if rows:
+        header[0] = rows[0][2]
+        header[1] = rows[0][3]
+        for dx, dy, _, _ in rows:
+            deltas.append(dx)
+            deltas.append(dy)
+    return Response(
+        content=header.tobytes() + deltas.tobytes(),
+        media_type="application/octet-stream",
+    )
 
 
 @app.post("/turfs/publish")

--- a/apps/web/src/components/map.tsx
+++ b/apps/web/src/components/map.tsx
@@ -92,12 +92,12 @@ type MapProps = {
   // map-internal events.
   loading?: boolean;
   // Optional point overlay rendered via a custom WebGL layer. The
-  // caller owns the data and passes a flat `[lng, lat, ...]` typed
-  // array straight into the GPU buffer — no per-point object
-  // allocation. We don't viewport-bound the data here; the layer
-  // renders whatever's loaded, and pan/zoom is purely a per-frame
-  // matrix update on the GPU.
-  points?: Float32Array;
+  // caller owns the data and passes a mercator-delta buffer + the fp64
+  // origin those deltas were computed against straight into the GPU
+  // buffer with no per-point object allocation. We don't viewport-bound
+  // the data here; the layer renders whatever's loaded, and pan/zoom
+  // is purely a per-frame matrix update on the GPU.
+  points?: { deltas: Float32Array; origin: [number, number] } | null;
   // Optional per-point RGB color overlay (one byte triple per point,
   // matched 1:1 with `points`). When provided, every dot uses its own
   // color instead of the layer's default style color. Mismatched

--- a/apps/web/src/components/points-layer.ts
+++ b/apps/web/src/components/points-layer.ts
@@ -1,32 +1,39 @@
 // Custom MapLibre layer that renders an array of geographic points as
 // anti-aliased dots via WebGL. Conforms to MapLibre's CustomLayerInterface.
 //
-// Input: a flat Float32Array of `[lng, lat, lng, lat, ...]` in degrees,
-// plus two optional per-point overlays:
+// Input: a Float32Array of mercator deltas `[dx, dy, dx, dy, ...]` where
+// each pair is the point's MapLibre [0,1] mercator coord minus a
+// stable `origin` (passed alongside the buffer, fp64). Pre-projecting
+// to mercator off the GPU is what ensures precision.
+//
+// Two optional per-point overlays:
 //   - colors  (Uint8Array RGB triples, one per point)
 //   - sizes   (Float32Array scaling factors, one per point)
 // Both default to a uniform style — `style.color` for color, 1.0 for
 // size — and resize automatically when `setPoints` runs.
 //
 // Data flow:
-//   setPoints(buf)  → one VBO upload per data refresh, plus reset of
+//   setPoints({deltas, origin})
+//                   → one VBO upload per data refresh, plus reset of
 //                     the color / size buffers to their defaults so a
 //                     stale per-point overlay can't outlive its points.
+//                     Stores `origin` for the per-frame shift math.
 //   setColors(buf)  → one VBO upload; `null` reverts to style color.
 //   setSizes(buf)   → one VBO upload; `null` reverts to scale 1.0.
-//   render()        → one draw call (gl.POINTS) per frame; the shader
-//                     subtracts a per-frame camera origin from each
-//                     projected mercator coord and applies an
-//                     origin-shifted matrix (see the "translation
-//                     split" comment on `render`).
+//   render()        → one draw call (gl.POINTS) per frame; computes
+//                     `shift = cameraMerc - storedOrigin` at fp64,
+//                     splits into hi/lo fp32, and the shader does
+//                     `a_merc_rel - shift` then multiplies by an
+//                     origin-shifted projection matrix (see the
+//                     "translation split" comment on `render`).
 //
 // The origin-split trick: at high zoom, MapLibre's `mainMatrix` has
 // translation values in the millions, and `mat * vec(small_mercator)`
 // in float32 is a difference-of-large-numbers that loses precision.
 // We compute a "shifted" matrix on the CPU (camera mercator origin
 // baked into the translation column at JS-double precision) and have
-// the shader multiply it against `mercator - origin`. Algebra cancels
-// the same way; the bytes flowing to the GPU are small numbers.
+// the shader multiply it against `mercator - cameraMerc`. Algebra
+// cancels the same way; the bytes flowing to the GPU are small numbers.
 
 import type {
   CustomLayerInterface,
@@ -37,8 +44,11 @@ import type {
 const VERTEX_SHADER = `#version 300 es
 precision highp float;
 
-// Per-vertex: lng, lat in degrees, straight from the server.
-in vec2 a_lnglat;
+// Per-vertex: mercator delta (point's [0,1] mercator coord minus the
+// layer's stored origin), pre-projected by the producer. Pre-projection +
+// origin subtract together keep fp32 spending its full mantissa on
+// useful digits, yielding millimeter precision at z20.
+in vec2 a_merc_rel;
 // Per-vertex color (UNSIGNED_BYTE normalized to 0..1). Defaults to
 // the style color when no per-point colors are provided.
 in vec3 a_color;
@@ -48,19 +58,15 @@ in float a_size;
 
 // Origin-shifted projection matrix (see PointsLayer.render).
 uniform mat4 u_matrix;
-// Camera mercator origin for the current frame, split into hi/lo
-// fp32 pair (effective ~48 bits of mantissa). The lo half absorbs
-// the fp32 quantization of the hi half, so the perceived origin
-// changes smoothly as the camera pans by sub-ULP amounts. Without
-// this, every fp32 quantum the camera crosses snaps all points by
-// 1 ULP at once — visible jitter during slow pan.
-uniform vec2 u_originHi;
-uniform vec2 u_originLo;
+// cameraMerc minus storedOrigin for the current frame, split into
+// hi/lo fp32 pair (effective ~48 bits of mantissa). Two-step subtract
+// in the shader stays smooth as the hi part ticks across fp32
+// boundaries during pan/zoom.
+uniform vec2 u_shiftHi;
+uniform vec2 u_shiftLo;
 uniform float u_zoom;
 
 out vec3 v_color;
-
-const float PI = 3.14159265359;
 
 // Zoom range and pixel-size endpoints for the dot. Each zoom level
 // scales the dot by the same factor (geometric ramp), matching the
@@ -71,17 +77,10 @@ const float PX_MIN = 2.0;
 const float PX_MAX = 14.0;
 
 void main() {
-  // Web Mercator projection: lng/lat (degrees) → mercator (0..1).
-  float x = (a_lnglat.x + 180.0) / 360.0;
-  float lat_rad = a_lnglat.y * PI / 180.0;
-  float y = 0.5 - log(tan(PI / 4.0 + lat_rad / 2.0)) / (2.0 * PI);
-
-  // Two-step subtraction: subtract the hi part (close to vertex
-  // mercator → fp32 has plenty of precision in the small result),
-  // then the lo residual. Equivalent to merc - (hi + lo) but stays
-  // smooth as the hi part ticks across fp32 boundaries during pan.
-  vec2 deltaHi = vec2(x, y) - u_originHi;
-  vec2 relative = deltaHi - u_originLo;
+  // (merc - cameraMerc) = (merc - storedOrigin) - (cameraMerc - storedOrigin).
+  // Two-step subtraction so cross-quantum camera shifts stay smooth.
+  vec2 deltaHi = a_merc_rel - u_shiftHi;
+  vec2 relative = deltaHi - u_shiftLo;
   gl_Position = u_matrix * vec4(relative, 0.0, 1.0);
 
   v_color = a_color;
@@ -138,20 +137,25 @@ export class PointsLayer implements CustomLayerInterface {
   private pointCount = 0;
 
   // Cached attribute / uniform locations.
-  private locA_lnglat = -1;
+  private locA_mercRel = -1;
   private locA_color = -1;
   private locA_size = -1;
   private locU_matrix: WebGLUniformLocation | null = null;
-  private locU_originHi: WebGLUniformLocation | null = null;
-  private locU_originLo: WebGLUniformLocation | null = null;
+  private locU_shiftHi: WebGLUniformLocation | null = null;
+  private locU_shiftLo: WebGLUniformLocation | null = null;
   private locU_zoom: WebGLUniformLocation | null = null;
 
   // Reusable scratch buffer for the shifted matrix; one allocation
   // amortized over every frame.
   private readonly shiftedMatrix = new Float32Array(16);
 
+  // Mercator origin the current `a_merc_rel` deltas were computed
+  // against. Held at fp64, the per-frame `cameraMerc - storedOrigin`
+  // subtract is the precision-critical step.
+  private storedOrigin: [number, number] = [0, 0];
+
   // Pending point data — applied during the next `onAdd` once GL is up.
-  private pendingPoints: Float32Array | null = null;
+  private pendingPoints: { deltas: Float32Array; origin: [number, number] } | null = null;
 
   // Latest user-provided overlays. `null` means "no per-point data,
   // use the style/default." Held independent of GL state so we can
@@ -174,7 +178,8 @@ export class PointsLayer implements CustomLayerInterface {
     this.colorBuffer = this.gl.createBuffer();
     this.sizeBuffer = this.gl.createBuffer();
     if (this.pendingPoints) {
-      this.uploadPoints(this.pendingPoints);
+      this.storedOrigin = this.pendingPoints.origin;
+      this.uploadPoints(this.pendingPoints.deltas);
       this.pendingPoints = null;
     }
     // Color/size buffers always need *some* contents — the shader
@@ -208,8 +213,8 @@ export class PointsLayer implements CustomLayerInterface {
     gl2.useProgram(this.program);
 
     gl2.bindBuffer(gl2.ARRAY_BUFFER, this.pointsBuffer);
-    gl2.enableVertexAttribArray(this.locA_lnglat);
-    gl2.vertexAttribPointer(this.locA_lnglat, 2, gl2.FLOAT, false, 0, 0);
+    gl2.enableVertexAttribArray(this.locA_mercRel);
+    gl2.vertexAttribPointer(this.locA_mercRel, 2, gl2.FLOAT, false, 0, 0);
 
     // Per-point color attribute when an overlay is active; otherwise
     // disable the array and feed the shader a constant style color via
@@ -267,19 +272,21 @@ export class PointsLayer implements CustomLayerInterface {
     this.shiftedMatrix[14] = M[2] * ox + M[6] * oy + M[14];
     this.shiftedMatrix[15] = M[3] * ox + M[7] * oy + M[15];
 
-    // Split the fp64 origin into a hi/lo fp32 pair. `Math.fround`
-    // gives the closest fp32; the residual fits in fp32 precision-wise
-    // because we just subtracted two close values. The shader does a
-    // two-step subtraction (see VERTEX_SHADER) so cross-quantum camera
-    // shifts stay smooth.
-    const oxHi = Math.fround(ox);
-    const oxLo = ox - oxHi;
-    const oyHi = Math.fround(oy);
-    const oyLo = oy - oyHi;
+    // Shift = cameraMerc - storedOrigin, computed at fp64 then split
+    // into hi/lo fp32. The subtraction itself is the precision-critical
+    // step — both operands are fp64 here. `Math.fround` quantizes to
+    // fp32; the residual recovers the bits lost. Two-step subtract in
+    // the shader keeps cross-quantum camera shifts smooth.
+    const sx = ox - this.storedOrigin[0];
+    const sy = oy - this.storedOrigin[1];
+    const sxHi = Math.fround(sx);
+    const sxLo = sx - sxHi;
+    const syHi = Math.fround(sy);
+    const syLo = sy - syHi;
 
     gl2.uniformMatrix4fv(this.locU_matrix, false, this.shiftedMatrix);
-    gl2.uniform2f(this.locU_originHi, oxHi, oyHi);
-    gl2.uniform2f(this.locU_originLo, oxLo, oyLo);
+    gl2.uniform2f(this.locU_shiftHi, sxHi, syHi);
+    gl2.uniform2f(this.locU_shiftLo, sxLo, syLo);
     gl2.uniform1f(this.locU_zoom, this.map.getZoom());
 
     gl2.drawArrays(gl2.POINTS, 0, this.pointCount);
@@ -288,17 +295,20 @@ export class PointsLayer implements CustomLayerInterface {
   // Replace the entire point set. One VBO upload for positions; the
   // color/size buffers only get touched when a per-point overlay is
   // active (otherwise render() supplies a constant attribute value).
-  // `flat` is `[lng0, lat0, lng1, lat1, ...]`. If the layer hasn't been
+  // `deltas` is `[dx0, dy0, dx1, dy1, ...]` in MapLibre [0,1] mercator,
+  // each pair already offset by `origin`. If the layer hasn't been
   // added to the map yet (onAdd hasn't run), we stash and upload on add.
-  setPoints(flat: Float32Array | null | undefined): void {
-    const data = flat ?? new Float32Array(0);
+  setPoints(input: { deltas: Float32Array; origin: [number, number] } | null | undefined): void {
+    const deltas = input?.deltas ?? new Float32Array(0);
+    const origin: [number, number] = input?.origin ?? [0, 0];
+    this.storedOrigin = origin;
     if (this.gl && this.pointsBuffer) {
-      this.uploadPoints(data);
+      this.uploadPoints(deltas);
       if (this.userColors) this.uploadDerivedColors();
       if (this.userSizes) this.uploadDerivedSizes();
     } else {
-      this.pendingPoints = data;
-      this.pointCount = data.length / 2;
+      this.pendingPoints = { deltas, origin };
+      this.pointCount = deltas.length / 2;
     }
     this.nudgeOnTop();
     this.map?.triggerRepaint();
@@ -393,12 +403,12 @@ export class PointsLayer implements CustomLayerInterface {
     }
     this.program = program;
 
-    this.locA_lnglat = gl.getAttribLocation(program, "a_lnglat");
+    this.locA_mercRel = gl.getAttribLocation(program, "a_merc_rel");
     this.locA_color = gl.getAttribLocation(program, "a_color");
     this.locA_size = gl.getAttribLocation(program, "a_size");
     this.locU_matrix = gl.getUniformLocation(program, "u_matrix");
-    this.locU_originHi = gl.getUniformLocation(program, "u_originHi");
-    this.locU_originLo = gl.getUniformLocation(program, "u_originLo");
+    this.locU_shiftHi = gl.getUniformLocation(program, "u_shiftHi");
+    this.locU_shiftLo = gl.getUniformLocation(program, "u_shiftLo");
     this.locU_zoom = gl.getUniformLocation(program, "u_zoom");
   }
 }

--- a/apps/web/src/lib/queries/segments.ts
+++ b/apps/web/src/lib/queries/segments.ts
@@ -26,6 +26,11 @@ export const segmentCountsQuery = (criteria: Criteria) =>
     staleTime: Number.POSITIVE_INFINITY,
   });
 
+export type SegmentPoints = {
+  origin: [number, number];
+  deltas: Float32Array;
+};
+
 // gcTime:0 releases the multi-MB Float32Array the moment the query goes
 // inactive — accumulating multiple buffers triggers V8 GC pauses.
 export const segmentPointsQuery = (criteria: Criteria) =>
@@ -50,14 +55,20 @@ export const segmentCascadeQuery = (criteria: Criteria) =>
     staleTime: Number.POSITIVE_INFINITY,
   });
 
-// Binary lng/lat pairs — uploaded directly into a GPU buffer, so the
-// response stays as raw bytes the whole way through (no JSON envelope,
-// no per-byte JS decode). Lives outside oRPC for that reason; auth /
-// org are enforced by the /api proxy on the web edge.
+// Binary mercator-delta pairs — uploaded directly into a GPU buffer,
+// so the response stays as raw bytes the whole way through (no JSON
+// envelope, no per-byte JS decode). Lives outside oRPC for that
+// reason; auth / org are enforced by the /api proxy on the web edge.
+//
+// Wire: 16-byte header (two fp64 — origin x, y in [0,1] mercator),
+// then N*8 bytes of fp32 (dx, dy). The fp64 origin is critical: the
+// per-frame `cameraMerc - origin` subtract in PointsLayer happens at
+// fp64, and an fp32 origin would re-introduce the precision loss the
+// delta encoding exists to fix.
 export async function fetchSegmentPoints(input: {
   criteria: unknown;
   keyFilter?: { keyGroup: string; keys: string[] } | null;
-}): Promise<Float32Array> {
+}): Promise<SegmentPoints> {
   const orgSlug = getCurrentOrgSlug();
   const res = await fetch(`/api/web/${orgSlug}/segment-points`, {
     method: "POST",
@@ -68,7 +79,10 @@ export async function fetchSegmentPoints(input: {
     }),
   });
   if (!res.ok) throw new Error(`segment-points failed: ${res.status} ${await res.text()}`);
-  return new Float32Array(await res.arrayBuffer());
+  const buf = await res.arrayBuffer();
+  const header = new Float64Array(buf, 0, 2);
+  const deltas = new Float32Array(buf, 16);
+  return { origin: [header[0]!, header[1]!], deltas };
 }
 
 // Buildings inside a single zone, narrowed by segment criteria. Used by

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut.$zoneId.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut.$zoneId.tsx
@@ -107,14 +107,34 @@ function Cutter({
   });
   const buildings = buildingsResult?.buildings;
 
+  // Project to MapLibre [0,1] mercator at fp64, subtract the centroid,
+  // then store fp32 deltas. fp32 over the tight centered range keeps
+  // millimeter precision at z20 (raw lng/lat → mercator in the shader
+  // at fp32 loses ~8 px per ULP at z20 — visible jitter).
   const pointsBuffer = useMemo(() => {
-    if (!buildings) return undefined;
-    const buf = new Float32Array(buildings.length * 2);
-    for (let i = 0; i < buildings.length; i++) {
-      buf[i * 2] = buildings[i]!.longitude;
-      buf[i * 2 + 1] = buildings[i]!.latitude;
+    if (!buildings || buildings.length === 0) return undefined;
+    const n = buildings.length;
+    const merc = new Float64Array(n * 2);
+    let ox = 0;
+    let oy = 0;
+    for (let i = 0; i < n; i++) {
+      const b = buildings[i]!;
+      const mx = (b.longitude + 180) / 360;
+      const my =
+        0.5 - Math.log(Math.tan(Math.PI / 4 + (b.latitude * Math.PI) / 360)) / (2 * Math.PI);
+      merc[i * 2] = mx;
+      merc[i * 2 + 1] = my;
+      ox += mx;
+      oy += my;
     }
-    return buf;
+    ox /= n;
+    oy /= n;
+    const deltas = new Float32Array(n * 2);
+    for (let i = 0; i < n; i++) {
+      deltas[i * 2] = merc[i * 2]! - ox;
+      deltas[i * 2 + 1] = merc[i * 2 + 1]! - oy;
+    }
+    return { deltas, origin: [ox, oy] as [number, number] };
   }, [buildings]);
 
   // BBox of the zone's keys' polygons (no unioning needed — bbox accumulates the same).


### PR DESCRIPTION
This PR changes the math for rendering points to eliminate jitter at high zooms caused by floating point math. Instead of passing lat lons and converting to mercator on the GPU, we convert to mercator in Python and ship deltas relative to an origin, which the GPU can then render with higher precision at extreme zoom. The payload for the turf cutter is slightly different (because it includes door and people counts) but it's shipped in the same format. 

With this change, the previous jitter at high zooms is totally gone.