### PR TITLE
feat: cut segments without zones

### DIFF
--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -330,6 +330,7 @@ async def persons_count_by_key(req: _PersonsCountByKeyRequest):
         f"""
         SELECT
             {group_expr} AS key,
+            count(DISTINCT building_id) AS buildings,
             count(DISTINCT door_id) AS doors,
             count(*) AS people
         FROM {{persons_geocoded}}
@@ -340,10 +341,14 @@ async def persons_count_by_key(req: _PersonsCountByKeyRequest):
     )
     rows = conn.execute(sql, params).fetchall()
     counts: dict[str, dict[str, int]] = {}
-    for key, doors, people in rows:
+    for key, buildings, doors, people in rows:
         if key is None:
             continue
-        counts[key] = {"doors": int(doors), "people": int(people)}
+        counts[key] = {
+            "buildings": int(buildings),
+            "doors": int(doors),
+            "people": int(people),
+        }
     return {"counts": counts}
 
 

--- a/apps/data/src/publish_turfs.py
+++ b/apps/data/src/publish_turfs.py
@@ -35,21 +35,29 @@ logger = logging.getLogger("uvicorn")
 
 class PublishTurfsRequest(BaseModel):
     campaignId: str  # noqa: N815
-    zoneId: str  # noqa: N815
+    # `null` ⇒ zoneless campaign: drafts are scoped only by campaign and
+    # the publish reads the full segment (no key filter).
+    zoneId: str | None  # noqa: N815
     createdBy: str  # noqa: N815
     orgSlug: str  # noqa: N815
 
 
 @dataclass(frozen=True)
 class _PublishScope:
-    """Pre-resolved facts the publish SQL needs as parameters."""
+    """Pre-resolved facts the publish SQL needs as parameters.
+
+    For zoneless campaigns, ``zone_id``, ``zone_group_id``, ``key_group``
+    are ``None`` and ``keys`` is empty — downstream SQL binds NULL for
+    the zone columns and ``criteria_to_where`` is called without a key
+    filter.
+    """
 
     campaign_id: str
     segment_id: str
-    zone_id: str
-    zone_group_id: str
+    zone_id: str | None
+    zone_group_id: str | None
     script_id: str
-    key_group: str
+    key_group: str | None
     keys: list[str]
     criteria: Criteria
     draft_count: int
@@ -85,7 +93,10 @@ async def publish_turfs(req: PublishTurfsRequest) -> dict[str, Any]:
     scope = _load_publish_scope(conn, req)
     criteria = resolve_criteria(scope.criteria, conn, settings, req.orgSlug)
     where_params: list = []
-    where_sql = criteria_to_where(criteria, KeyFilter(keyGroup=scope.key_group, keys=scope.keys), where_params)
+    # Zoned: scope to the zone's keys. Zoneless: no key filter — publish
+    # spans the whole segment.
+    key_filter = KeyFilter(keyGroup=scope.key_group, keys=scope.keys) if scope.key_group is not None else None
+    where_sql = criteria_to_where(criteria, key_filter, where_params)
     _check_no_ambiguous_assignments(conn, req, where_sql, where_params)
 
     # Retry budget exists only to swallow the rare turf_code collision
@@ -155,13 +166,16 @@ def _check_no_ambiguous_assignments(
     """
     persons_table = resolve("{persons_geocoded}", slug=req.orgSlug)
     buildings_table = resolve("{buildings_geocoded}", slug=req.orgSlug)
+    # `IS NOT DISTINCT FROM` matches null-to-null, so the same predicate
+    # works for zoned (zoneId is a UUID) and zoneless (zoneId is NULL)
+    # publishes — no SQL branching needed.
     sql = f"""
     WITH drafts AS (
         SELECT
             row_number() OVER (ORDER BY d.sort_order, d.turf_draft_id) - 1 AS idx,
             ST_GeomFromGeoJSON(d.geometry::VARCHAR) AS geom
         FROM {OPERATIONAL_PG_ALIAS}.public.turf_drafts d
-        WHERE d.campaign_id = ?::UUID AND d.zone_id = ?::UUID
+        WHERE d.campaign_id = ?::UUID AND d.zone_id IS NOT DISTINCT FROM ?::UUID
     ),
     matched_buildings AS (
         SELECT DISTINCT b.building_id, b.longitude, b.latitude
@@ -196,9 +210,17 @@ def _check_no_ambiguous_assignments(
 
 
 def _load_publish_scope(conn: duckdb.DuckDBPyConnection, req: PublishTurfsRequest) -> _PublishScope:
-    """Resolve the campaign + segment + zone + draft count in a single SQL
-    hit through the attached Postgres. Raises 4xx for the various
-    "not configured to publish" cases."""
+    """Resolve the campaign + segment + (optional) zone + draft count in
+    one SQL hit through the attached Postgres.
+
+    Zone joins are LEFT so zoneless campaigns (``req.zoneId is None``
+    AND ``campaigns.zone_group_id IS NULL``) still produce a row with
+    nulls in the zone columns. ``IS NOT DISTINCT FROM`` matches the
+    draft-count subquery for both zoned (zoneId UUID) and zoneless
+    (zoneId NULL) callers.
+
+    Raises 4xx for the various "not configured to publish" cases.
+    """
     row = conn.execute(
         f"""
         SELECT
@@ -212,28 +234,29 @@ def _load_publish_scope(conn: duckdb.DuckDBPyConnection, req: PublishTurfsReques
             z.keys::VARCHAR AS keys_json,
             (
                 SELECT count(*)::INT FROM {OPERATIONAL_PG_ALIAS}.public.turf_drafts d
-                WHERE d.campaign_id = c.campaign_id AND d.zone_id = z.zone_id
+                WHERE d.campaign_id = c.campaign_id
+                  AND d.zone_id IS NOT DISTINCT FROM ?::UUID
             ) AS draft_count
         FROM {OPERATIONAL_PG_ALIAS}.public.campaigns c
         JOIN {OPERATIONAL_PG_ALIAS}.public.segments s ON s.segment_id = c.segment_id
-        JOIN {OPERATIONAL_PG_ALIAS}.public.zone_groups zg
+        LEFT JOIN {OPERATIONAL_PG_ALIAS}.public.zone_groups zg
             ON zg.zone_group_id = c.zone_group_id
-        JOIN {OPERATIONAL_PG_ALIAS}.public.zones z
+        LEFT JOIN {OPERATIONAL_PG_ALIAS}.public.zones z
             ON z.zone_id = ?::UUID
             AND z.zone_group_id = c.zone_group_id
         WHERE c.campaign_id = ?::UUID
         """,
-        [req.zoneId, req.campaignId],
+        [req.zoneId, req.zoneId, req.campaignId],
     ).fetchone()
 
     if not row:
-        raise HTTPException(status_code=404, detail="Campaign or zone not found.")
+        raise HTTPException(status_code=404, detail="Campaign not found.")
 
     (
         campaign_id,
         segment_id,
         script_id,
-        zone_group_id,
+        campaign_zone_group_id,
         criteria_json,
         key_group,
         zone_id,
@@ -241,11 +264,26 @@ def _load_publish_scope(conn: duckdb.DuckDBPyConnection, req: PublishTurfsReques
         draft_count,
     ) = row
 
-    if not segment_id or not script_id or not zone_group_id:
+    if not segment_id or not script_id:
         raise HTTPException(
             status_code=400,
-            detail="Campaign must have a segment, script, and zone group bound to publish.",
+            detail="Campaign must have a segment and script bound to publish.",
         )
+    # Detect the two coherent shapes (and reject mismatches):
+    #   zoned:    req.zoneId set + campaign has zone group + zone row found
+    #   zoneless: req.zoneId null + campaign has no zone group
+    if req.zoneId is None and campaign_zone_group_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Campaign has a zone group; publish must specify a zoneId.",
+        )
+    if req.zoneId is not None and not campaign_zone_group_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Campaign has no zone group; publish with zoneId=null.",
+        )
+    if req.zoneId is not None and not zone_id:
+        raise HTTPException(status_code=404, detail="Zone not found in campaign's zone group.")
     if draft_count == 0:
         raise HTTPException(status_code=400, detail="No drafts to publish.")
 
@@ -258,7 +296,7 @@ def _load_publish_scope(conn: duckdb.DuckDBPyConnection, req: PublishTurfsReques
         campaign_id=campaign_id,
         segment_id=segment_id,
         zone_id=zone_id,
-        zone_group_id=zone_group_id,
+        zone_group_id=campaign_zone_group_id,
         script_id=script_id,
         key_group=key_group,
         keys=[str(k) for k in keys],
@@ -298,7 +336,7 @@ def _build_publish_temp_table_sql(org_slug: str, where_sql: str) -> str:
             ST_GeomFromGeoJSON(d.geometry::VARCHAR) AS geom
         FROM {OPERATIONAL_PG_ALIAS}.public.turf_drafts d
         WHERE d.campaign_id = ?::UUID
-          AND d.zone_id = ?::UUID
+          AND d.zone_id IS NOT DISTINCT FROM ?::UUID
     ),
     filtered_persons AS (
         SELECT * FROM {persons_table} {where_sql}

--- a/apps/data/src/publish_turfs.py
+++ b/apps/data/src/publish_turfs.py
@@ -269,20 +269,16 @@ def _load_publish_scope(conn: duckdb.DuckDBPyConnection, req: PublishTurfsReques
             status_code=400,
             detail="Campaign must have a segment and script bound to publish.",
         )
-    # Detect the two coherent shapes (and reject mismatches):
-    #   zoned:    req.zoneId set + campaign has zone group + zone row found
-    #   zoneless: req.zoneId null + campaign has no zone group
-    if req.zoneId is None and campaign_zone_group_id:
+    # Valid shapes: zoned (both zoneId and zoneGroupId present) or
+    # zoneless (both absent). Anything else is a caller bug.
+    expects_zone = req.zoneId is not None
+    has_zone_group = campaign_zone_group_id is not None
+    if expects_zone != has_zone_group:
         raise HTTPException(
             status_code=400,
-            detail="Campaign has a zone group; publish must specify a zoneId.",
+            detail="zoneId presence must match campaign.zoneGroupId presence.",
         )
-    if req.zoneId is not None and not campaign_zone_group_id:
-        raise HTTPException(
-            status_code=400,
-            detail="Campaign has no zone group; publish with zoneId=null.",
-        )
-    if req.zoneId is not None and not zone_id:
+    if expects_zone and not zone_id:
         raise HTTPException(status_code=404, detail="Zone not found in campaign's zone group.")
     if draft_count == 0:
         raise HTTPException(status_code=400, detail="No drafts to publish.")

--- a/apps/web/src/components/turf-list.tsx
+++ b/apps/web/src/components/turf-list.tsx
@@ -91,15 +91,15 @@ export function TurfList({ turfs, selectedTurfId, onSelect, onRemove, emptyMessa
                   variant="number"
                   className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
                 >
-                  <DoorClosed className="size-3.5 text-foreground" />
-                  {turf.counts.doors.toLocaleString()}
+                  <UserRound className="size-3.5 text-foreground" />
+                  {turf.counts.people.toLocaleString()}
                 </Pill>
                 <Pill
                   variant="number"
                   className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
                 >
-                  <UserRound className="size-3.5 text-foreground" />
-                  {turf.counts.people.toLocaleString()}
+                  <DoorClosed className="size-3.5 text-foreground" />
+                  {turf.counts.doors.toLocaleString()}
                 </Pill>
               </div>
             ) : null}

--- a/apps/web/src/lib/queries/segments.ts
+++ b/apps/web/src/lib/queries/segments.ts
@@ -85,11 +85,14 @@ export async function fetchSegmentPoints(input: {
   return { origin: [header[0]!, header[1]!], deltas };
 }
 
-// Buildings inside a single zone, narrowed by segment criteria. Used by
-// the turf cutter. `segmentCriteria` is `unknown`-typed at the type level,
-// so passing `undefined` is structurally allowed for disabled-state calls.
+// Buildings for the turf cutter, narrowed by segment criteria and
+// optionally further filtered to a specific zone's keys. Pass
+// `zoneId: null` and `keyFilter: undefined` for zoneless campaigns —
+// the cutter then renders the full segment's points. `segmentCriteria`
+// is `unknown`-typed at the type level, so passing `undefined` is
+// structurally allowed for disabled-state calls.
 export const cutterBuildingsQuery = (
-  zoneId: string,
+  zoneId: string | null,
   segmentCriteria: SegmentCriteria,
   keyFilter: { keyGroup: string; keys: string[] } | undefined,
 ) =>

--- a/apps/web/src/lib/queries/turf-drafts.ts
+++ b/apps/web/src/lib/queries/turf-drafts.ts
@@ -1,7 +1,10 @@
 import { queryOptions } from "@tanstack/react-query";
 import { client } from "~/rpc/client";
 
-export const turfDraftsQuery = (campaignId: string, zoneId: string) =>
+// `zoneId: null` is the zoneless scope (cut against the full segment).
+// The cache key keeps `null` as a discrete bucket so zoned and zoneless
+// drafts on the same campaign don't share state.
+export const turfDraftsQuery = (campaignId: string, zoneId: string | null) =>
   queryOptions({
     queryKey: ["turf-drafts", campaignId, zoneId] as const,
     queryFn: () => client.turfDrafts.list({ campaignId, zoneId }),

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut/$zoneId.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut/$zoneId.tsx
@@ -60,14 +60,20 @@ function CutterPage() {
   return <Cutter key={zoneId} orgSlug={orgSlug} campaignId={campaignId} zoneId={zoneId} />;
 }
 
-function Cutter({
+// Exported so the zoneless `cut.tsx` route can render the same Cutter
+// with `zoneId={null}` — keeps the two routes thin shells over one
+// implementation.
+export function Cutter({
   orgSlug,
   campaignId,
   zoneId,
 }: {
   orgSlug: string;
   campaignId: string;
-  zoneId: string;
+  // `zoneId === null` means the campaign has no zone group — the cutter
+  // operates against the full segment (no key filter, fitBounds from
+  // the points buffer, drafts/publish RPCs accept null).
+  zoneId: string | null;
 }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -97,13 +103,18 @@ function Cutter({
   });
 
   const segmentCriteria = segmentDetail?.criteria as Criteria | null | undefined;
+  // Zoned: pass keyFilter so the data server narrows buildings to the
+  // zone's keys. Zoneless: no keyFilter → all buildings matching the
+  // segment criteria. The query is enabled either as soon as we have a
+  // segment + zone match (zoned), or as soon as we have a segment at
+  // all (zoneless).
   const { data: buildingsResult } = useQuery({
     ...cutterBuildingsQuery(
       zoneId,
       segmentCriteria,
       zoneGroup && zone ? { keyGroup: zoneGroup.keyGroup, keys: zone.keys } : undefined,
     ),
-    enabled: !!segmentCriteria && !!zone,
+    enabled: !!segmentCriteria && (zoneId === null || !!zone),
   });
   const buildings = buildingsResult?.buildings;
 
@@ -137,8 +148,25 @@ function Cutter({
     return { deltas, origin: [ox, oy] as [number, number] };
   }, [buildings]);
 
-  // BBox of the zone's keys' polygons (no unioning needed — bbox accumulates the same).
-  const fitBounds = useMemo(() => {
+  // Zoned: bbox of the zone's keys' polygons (no unioning needed — bbox
+  // accumulates the same). Zoneless: bbox of the buildings themselves,
+  // which is the natural "fit to what you can cut" framing when there's
+  // no zone perimeter to anchor against.
+  const fitBounds = useMemo<[number, number, number, number] | null>(() => {
+    if (zoneId === null) {
+      if (!buildings || buildings.length === 0) return null;
+      let minLng = Infinity;
+      let minLat = Infinity;
+      let maxLng = -Infinity;
+      let maxLat = -Infinity;
+      for (const b of buildings) {
+        if (b.longitude < minLng) minLng = b.longitude;
+        if (b.longitude > maxLng) maxLng = b.longitude;
+        if (b.latitude < minLat) minLat = b.latitude;
+        if (b.latitude > maxLat) maxLat = b.latitude;
+      }
+      return [minLng, minLat, maxLng, maxLat];
+    }
     if (!zone || !boundaryFC) return null;
     const keys = new Set(zone.keys);
     let minLng = Infinity;
@@ -165,8 +193,8 @@ function Cutter({
         for (const poly of g.coordinates) for (const ring of poly) for (const c of ring) visit(c);
       }
     }
-    return touched ? ([minLng, minLat, maxLng, maxLat] as [number, number, number, number]) : null;
-  }, [zone, boundaryFC]);
+    return touched ? [minLng, minLat, maxLng, maxLat] : null;
+  }, [zoneId, zone, boundaryFC, buildings]);
 
   // In-progress turfs. Lives in the parent so the sidebar list and the
   // drawer share one source of truth. Initialised from loader-fresh drafts.
@@ -398,7 +426,7 @@ function Cutter({
     <div className={shouldFade}>
       <EditorHeader
         title="Turf Cutter"
-        subtitle={zone?.name}
+        subtitle={zoneId === null ? "Full segment" : zone?.name}
         leading={
           <Button variant="outline" size="icon" onClick={onBack} aria-label="Back to campaign">
             <ArrowLeft />
@@ -469,8 +497,8 @@ function Cutter({
         <DialogContent>
           <DialogTitle>Clear all turfs?</DialogTitle>
           <DialogDescription>
-            Removes every turf you've cut in this zone, including any in-progress turfs. This can't
-            be undone.
+            Removes every turf you've cut in {zoneId === null ? "this campaign" : "this zone"},
+            including any in-progress turfs. This can't be undone.
           </DialogDescription>
           <div className="mt-2 flex justify-end gap-2">
             <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut/$zoneId.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut/$zoneId.tsx
@@ -35,9 +35,10 @@ export const Route = createFileRoute("/$orgSlug/campaigns/$campaignId/cut/$zoneI
   // the heavy queries, and we'd rather get the user to the cutter chrome
   // fast and let the Map curtain hide their fetch than block navigation.
   loader: async ({ context: { queryClient }, params: { campaignId, zoneId } }) => {
+    // zoneGroupsQuery is already prefetched by the parent campaigns
+    // route loader, so we don't refetch it here.
     const [campaign] = await Promise.all([
       queryClient.fetchQuery(campaignDetailQuery(campaignId)),
-      queryClient.fetchQuery(zoneGroupsQuery()),
       queryClient.fetchQuery(turfDraftsQuery(campaignId, zoneId)),
     ]);
 
@@ -60,9 +61,7 @@ function CutterPage() {
   return <Cutter key={zoneId} orgSlug={orgSlug} campaignId={campaignId} zoneId={zoneId} />;
 }
 
-// Exported so the zoneless `cut.tsx` route can render the same Cutter
-// with `zoneId={null}` — keeps the two routes thin shells over one
-// implementation.
+// Shared between zoned (`./$zoneId`) and zoneless (`./index`) cutter routes.
 export function Cutter({
   orgSlug,
   campaignId,

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut/index.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut/index.tsx
@@ -1,0 +1,32 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { campaignDetailQuery } from "~/lib/queries/campaigns";
+import { segmentDetailQuery } from "~/lib/queries/segments";
+import { turfDraftsQuery } from "~/lib/queries/turf-drafts";
+import { Cutter } from "./$zoneId";
+
+// Zoneless cutter route — campaign has no zone group, so the cutter
+// operates against the full segment. The Cutter component is shared
+// with `./$zoneId.tsx`; this file is just the route wrapper.
+export const Route = createFileRoute("/$orgSlug/campaigns/$campaignId/cut/")({
+  loader: async ({ context: { queryClient }, params: { campaignId } }) => {
+    const [campaign] = await Promise.all([
+      queryClient.fetchQuery(campaignDetailQuery(campaignId)),
+      queryClient.fetchQuery(turfDraftsQuery(campaignId, null)),
+    ]);
+    if (campaign.segmentId) {
+      await queryClient.fetchQuery(segmentDetailQuery(campaign.segmentId));
+    }
+  },
+  component: CutterPage,
+});
+
+function CutterPage() {
+  const { orgSlug, campaignId } = Route.useParams();
+  // Key includes campaignId so navigating between two zoneless campaigns
+  // forces a remount — same reset semantics as the zoned route's
+  // `key={zoneId}` (zoneIds are unique per campaign, so swapping
+  // campaigns there changes the key naturally; here we need help).
+  return (
+    <Cutter key={`${campaignId}-full`} orgSlug={orgSlug} campaignId={campaignId} zoneId={null} />
+  );
+}

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut/index.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/cut/index.tsx
@@ -22,10 +22,8 @@ export const Route = createFileRoute("/$orgSlug/campaigns/$campaignId/cut/")({
 
 function CutterPage() {
   const { orgSlug, campaignId } = Route.useParams();
-  // Key includes campaignId so navigating between two zoneless campaigns
-  // forces a remount — same reset semantics as the zoned route's
-  // `key={zoneId}` (zoneIds are unique per campaign, so swapping
-  // campaigns there changes the key naturally; here we need help).
+  // Key includes campaignId so navigating between zoneless campaigns
+  // remounts the Cutter; the zoned route gets this for free via `zoneId`.
   return (
     <Cutter key={`${campaignId}-full`} orgSlug={orgSlug} campaignId={campaignId} zoneId={null} />
   );

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
@@ -19,7 +19,7 @@ import {
 import { scriptsListQuery } from "~/lib/queries/scripts";
 import {
   segmentCountsQuery,
-  segmentDetailQuery,
+  segmentsListQuery,
   type SegmentCriteria,
 } from "~/lib/queries/segments";
 import { turfStatsForCampaignQuery } from "~/lib/queries/turfs";
@@ -119,14 +119,13 @@ export const Route = createFileRoute("/$orgSlug/campaigns/$campaignId/")({
       queryClient.fetchQuery(campaignDetailQuery(campaignId)),
       queryClient.fetchQuery(turfStatsForCampaignQuery(campaignId)),
     ]);
-    await Promise.all([
-      campaign.segmentId
-        ? queryClient.fetchQuery(segmentDetailQuery(campaign.segmentId))
-        : Promise.resolve(undefined),
-      campaign.zoneGroupId
-        ? queryClient.fetchQuery(zonesQuery(campaign.zoneGroupId))
-        : Promise.resolve(undefined),
-    ]);
+    if (campaign.zoneGroupId) {
+      await queryClient.fetchQuery(zonesQuery(campaign.zoneGroupId));
+    }
+    // segmentsListQuery is prefetched by the parent campaigns layout
+    // loader, so we read segment name + criteria from there via find()
+    // — matches how the script and zone-group lookups work and keeps
+    // a rename's optimistic list patch visible without a hard reload.
   },
   component: CampaignEditor,
 });
@@ -137,19 +136,17 @@ function CampaignEditor() {
 
   const { data: campaign } = useSuspenseQuery(campaignDetailQuery(campaignId));
   const { data: zoneGroups } = useSuspenseQuery(zoneGroupsQuery());
-  // Scripts list is pre-fetched by the parent campaigns route loader so this
-  // resolves from cache — used to look up the bound script's display name
-  // for the header card row.
+  // Scripts + segments lists are pre-fetched by the parent campaigns
+  // route loader so these resolve from cache. We look up the bound
+  // segment/script/zone-group by id via find(); using the list lets a
+  // rename's optimistic patch surface here without a separate detail
+  // cache to keep in sync.
   const { data: scripts } = useSuspenseQuery(scriptsListQuery());
+  const { data: segments } = useSuspenseQuery(segmentsListQuery());
 
   const activeZoneGroup = zoneGroups.find((g) => g.zoneGroupId === campaign?.zoneGroupId) ?? null;
   const activeScript = scripts.find((s) => s.scriptId === campaign?.scriptId) ?? null;
-
-  const { data: segmentDetail, isPlaceholderData: segmentDetailStale } = useQuery({
-    ...segmentDetailQuery(campaign?.segmentId ?? ""),
-    enabled: !!campaign?.segmentId,
-    placeholderData: keepPreviousData,
-  });
+  const activeSegment = segments.find((s) => s.segmentId === campaign?.segmentId) ?? null;
 
   const { data: zones, isPlaceholderData: zonesStale } = useQuery({
     ...zonesQuery(campaign?.zoneGroupId ?? ""),
@@ -172,7 +169,7 @@ function CampaignEditor() {
     [activeZoneGroup, zones],
   );
 
-  const segmentCriteria = segmentDetail?.criteria as Criteria | null | undefined;
+  const segmentCriteria = activeSegment?.criteria as Criteria | null | undefined;
 
   // Points run for both zoned and zoneless campaigns. When `keyFilter` is
   // null the query asks the data server for *all* segment-matching points
@@ -227,33 +224,9 @@ function CampaignEditor() {
     return out;
   }, [perKeyCounts, zones, countsStale]);
 
-  // Campaign-wide totals. Buildings/doors/people source depends on
-  // whether the campaign has a zone group:
-  //   - zoned: sum per-zone counts (already a key-filtered query)
-  //   - zoneless: segmentTotals (segment-wide, unfiltered)
-  // Both sources fetch *after* the route loader runs, so the count
-  // fields are nullable — SummaryCard's value spans render only once
-  // they're truthy, which gates the animate-in fade. Turf stats are
-  // prefetched in the loader and arrive on first render, hence the
-  // unconditional sum.
+  // Campaign-wide turf stats. Prefetched in the loader, so they arrive
+  // on first render and don't need fade-in handling.
   const totals = useMemo(() => {
-    let buildings: number | null = null;
-    let doors: number | null = null;
-    let people: number | null = null;
-    if (zoneCounts) {
-      buildings = 0;
-      doors = 0;
-      people = 0;
-      for (const c of Object.values(zoneCounts)) {
-        buildings += c.buildings;
-        doors += c.doors;
-        people += c.people;
-      }
-    } else if (segmentTotals) {
-      buildings = segmentTotals.buildingCount;
-      doors = segmentTotals.doorCount;
-      people = segmentTotals.personCount;
-    }
     let drafts = 0;
     let active = 0;
     let published = 0;
@@ -264,17 +237,14 @@ function CampaignEditor() {
         published += s.published;
       }
     }
-    return { buildings, doors, people, drafts, active, published };
-  }, [zoneCounts, segmentTotals, turfStats]);
+    return { drafts, active, published };
+  }, [turfStats]);
 
   // One unioned polygon per zone, tagged with `zoneId`. Single-key zones
   // short-circuit because turf.union returns null for degenerate inputs.
-  //
-  // We bail eagerly on `campaign.zoneGroupId == null` because the
-  // `zones` and `boundaryFC` queries both keep their previous data on
-  // navigate (placeholderData: keepPreviousData) — without this guard,
-  // switching from a zoned campaign to a zoneless one would briefly
-  // render the previous campaign's polygons on the map.
+  // Bails when zoneless — `zones` and `boundaryFC` use placeholderData,
+  // so without this guard a zoned→zoneless switch flashes the previous
+  // campaign's polygons.
   const zonePerimeters = useMemo<FeatureCollection | undefined>(() => {
     if (!campaign?.zoneGroupId) return undefined;
     if (!zones || !boundaryFC) return undefined;
@@ -337,7 +307,10 @@ function CampaignEditor() {
     const s = !!campaign.segmentId;
     const z = !!campaign.zoneGroupId;
     if (s) {
-      if (!segmentDetail || segmentDetailStale) return false;
+      // The segments list is loader-prefetched and rerendered via
+      // useSuspenseQuery, so `activeSegment` is always fresh — no
+      // separate staleness gate needed for the segment binding.
+      if (!activeSegment) return false;
       // Points fire as soon as we have a segment, zoned or not.
       if (!pointsBuffer || pointsStale) return false;
     }
@@ -395,8 +368,8 @@ function CampaignEditor() {
   return (
     <div className="flex gap-4 h-full">
       {/* Sidebar renders immediately against loader-cached chrome data
-          (zones, segmentDetail). The map curtain handles waits for the
-          heavy data still fetching in-component. */}
+          (zones + segment binding). The map curtain handles waits for
+          the heavy data still fetching in-component. */}
       <div className="w-128 shrink-0 h-full min-h-0">
         <ZonesList
           campaignId={campaignId}
@@ -413,7 +386,7 @@ function CampaignEditor() {
               ? { doors: segmentTotals.doorCount, people: segmentTotals.personCount }
               : null
           }
-          segmentName={segmentDetail?.name ?? null}
+          segmentName={activeSegment?.name ?? null}
           scriptName={activeScript?.name ?? null}
           zoneGroupName={activeZoneGroup?.name ?? null}
           onSelect={setSelectedZoneId}
@@ -471,9 +444,6 @@ function ZonesList({
   zoneCounts: Record<string, { buildings: number; doors: number; people: number }> | null;
   turfStats: TurfStats | null;
   totals: {
-    buildings: number | null;
-    doors: number | null;
-    people: number | null;
     drafts: number;
     active: number;
     published: number;
@@ -537,73 +507,42 @@ function ConfigSummary({
   scriptName: string | null;
   zoneGroupName: string | null;
   totals: {
-    buildings: number | null;
-    doors: number | null;
-    people: number | null;
     drafts: number;
     active: number;
     published: number;
   };
 }) {
-  const fmt = (n: number | null) => (n === null ? null : n.toLocaleString());
-  // Layout uses an implicit 3-column grid: top row splits 2/3 (config) + 1/3
-  // (counts) so the gridline lands where the bottom row's middle/right
-  // boundary sits, keeping vertical column rhythm consistent.
   return (
-    <div className="flex flex-col gap-2">
-      <div className="grid grid-cols-2 gap-2">
-        <SummaryCard
-          className="col-span-1"
-          rows={[
-            { label: "Segment", value: segmentName ?? "None selected" },
-            { label: "Script", value: scriptName ?? "None selected" },
-            { label: "Zones", value: zoneGroupName ?? "None selected" },
-          ]}
-        />
-        <SummaryCard
-          rows={[
-            { label: "Total people", value: fmt(totals.people) },
-            { label: "Total doors", value: fmt(totals.doors) },
-            { label: "Total buildings", value: fmt(totals.buildings) },
-          ]}
-        />
-      </div>
+    <div className="flex flex-col gap-2 rounded-md border border-border bg-card px-3 py-2">
       <div className="grid grid-cols-3 gap-2">
-        <SummaryCard rows={[{ label: "Cut turfs", value: totals.drafts.toLocaleString() }]} />
-        <SummaryCard rows={[{ label: "Active turfs", value: totals.active.toLocaleString() }]} />
-        <SummaryCard rows={[{ label: "Published", value: totals.published.toLocaleString() }]} />
+        <div className="flex flex-col">
+          <span className="text-muted-foreground">Segment</span>
+          <span className="truncate">{segmentName}</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-muted-foreground">Zones</span>
+          <span className="truncate">{zoneGroupName || "None selected"}</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-muted-foreground">Script</span>
+          <span className="truncate">{scriptName}</span>
+        </div>
+      </div>
+      <hr className="my-1 border-t border-border" />
+      <div className="grid grid-cols-3 gap-2">
+        <Stat label="Draft turfs" value={totals.drafts} />
+        <Stat label="Published turfs" value={totals.published} />
+        <Stat label="Active turfs" value={totals.active} />
       </div>
     </div>
   );
 }
 
-function SummaryCard({
-  className,
-  rows,
-}: {
-  className?: string;
-  // `value: null` means "not loaded yet" — render only the label so the
-  // value span can mount + fade in once data arrives, matching how
-  // ZoneRow/FullSegmentRow pills gate on their counts.
-  rows: Array<{ label: string; value: string | null }>;
-}) {
+function Stat({ label, value }: { label: string; value: number }) {
   return (
-    <div
-      className={cn(
-        "min-w-0 flex flex-col gap-1 rounded-md border border-border bg-card px-3 py-2",
-        className,
-      )}
-    >
-      {rows.map((row) => (
-        <div key={row.label} className="flex items-baseline justify-between gap-2">
-          <span className="shrink-0 text-sm">{row.label}</span>
-          {row.value !== null ? (
-            <span className="truncate text-sm tabular-nums text-muted-foreground animate-in fade-in duration-100">
-              {row.value}
-            </span>
-          ) : null}
-        </div>
-      ))}
+    <div className="flex flex-col">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="tabular-nums">{value.toLocaleString()}</span>
     </div>
   );
 }

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
@@ -16,7 +16,12 @@ import {
   campaignsListQuery,
   type KeyFilter,
 } from "~/lib/queries/campaigns";
-import { type SegmentCriteria, segmentDetailQuery } from "~/lib/queries/segments";
+import { scriptsListQuery } from "~/lib/queries/scripts";
+import {
+  segmentCountsQuery,
+  segmentDetailQuery,
+  type SegmentCriteria,
+} from "~/lib/queries/segments";
 import { turfStatsForCampaignQuery } from "~/lib/queries/turfs";
 import { zoneGroupsQuery, zonesQuery } from "~/lib/queries/zones";
 import type { Criteria } from "~/lib/filters";
@@ -33,6 +38,42 @@ function deriveKeyFilter(
     keyGroup: zoneGroup.keyGroup,
     keys: Array.from(new Set(zones.flatMap((z) => z.keys))).sort(),
   };
+}
+
+// Reverses the Web Mercator y → lat projection (matches the forward
+// transform used in apps/web/src/lib/queries/segments.ts when the points
+// buffer is built server-side).
+function mercY2Lat(my: number): number {
+  return (Math.atan(Math.sinh(Math.PI * (1 - 2 * my))) * 180) / Math.PI;
+}
+
+// bbox in [west, south, east, north] from the origin-relative fp32
+// mercator delta buffer used by the points layer. Used as a fitBounds
+// fallback when there's no zone perimeter to fit to.
+function bboxOfMercDeltas(buffer: {
+  deltas: Float32Array;
+  origin: [number, number];
+}): [number, number, number, number] | null {
+  if (buffer.deltas.length === 0) return null;
+  const [ox, oy] = buffer.origin;
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (let i = 0; i < buffer.deltas.length; i += 2) {
+    const x = buffer.deltas[i]!;
+    const y = buffer.deltas[i + 1]!;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+  const minLng = (ox + minX) * 360 - 180;
+  const maxLng = (ox + maxX) * 360 - 180;
+  // Smaller mercator y = larger latitude (top of the map).
+  const maxLat = mercY2Lat(oy + minY);
+  const minLat = mercY2Lat(oy + maxY);
+  return [minLng, minLat, maxLng, maxLat];
 }
 
 // Walks every coord in a polygon/multipolygon FeatureCollection.
@@ -96,8 +137,13 @@ function CampaignEditor() {
 
   const { data: campaign } = useSuspenseQuery(campaignDetailQuery(campaignId));
   const { data: zoneGroups } = useSuspenseQuery(zoneGroupsQuery());
+  // Scripts list is pre-fetched by the parent campaigns route loader so this
+  // resolves from cache — used to look up the bound script's display name
+  // for the header card row.
+  const { data: scripts } = useSuspenseQuery(scriptsListQuery());
 
   const activeZoneGroup = zoneGroups.find((g) => g.zoneGroupId === campaign?.zoneGroupId) ?? null;
+  const activeScript = scripts.find((s) => s.scriptId === campaign?.scriptId) ?? null;
 
   const { data: segmentDetail, isPlaceholderData: segmentDetailStale } = useQuery({
     ...segmentDetailQuery(campaign?.segmentId ?? ""),
@@ -128,14 +174,18 @@ function CampaignEditor() {
 
   const segmentCriteria = segmentDetail?.criteria as Criteria | null | undefined;
 
+  // Points run for both zoned and zoneless campaigns. When `keyFilter` is
+  // null the query asks the data server for *all* segment-matching points
+  // (no zone-keyed narrowing), which is the right answer for zoneless.
   const { data: pointsBuffer, isPlaceholderData: pointsStale } = useQuery({
-    ...(segmentCriteria && keyFilter
-      ? campaignPointsQuery(segmentCriteria, keyFilter)
-      : campaignPointsQuery({} as SegmentCriteria, null)),
-    enabled: !!segmentCriteria && !!keyFilter,
+    ...campaignPointsQuery(segmentCriteria ?? ({} as SegmentCriteria), keyFilter),
+    enabled: !!segmentCriteria,
     placeholderData: keepPreviousData,
   });
 
+  // Per-key counts only matter when zoned (zoneCounts sums them per zone).
+  // For zoneless we use segmentCountsQuery below instead, which returns
+  // segment-wide totals directly.
   const { data: keyCountsResult, isPlaceholderData: countsStale } = useQuery({
     ...(segmentCriteria && keyFilter
       ? campaignKeyCountsQuery(segmentCriteria, keyFilter.keyGroup, keyFilter.keys)
@@ -145,6 +195,13 @@ function CampaignEditor() {
   });
   const perKeyCounts = keyCountsResult?.counts ?? null;
 
+  // Segment-wide totals for zoneless campaigns — drives the header card's
+  // Buildings/Doors/People numbers when there's no zone group to sum from.
+  const { data: segmentTotals } = useQuery({
+    ...segmentCountsQuery(segmentCriteria ?? ({} as Criteria)),
+    enabled: !!segmentCriteria && !campaign?.zoneGroupId,
+  });
+
   // Per-zone totals = sum per-key counts across each zone's keys.
   // Returns null when the underlying counts query is still resolving
   // for the new binding — otherwise mixing stale (previous campaign's)
@@ -152,25 +209,74 @@ function CampaignEditor() {
   // sidebar pills. Better to drop the pills until real data lands.
   const zoneCounts = useMemo(() => {
     if (!perKeyCounts || !zones || countsStale) return null;
-    const out: Record<string, { doors: number; people: number }> = {};
+    const out: Record<string, { buildings: number; doors: number; people: number }> = {};
     for (const z of zones) {
+      let buildings = 0;
       let doors = 0;
       let people = 0;
       for (const k of z.keys) {
         const c = perKeyCounts[k];
         if (c) {
+          buildings += c.buildings;
           doors += c.doors;
           people += c.people;
         }
       }
-      out[z.zoneId] = { doors, people };
+      out[z.zoneId] = { buildings, doors, people };
     }
     return out;
   }, [perKeyCounts, zones, countsStale]);
 
+  // Campaign-wide totals. Buildings/doors/people source depends on
+  // whether the campaign has a zone group:
+  //   - zoned: sum per-zone counts (already a key-filtered query)
+  //   - zoneless: segmentTotals (segment-wide, unfiltered)
+  // Both sources fetch *after* the route loader runs, so the count
+  // fields are nullable — SummaryCard's value spans render only once
+  // they're truthy, which gates the animate-in fade. Turf stats are
+  // prefetched in the loader and arrive on first render, hence the
+  // unconditional sum.
+  const totals = useMemo(() => {
+    let buildings: number | null = null;
+    let doors: number | null = null;
+    let people: number | null = null;
+    if (zoneCounts) {
+      buildings = 0;
+      doors = 0;
+      people = 0;
+      for (const c of Object.values(zoneCounts)) {
+        buildings += c.buildings;
+        doors += c.doors;
+        people += c.people;
+      }
+    } else if (segmentTotals) {
+      buildings = segmentTotals.buildingCount;
+      doors = segmentTotals.doorCount;
+      people = segmentTotals.personCount;
+    }
+    let drafts = 0;
+    let active = 0;
+    let published = 0;
+    if (turfStats) {
+      for (const s of Object.values(turfStats)) {
+        drafts += s.drafts;
+        active += s.active;
+        published += s.published;
+      }
+    }
+    return { buildings, doors, people, drafts, active, published };
+  }, [zoneCounts, segmentTotals, turfStats]);
+
   // One unioned polygon per zone, tagged with `zoneId`. Single-key zones
   // short-circuit because turf.union returns null for degenerate inputs.
+  //
+  // We bail eagerly on `campaign.zoneGroupId == null` because the
+  // `zones` and `boundaryFC` queries both keep their previous data on
+  // navigate (placeholderData: keepPreviousData) — without this guard,
+  // switching from a zoned campaign to a zoneless one would briefly
+  // render the previous campaign's polygons on the map.
   const zonePerimeters = useMemo<FeatureCollection | undefined>(() => {
+    if (!campaign?.zoneGroupId) return undefined;
     if (!zones || !boundaryFC) return undefined;
     const featuresByKey: Record<string, Feature<Polygon | MultiPolygon>> = {};
     for (const f of boundaryFC.features) {
@@ -213,12 +319,16 @@ function CampaignEditor() {
       }
     });
     return { type: "FeatureCollection", features: out };
-  }, [zones, boundaryFC]);
+  }, [zones, boundaryFC, campaign?.zoneGroupId]);
 
-  const fitBounds = useMemo(
-    () => (zonePerimeters ? bboxOfPolys(zonePerimeters) : null),
-    [zonePerimeters],
-  );
+  // Prefer zone perimeters for the fit when we have them (matches the
+  // visible boundary on the map). Fall back to the points cloud for
+  // zoneless campaigns so the map still lands somewhere sensible.
+  const fitBounds = useMemo(() => {
+    if (zonePerimeters) return bboxOfPolys(zonePerimeters);
+    if (pointsBuffer) return bboxOfMercDeltas(pointsBuffer);
+    return null;
+  }, [zonePerimeters, pointsBuffer]);
 
   // Curtain stays up until every relevant query has data for the current
   // bindings (no `isPlaceholderData` from a previous binding).
@@ -228,14 +338,17 @@ function CampaignEditor() {
     const z = !!campaign.zoneGroupId;
     if (s) {
       if (!segmentDetail || segmentDetailStale) return false;
+      // Points fire as soon as we have a segment, zoned or not.
+      if (!pointsBuffer || pointsStale) return false;
     }
     if (z) {
       if (!zones || zonesStale) return false;
       if (!boundaryFC || boundaryStale) return false;
-    }
-    if (s && z) {
-      if (!pointsBuffer || pointsStale) return false;
       if (!perKeyCounts || countsStale) return false;
+    } else if (s) {
+      // Zoneless: header totals come from segmentTotals instead of
+      // per-zone aggregation.
+      if (!segmentTotals) return false;
     }
     return true;
   })();
@@ -284,19 +397,38 @@ function CampaignEditor() {
       {/* Sidebar renders immediately against loader-cached chrome data
           (zones, segmentDetail). The map curtain handles waits for the
           heavy data still fetching in-component. */}
-      <div className="w-124 shrink-0 h-full min-h-0">
+      <div className="w-128 shrink-0 h-full min-h-0">
         <ZonesList
           campaignId={campaignId}
           zones={zones ?? null}
           selectedZoneId={selectedZoneId}
           zoneCounts={zoneCounts}
           turfStats={turfStats ?? null}
+          totals={totals}
+          // Null-until-loaded mirror of zoneCounts[zoneId] — gates the
+          // FullSegmentRow's pills so they fade in cleanly instead of
+          // flashing zeros first.
+          fullSegmentCounts={
+            segmentTotals
+              ? { doors: segmentTotals.doorCount, people: segmentTotals.personCount }
+              : null
+          }
+          segmentName={segmentDetail?.name ?? null}
+          scriptName={activeScript?.name ?? null}
+          zoneGroupName={activeZoneGroup?.name ?? null}
           onSelect={setSelectedZoneId}
           onCut={(zoneId) => {
-            void navigate({
-              to: "/$orgSlug/campaigns/$campaignId/cut/$zoneId",
-              params: { orgSlug, campaignId, zoneId },
-            });
+            if (zoneId === null) {
+              void navigate({
+                to: "/$orgSlug/campaigns/$campaignId/cut",
+                params: { orgSlug, campaignId },
+              });
+            } else {
+              void navigate({
+                to: "/$orgSlug/campaigns/$campaignId/cut/$zoneId",
+                params: { orgSlug, campaignId, zoneId },
+              });
+            }
           }}
         />
       </div>
@@ -317,7 +449,7 @@ function CampaignEditor() {
   );
 }
 
-type TurfStats = Record<string, { drafts: number; published: number }>;
+type TurfStats = Record<string, { drafts: number; published: number; active: number }>;
 
 function ZonesList({
   campaignId,
@@ -325,32 +457,217 @@ function ZonesList({
   selectedZoneId,
   zoneCounts,
   turfStats,
+  totals,
+  fullSegmentCounts,
+  segmentName,
+  scriptName,
+  zoneGroupName,
   onSelect,
   onCut,
 }: {
   campaignId: string;
   zones: Awaited<ReturnType<typeof client.zones.list>> | null;
   selectedZoneId: string | null;
-  zoneCounts: Record<string, { doors: number; people: number }> | null;
+  zoneCounts: Record<string, { buildings: number; doors: number; people: number }> | null;
   turfStats: TurfStats | null;
+  totals: {
+    buildings: number | null;
+    doors: number | null;
+    people: number | null;
+    drafts: number;
+    active: number;
+    published: number;
+  };
+  fullSegmentCounts: { doors: number; people: number } | null;
+  segmentName: string | null;
+  scriptName: string | null;
+  zoneGroupName: string | null;
   onSelect: (zoneId: string) => void;
-  onCut: (zoneId: string) => void;
+  // `null` means navigate to the zoneless cutter route.
+  onCut: (zoneId: string | null) => void;
 }) {
+  // When there's no zone group, the user can still cut turfs — they're
+  // just scoped to the full segment instead of a zone. Surface that as a
+  // single row that looks like a ZoneRow so the layout doesn't change
+  // shape between zoned and zoneless campaigns.
+  const zoneless = zoneGroupName === null;
   return (
     <div className="flex h-full flex-col gap-2 overflow-y-auto">
-      {zones?.map((zone, idx) => (
-        <ZoneRow
-          key={zone.zoneId}
+      <ConfigSummary
+        segmentName={segmentName}
+        scriptName={scriptName}
+        zoneGroupName={zoneGroupName}
+        totals={totals}
+      />
+      {zoneless ? (
+        <FullSegmentRow
           campaignId={campaignId}
-          zone={zone}
-          color={colorFor(idx)}
-          selected={zone.zoneId === selectedZoneId}
-          counts={zoneCounts?.[zone.zoneId] ?? null}
-          turfStats={turfStats?.[zone.zoneId] ?? null}
-          onSelect={() => onSelect(zone.zoneId)}
-          onCut={() => onCut(zone.zoneId)}
+          counts={fullSegmentCounts}
+          // Zoneless turfs land under the empty-string key in
+          // statsForCampaign — see the sentinel comment there.
+          turfStats={turfStats?.[""] ?? null}
+          onCut={() => onCut(null)}
         />
+      ) : (
+        zones?.map((zone, idx) => (
+          <ZoneRow
+            key={zone.zoneId}
+            campaignId={campaignId}
+            zone={zone}
+            color={colorFor(idx)}
+            selected={zone.zoneId === selectedZoneId}
+            counts={zoneCounts?.[zone.zoneId] ?? null}
+            turfStats={turfStats?.[zone.zoneId] ?? null}
+            onSelect={() => onSelect(zone.zoneId)}
+            onCut={() => onCut(zone.zoneId)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function ConfigSummary({
+  segmentName,
+  scriptName,
+  zoneGroupName,
+  totals,
+}: {
+  segmentName: string | null;
+  scriptName: string | null;
+  zoneGroupName: string | null;
+  totals: {
+    buildings: number | null;
+    doors: number | null;
+    people: number | null;
+    drafts: number;
+    active: number;
+    published: number;
+  };
+}) {
+  const fmt = (n: number | null) => (n === null ? null : n.toLocaleString());
+  // Layout uses an implicit 3-column grid: top row splits 2/3 (config) + 1/3
+  // (counts) so the gridline lands where the bottom row's middle/right
+  // boundary sits, keeping vertical column rhythm consistent.
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-2 gap-2">
+        <SummaryCard
+          className="col-span-1"
+          rows={[
+            { label: "Segment", value: segmentName ?? "None selected" },
+            { label: "Script", value: scriptName ?? "None selected" },
+            { label: "Zones", value: zoneGroupName ?? "None selected" },
+          ]}
+        />
+        <SummaryCard
+          rows={[
+            { label: "Total people", value: fmt(totals.people) },
+            { label: "Total doors", value: fmt(totals.doors) },
+            { label: "Total buildings", value: fmt(totals.buildings) },
+          ]}
+        />
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <SummaryCard rows={[{ label: "Cut turfs", value: totals.drafts.toLocaleString() }]} />
+        <SummaryCard rows={[{ label: "Active turfs", value: totals.active.toLocaleString() }]} />
+        <SummaryCard rows={[{ label: "Published", value: totals.published.toLocaleString() }]} />
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({
+  className,
+  rows,
+}: {
+  className?: string;
+  // `value: null` means "not loaded yet" — render only the label so the
+  // value span can mount + fade in once data arrives, matching how
+  // ZoneRow/FullSegmentRow pills gate on their counts.
+  rows: Array<{ label: string; value: string | null }>;
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-0 flex flex-col gap-1 rounded-md border border-border bg-card px-3 py-2",
+        className,
+      )}
+    >
+      {rows.map((row) => (
+        <div key={row.label} className="flex items-baseline justify-between gap-2">
+          <span className="shrink-0 text-sm">{row.label}</span>
+          {row.value !== null ? (
+            <span className="truncate text-sm tabular-nums text-muted-foreground animate-in fade-in duration-100">
+              {row.value}
+            </span>
+          ) : null}
+        </div>
       ))}
+    </div>
+  );
+}
+
+function FullSegmentRow({
+  campaignId,
+  counts,
+  turfStats,
+  onCut,
+}: {
+  campaignId: string;
+  counts: { doors: number; people: number } | null;
+  turfStats: { drafts: number; published: number; active: number } | null;
+  onCut: () => void;
+}) {
+  const turfCount = turfStats?.drafts ?? 0;
+  const hasPublished = (turfStats?.published ?? 0) > 0;
+  return (
+    <div
+      className={cn(
+        "flex h-11 items-center gap-2 rounded-md border border-border bg-card py-2 pr-2 pl-3 text-left",
+      )}
+    >
+      <span className="flex-1 truncate text-sm">Full segment</span>
+      {/* Keyed by campaignId — matches the ZoneRow pattern so pills
+          remount + re-fire animate-in on every campaign switch. */}
+      {counts ? (
+        <Fragment key={campaignId}>
+          <Pill
+            variant="number"
+            className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
+          >
+            <UserRound className="size-3.5 text-foreground" />
+            {counts.people.toLocaleString()}
+          </Pill>
+          <Pill
+            variant="number"
+            className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
+          >
+            <DoorClosed className="size-3.5 text-foreground" />
+            {counts.doors.toLocaleString()}
+          </Pill>
+          {hasPublished ? (
+            <Pill
+              variant="number"
+              className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100 [&_svg]:[stroke-width:2]"
+            >
+              <Send className="size-3.5 text-foreground" />
+              {(turfStats?.published ?? 0).toLocaleString()}
+            </Pill>
+          ) : null}
+          <Pill
+            variant="number"
+            className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
+          >
+            <CircleDotDashed className="size-3.5 text-foreground" />
+            {turfCount}
+          </Pill>
+        </Fragment>
+      ) : null}
+      <Button variant="outline" className="h-[31px]" onClick={onCut}>
+        <Scissors />
+        Cut
+      </Button>
     </div>
   );
 }
@@ -370,7 +687,7 @@ function ZoneRow({
   color: string;
   selected: boolean;
   counts: { doors: number; people: number } | null;
-  turfStats: { drafts: number; published: number } | null;
+  turfStats: { drafts: number; published: number; active: number } | null;
   onSelect: () => void;
   onCut: () => void;
 }) {
@@ -407,22 +724,23 @@ function ZoneRow({
             variant="number"
             className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
           >
-            <DoorClosed className="size-3.5 text-foreground" />
-            {counts.doors.toLocaleString()}
+            <UserRound className="size-3.5 text-foreground" />
+            {counts.people.toLocaleString()}
           </Pill>
           <Pill
             variant="number"
             className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
           >
-            <UserRound className="size-3.5 text-foreground" />
-            {counts.people.toLocaleString()}
+            <DoorClosed className="size-3.5 text-foreground" />
+            {counts.doors.toLocaleString()}
           </Pill>
           {hasPublished ? (
             <Pill
               variant="number"
-              className="size-7 shrink-0 justify-center !px-0 animate-in fade-in duration-100 [&_svg]:[stroke-width:2]"
+              className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100 [&_svg]:[stroke-width:2]"
             >
-              <Send className="size-4 text-foreground" />
+              <Send className="size-3.5 text-foreground" />
+              {(turfStats?.published ?? 0).toLocaleString()}
             </Pill>
           ) : null}
           <Pill
@@ -435,8 +753,8 @@ function ZoneRow({
         </Fragment>
       ) : null}
       <Button
-        size="sm"
         variant="outline"
+        className="h-[31px]"
         onClick={(e) => {
           e.stopPropagation();
           onCut();

--- a/apps/web/src/routes/$orgSlug/campaigns/route.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/route.tsx
@@ -27,7 +27,6 @@ import { EditorHeader } from "~/components/editor-header";
 import { EditorPage } from "~/components/editor-page";
 import { Input } from "~/components/input";
 import { Rail } from "~/components/rail";
-import { KEY_GROUPS_AVAILABLE } from "~/lib/key-groups";
 import { boundariesGeoJsonQuery } from "~/lib/queries/boundaries";
 import {
   campaignKeyCountsQuery,
@@ -88,7 +87,9 @@ function CampaignsLayout() {
   // case. Reads the *committed* match (not the eager pathname) so the
   // header doesn't flicker during the cutter's loader run.
   const childMatches = useChildMatches();
-  const isCut = childMatches.some((m) => m.routeId.endsWith("/cut/$zoneId"));
+  const isCut = childMatches.some(
+    (m) => m.routeId.endsWith("/cut/$zoneId") || m.routeId.endsWith("/cut/"),
+  );
 
   const { data: campaigns } = useSuspenseQuery(campaignsListQuery());
   const { data: segments } = useSuspenseQuery(segmentsListQuery());
@@ -168,28 +169,17 @@ function CampaignsLayout() {
   // Wrapping zoneGroups.createWithDefaultZone + campaigns.create in one
   // mutation so the dialog's pending/error UX is coherent across both paths.
   const createCampaign = useDialogMutation({
-    mutationFn: async (input: {
+    mutationFn: (input: {
       name: string;
       segmentId: string;
       scriptId: string;
       zoneGroupId: string | null;
-      constructFromKeyGroup: string | null;
     }) => {
-      let zoneGroupId = input.zoneGroupId;
-      if (input.constructFromKeyGroup) {
-        const zg = await client.zoneGroups.createWithDefaultZone({
-          name: `${input.name} zones`,
-          keyGroup: input.constructFromKeyGroup,
-          segmentId: input.segmentId,
-        });
-        zoneGroupId = zg.zoneGroupId;
-        void queryClient.invalidateQueries({ queryKey: ["zone-groups"] });
-      }
       return client.campaigns.create({
         name: input.name,
         segmentId: input.segmentId,
         scriptId: input.scriptId,
-        zoneGroupId,
+        zoneGroupId: input.zoneGroupId,
       });
     },
     onSuccess: (created) => {
@@ -444,7 +434,6 @@ type SelectOption = { value: string; label: string };
 
 // Sentinel for the "construct fresh zone group from key group" path —
 // sits alongside real zone-group ids in the create-dialog dropdown.
-const AUTO_ZONES_SENTINEL = "__auto__";
 
 function DialogError({ error }: { error: string | null }) {
   if (!error) return null;
@@ -482,41 +471,33 @@ function CreateCampaignDialog({
     segmentId: string;
     scriptId: string;
     zoneGroupId: string | null;
-    constructFromKeyGroup: string | null;
   }) => void;
 }) {
   const [name, setName] = useState("");
   const [segmentId, setSegmentId] = useState<string | null>(null);
   const [scriptId, setScriptId] = useState<string | null>(null);
   const [zonesValue, setZonesValue] = useState<string | null>(null);
-  const [constructKeyGroup, setConstructKeyGroup] = useState<string>(
-    KEY_GROUPS_AVAILABLE[0]!.value,
-  );
   useEffect(() => {
     if (open) {
       setName("");
       setSegmentId(null);
       setScriptId(null);
       setZonesValue(null);
-      setConstructKeyGroup(KEY_GROUPS_AVAILABLE[0]!.value);
     }
   }, [open]);
 
-  const isAuto = zonesValue === AUTO_ZONES_SENTINEL;
-  const zonesOptions: ReadonlyArray<SelectOption> = [
-    { value: AUTO_ZONES_SENTINEL, label: "Define automatically" },
-    ...zoneGroupOptions,
-  ];
-  const validZones = zonesValue !== null && (!isAuto || constructKeyGroup !== "");
-  const valid = name.trim().length > 0 && segmentId !== null && scriptId !== null && validZones;
+  // Zones is optional — a campaign with no zone group cuts turfs against
+  // the whole segment.
+  const valid = name.trim().length > 0 && segmentId !== null && scriptId !== null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogTitle>Create new campaign</DialogTitle>
         <DialogDescription>
-          A campaign combines a segment (people), a group of zones (geography), and a script
-          (questions). Choices can be edited later via Configure.
+          A campaign combines a segment (people) and a script (questions). Optionally pick a group
+          of zones to subdivide the segment for turf cutting. Choices can be edited later via
+          Configure.
         </DialogDescription>
         <form
           onSubmit={(e) => {
@@ -526,8 +507,7 @@ function CreateCampaignDialog({
               name: name.trim(),
               segmentId: segmentId!,
               scriptId: scriptId!,
-              zoneGroupId: isAuto ? null : zonesValue,
-              constructFromKeyGroup: isAuto ? constructKeyGroup : null,
+              zoneGroupId: zonesValue,
             });
           }}
           className="flex flex-col gap-3"
@@ -550,18 +530,12 @@ function CreateCampaignDialog({
             onChange={setSegmentId}
           />
           <ConfigField
-            label="Zones"
+            label="Zones (optional)"
             placeholder="Pick a zone group…"
             value={zonesValue}
-            options={zonesOptions}
+            options={zoneGroupOptions}
             onChange={setZonesValue}
           />
-          {isAuto ? (
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm text-muted-foreground">Define from</label>
-              <KeyGroupRadio value={constructKeyGroup} onChange={setConstructKeyGroup} />
-            </div>
-          ) : null}
           <ConfigField
             label="Script"
             placeholder="Pick a script…"
@@ -884,29 +858,6 @@ function ConfigField({
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
-    </div>
-  );
-}
-
-function KeyGroupRadio({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  return (
-    <div className="flex flex-wrap gap-1.5">
-      {KEY_GROUPS_AVAILABLE.map((kg) => {
-        const selected = value === kg.value;
-        return (
-          <button
-            type="button"
-            key={kg.value}
-            onClick={() => onChange(kg.value)}
-            className={cn(
-              "rounded-md border border-border px-2.5 py-1 text-sm active:translate-y-px",
-              selected ? "bg-foreground/10" : "bg-background hover:bg-muted",
-            )}
-          >
-            {kg.label}
-          </button>
-        );
-      })}
     </div>
   );
 }

--- a/apps/web/src/routes/$orgSlug/campaigns/route.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/route.tsx
@@ -35,7 +35,7 @@ import {
   type KeyFilter,
 } from "~/lib/queries/campaigns";
 import { scriptsListQuery } from "~/lib/queries/scripts";
-import { segmentDetailQuery, segmentsListQuery } from "~/lib/queries/segments";
+import { segmentsListQuery } from "~/lib/queries/segments";
 import { turfStatsForCampaignQuery } from "~/lib/queries/turfs";
 import { zoneGroupsQuery, zonesQuery } from "~/lib/queries/zones";
 import { useConfirmHotkey } from "~/lib/use-confirm-hotkey";
@@ -115,6 +115,8 @@ function CampaignsLayout() {
   // Mirror of the editor-route loader's prefetch logic — used by the
   // create/clone flows to warm caches against the new campaign's
   // bindings before the navigate, so the body's queries cache-hit.
+  // Segment criteria comes from the segments list cache (already loaded
+  // above) — same lookup pattern the campaign view uses.
   const prefetchCampaignViewData = async (target: {
     campaignId: string;
     segmentId: string | null;
@@ -122,14 +124,13 @@ function CampaignsLayout() {
   }) => {
     const zgs = await queryClient.fetchQuery(zoneGroupsQuery());
     const nextZoneGroup = zgs.find((g) => g.zoneGroupId === target.zoneGroupId) ?? null;
-    const [nextSegmentDetail, nextZones] = await Promise.all([
-      target.segmentId
-        ? queryClient.fetchQuery(segmentDetailQuery(target.segmentId))
-        : Promise.resolve(undefined),
-      target.zoneGroupId
-        ? queryClient.fetchQuery(zonesQuery(target.zoneGroupId))
-        : Promise.resolve(undefined),
-    ]);
+    const nextSegment = target.segmentId
+      ? (segments.find((s) => s.segmentId === target.segmentId) ?? null)
+      : null;
+    const nextCriteria = nextSegment?.criteria ?? null;
+    const nextZones = target.zoneGroupId
+      ? await queryClient.fetchQuery(zonesQuery(target.zoneGroupId))
+      : undefined;
     const nextKeyFilter = deriveKeyFilter(nextZoneGroup, nextZones);
     await Promise.all([
       queryClient.prefetchQuery(turfStatsForCampaignQuery(target.campaignId)),
@@ -138,16 +139,12 @@ function CampaignsLayout() {
             boundariesGeoJsonQuery(nextZoneGroup.keyGroup, nextZoneGroup.updatedAt),
           )
         : Promise.resolve(),
-      nextSegmentDetail?.criteria && nextKeyFilter
-        ? queryClient.prefetchQuery(campaignPointsQuery(nextSegmentDetail.criteria, nextKeyFilter))
+      nextCriteria && nextKeyFilter
+        ? queryClient.prefetchQuery(campaignPointsQuery(nextCriteria, nextKeyFilter))
         : Promise.resolve(),
-      nextSegmentDetail?.criteria && nextKeyFilter
+      nextCriteria && nextKeyFilter
         ? queryClient.prefetchQuery(
-            campaignKeyCountsQuery(
-              nextSegmentDetail.criteria,
-              nextKeyFilter.keyGroup,
-              nextKeyFilter.keys,
-            ),
+            campaignKeyCountsQuery(nextCriteria, nextKeyFilter.keyGroup, nextKeyFilter.keys),
           )
         : Promise.resolve(),
     ]);
@@ -242,6 +239,12 @@ function CampaignsLayout() {
 
   const [configOpen, setConfigOpen] = useState(false);
   const [configSaving, setConfigSaving] = useState(false);
+  // Pending patch + draft count snapshotted at Save-click time, used by
+  // the zone-change confirm dialog. Non-null state == confirm is open.
+  const [pendingZoneChange, setPendingZoneChange] = useState<{
+    patch: { segmentId: string | null; zoneGroupId: string | null; scriptId: string | null };
+    draftCount: number;
+  } | null>(null);
   // Snapshotted at click time so the dialog body keeps showing the
   // just-deleted name during its close animation, even after the URL
   // has reactively swapped to the fallback campaign.
@@ -282,27 +285,71 @@ function CampaignsLayout() {
     },
   });
 
-  const saveConfigure = async (patch: {
-    segmentId: string | null;
-    zoneGroupId: string | null;
-    scriptId: string | null;
-  }) => {
+  // Actual save path — clears drafts when the zone group changed, then
+  // warms caches against the new bindings before firing the optimistic
+  // detail update. Called directly when no drafts are at risk, or via
+  // the confirm dialog when there are.
+  const commitConfigure = async (
+    patch: {
+      segmentId: string | null;
+      zoneGroupId: string | null;
+      scriptId: string | null;
+    },
+    opts: { clearDrafts: boolean },
+  ) => {
     if (!activeCampaignId) return;
     setConfigSaving(true);
     try {
-      // Warm caches against the new bindings before the optimistic
-      // detail update fires, so the body's queries cache-hit on
-      // rebind and the `ready` curtain never drops.
-      await prefetchCampaignViewData({
+      if (opts.clearDrafts) {
+        await client.turfDrafts.clearForCampaign({ campaignId: activeCampaignId });
+        // Remove rather than invalidate — we know the drafts no longer
+        // exist server-side, so any cached row would be wrong, and we'd
+        // rather force a clean refetch on next access than risk a render
+        // with stale cache that's been marked-but-not-yet-refetched.
+        queryClient.removeQueries({ queryKey: ["turf-drafts", activeCampaignId] });
+        void queryClient.invalidateQueries({ queryKey: ["turf-stats", activeCampaignId] });
+      }
+      // Fire-and-forget the cache-warming prefetch — awaiting it pushes
+      // the total dialog-locked time past the spinner threshold (~100ms)
+      // for no UX benefit, since the optimistic campaign update below is
+      // what actually drives the view's rebind.
+      void prefetchCampaignViewData({
         campaignId: activeCampaignId,
         segmentId: patch.segmentId,
         zoneGroupId: patch.zoneGroupId,
       });
       updateCampaignMutation.mutate({ campaignId: activeCampaignId, ...patch });
       setConfigOpen(false);
+      setPendingZoneChange(null);
     } finally {
       setConfigSaving(false);
     }
+  };
+
+  const saveConfigure = async (patch: {
+    segmentId: string | null;
+    zoneGroupId: string | null;
+    scriptId: string | null;
+  }) => {
+    if (!activeCampaignId) return;
+    const zoneGroupChanged = patch.zoneGroupId !== (campaign?.zoneGroupId ?? null);
+    if (!zoneGroupChanged) {
+      await commitConfigure(patch, { clearDrafts: false });
+      return;
+    }
+    // Read draft count from the turf-stats cache (already warm when
+    // the editor is open). Trust the cache for the user-facing N; the
+    // server-side clear runs unconditionally on a zone change so any
+    // drift can't leave orphaned drafts behind.
+    const stats = queryClient.getQueryData<
+      Record<string, { drafts: number; published: number; active: number }>
+    >(turfStatsForCampaignQuery(activeCampaignId).queryKey);
+    const draftCount = stats ? Object.values(stats).reduce((a, b) => a + b.drafts, 0) : 0;
+    if (draftCount === 0) {
+      await commitConfigure(patch, { clearDrafts: true });
+      return;
+    }
+    setPendingZoneChange({ patch, draftCount });
   };
 
   return (
@@ -422,6 +469,19 @@ function CampaignsLayout() {
         pending={configSaving}
         onSubmit={(patch) => void saveConfigure(patch)}
       />
+
+      <ConfirmZoneChangeDialog
+        open={pendingZoneChange !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingZoneChange(null);
+        }}
+        draftCount={pendingZoneChange?.draftCount ?? 0}
+        pending={configSaving}
+        onConfirm={() => {
+          if (!pendingZoneChange) return;
+          void commitConfigure(pendingZoneChange.patch, { clearDrafts: true });
+        }}
+      />
     </>
   );
 }
@@ -530,11 +590,12 @@ function CreateCampaignDialog({
             onChange={setSegmentId}
           />
           <ConfigField
-            label="Zones (optional)"
+            label="Zones"
             placeholder="Pick a zone group…"
             value={zonesValue}
             options={zoneGroupOptions}
             onChange={setZonesValue}
+            noneLabel="None (full segment)"
           />
           <ConfigField
             label="Script"
@@ -724,6 +785,40 @@ function DeleteDialog({
   );
 }
 
+function ConfirmZoneChangeDialog({
+  open,
+  onOpenChange,
+  draftCount,
+  pending,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  draftCount: number;
+  pending: boolean;
+  onConfirm: () => void;
+}) {
+  useConfirmHotkey({ open, disabled: pending, onConfirm });
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>Change zones?</DialogTitle>
+        <DialogDescription>
+          Changing the zone group will discard{" "}
+          <span className="font-bold text-foreground">{draftCount}</span> draft turf
+          {draftCount === 1 ? "" : "s"}. Published turfs are unaffected.
+        </DialogDescription>
+        <div className="mt-2 flex justify-end gap-2">
+          <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+          <Button variant="destructive" onClick={onConfirm} loading={pending}>
+            Discard drafts and save
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function ConfigureDialog({
   open,
   onOpenChange,
@@ -800,6 +895,7 @@ function ConfigureDialog({
             value={zoneGroupId}
             options={zoneGroupOptions}
             onChange={setZoneGroupId}
+            noneLabel="None (full segment)"
           />
           <ConfigField
             label="Script"
@@ -826,15 +922,21 @@ function ConfigField({
   value,
   options,
   onChange,
+  noneLabel,
 }: {
   label: string;
   placeholder: string;
   value: string | null;
   options: ReadonlyArray<SelectOption>;
   onChange: (value: string | null) => void;
+  // When set, renders an explicit "none" item at the top of the list
+  // that commits `null`. The trigger displays this label when value is
+  // null (instead of the placeholder).
+  noneLabel?: string;
 }) {
   const dd = useDeferredRadioDropdown({ onCommit: (v) => onChange(v || null) });
   const current = options.find((o) => o.value === value);
+  const triggerLabel = current?.label ?? (value === null && noneLabel ? noneLabel : placeholder);
   return (
     <div className="flex flex-col gap-1.5">
       {label ? <label className="text-sm text-muted-foreground">{label}</label> : null}
@@ -845,11 +947,12 @@ function ConfigField({
             "enabled:hover:bg-muted",
           )}
         >
-          <span className="truncate">{current?.label ?? placeholder}</span>
+          <span className="truncate">{triggerLabel}</span>
           <ChevronDown className="size-3.5 shrink-0" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="min-w-[var(--anchor-width)]">
           <DropdownMenuRadioGroup {...dd.radio} value={value ?? ""}>
+            {noneLabel ? <DropdownMenuRadioItem value="">{noneLabel}</DropdownMenuRadioItem> : null}
             {options.map((o) => (
               <DropdownMenuRadioItem key={o.value} value={o.value}>
                 {o.label}

--- a/apps/web/src/rpc/index.ts
+++ b/apps/web/src/rpc/index.ts
@@ -70,6 +70,7 @@ export const webRouter = {
   turfDrafts: {
     list: turfDrafts.list,
     replaceAll: turfDrafts.replaceAll,
+    clearForCampaign: turfDrafts.clearForCampaign,
   },
   scripts: {
     list: scripts.list,

--- a/apps/web/src/rpc/web/segments.ts
+++ b/apps/web/src/rpc/web/segments.ts
@@ -16,7 +16,9 @@ type PersonsCount = {
   buildingCount: number;
 };
 
-type PersonsCountByKey = { counts: Record<string, { doors: number; people: number }> };
+type PersonsCountByKey = {
+  counts: Record<string, { buildings: number; doors: number; people: number }>;
+};
 
 type PersonsSample = {
   persons: Array<{

--- a/apps/web/src/rpc/web/turf-drafts.ts
+++ b/apps/web/src/rpc/web/turf-drafts.ts
@@ -1,8 +1,17 @@
 import { ORPCError } from "@orpc/server";
-import { and, asc, eq } from "@field-tools/db";
+import { and, asc, eq, isNull } from "@field-tools/db";
 import { campaigns, turfDrafts } from "@field-tools/db/schema";
 import { z } from "zod";
 import { webPub as pub } from "../context";
+
+// Drafts are scoped to `(campaignId, zoneId)`, where `zoneId` is null
+// for zoneless campaigns (cut against the full segment). Drizzle's
+// `eq(col, null)` resolves to `col = NULL` which is never true, so we
+// match the SQL semantics explicitly.
+const zoneIdMatch = (zid: string | null) =>
+  zid === null ? isNull(turfDrafts.zoneId) : eq(turfDrafts.zoneId, zid);
+
+const nullableUuid = z.string().uuid().nullable();
 
 // GeoJSON Polygon validator. We don't enforce ring-closure here —
 // the cutter naturally produces closed rings, and the publish path
@@ -18,7 +27,7 @@ export const list = pub
   .input(
     z.object({
       campaignId: z.string().uuid(),
-      zoneId: z.string().uuid(),
+      zoneId: nullableUuid,
     }),
   )
   .handler(async ({ context, input }) => {
@@ -43,7 +52,7 @@ export const list = pub
         sortOrder: turfDrafts.sortOrder,
       })
       .from(turfDrafts)
-      .where(and(eq(turfDrafts.campaignId, input.campaignId), eq(turfDrafts.zoneId, input.zoneId)))
+      .where(and(eq(turfDrafts.campaignId, input.campaignId), zoneIdMatch(input.zoneId)))
       .orderBy(asc(turfDrafts.sortOrder));
     return rows;
   });
@@ -61,7 +70,7 @@ export const replaceAll = pub
   .input(
     z.object({
       campaignId: z.string().uuid(),
-      zoneId: z.string().uuid(),
+      zoneId: nullableUuid,
       drafts: z.array(
         z.object({
           turfDraftId: z.string().uuid(),
@@ -93,9 +102,7 @@ export const replaceAll = pub
     await context.db.transaction(async (tx) => {
       await tx
         .delete(turfDrafts)
-        .where(
-          and(eq(turfDrafts.campaignId, input.campaignId), eq(turfDrafts.zoneId, input.zoneId)),
-        );
+        .where(and(eq(turfDrafts.campaignId, input.campaignId), zoneIdMatch(input.zoneId)));
       if (input.drafts.length > 0) {
         await tx.insert(turfDrafts).values(
           input.drafts.map((d) => ({

--- a/apps/web/src/rpc/web/turf-drafts.ts
+++ b/apps/web/src/rpc/web/turf-drafts.ts
@@ -120,3 +120,29 @@ export const replaceAll = pub
 
     return { ok: true as const };
   });
+
+// Wipe every draft across every zone for a campaign. Used when the
+// user changes the campaign's zone group (including zoned↔zoneless),
+// since drafts are inherently scoped to a specific zoneId and would
+// be orphaned by any rebind — even a "functionally identical" new
+// zone group is treated as a fresh slate.
+export const clearForCampaign = pub
+  .input(z.object({ campaignId: z.string().uuid() }))
+  .handler(async ({ context, input }) => {
+    const owned = await context.db
+      .select({ campaignId: campaigns.campaignId })
+      .from(campaigns)
+      .where(
+        and(
+          eq(campaigns.campaignId, input.campaignId),
+          eq(campaigns.organizationId, context.organizationId),
+        ),
+      );
+    if (owned.length === 0) throw new ORPCError("NOT_FOUND", { message: "Campaign not found" });
+
+    const deleted = await context.db
+      .delete(turfDrafts)
+      .where(eq(turfDrafts.campaignId, input.campaignId))
+      .returning({ turfDraftId: turfDrafts.turfDraftId });
+    return { deleted: deleted.length };
+  });

--- a/apps/web/src/rpc/web/turfs.ts
+++ b/apps/web/src/rpc/web/turfs.ts
@@ -85,16 +85,29 @@ export const statsForCampaign = pub
       .where(eq(turfDrafts.campaignId, input.campaignId))
       .groupBy(turfDrafts.zoneId);
     const turfRows = await context.db
-      .select({ zoneId: turfs.zoneId, count: sql<number>`count(*)::int` })
+      .select({
+        zoneId: turfs.zoneId,
+        published: sql<number>`count(*)::int`,
+        active: sql<number>`count(*) FILTER (WHERE ${turfs.status} = 'active')::int`,
+      })
       .from(turfs)
       .where(eq(turfs.campaignId, input.campaignId))
       .groupBy(turfs.zoneId);
-    const stats: Record<string, { drafts: number; published: number }> = {};
-    for (const r of draftRows) stats[r.zoneId] = { drafts: r.count, published: 0 };
+    // Keyed by zoneId; an empty-string key buckets rows from zoneless
+    // campaigns (turfs/drafts with `zoneId = NULL`). Consumers that
+    // render per-zone (ZoneRow) only look up real zoneIds; totals
+    // iterate Object.values so the sentinel key is invisible there.
+    const stats: Record<string, { drafts: number; published: number; active: number }> = {};
+    for (const r of draftRows) {
+      const key = r.zoneId ?? "";
+      stats[key] = { drafts: r.count, published: 0, active: 0 };
+    }
     for (const r of turfRows) {
-      const cur = stats[r.zoneId] ?? { drafts: 0, published: 0 };
-      cur.published = r.count;
-      stats[r.zoneId] = cur;
+      const key = r.zoneId ?? "";
+      const cur = stats[key] ?? { drafts: 0, published: 0, active: 0 };
+      cur.published = r.published;
+      cur.active = r.active;
+      stats[key] = cur;
     }
     return stats;
   });
@@ -111,7 +124,10 @@ export const publish = mut
   .input(
     z.object({
       campaignId: z.string().uuid(),
-      zoneId: z.string().uuid(),
+      // Null for zoneless campaigns; the data service will branch on
+      // its presence to scope the publish SQL to the segment instead
+      // of a specific zone.
+      zoneId: z.string().uuid().nullable(),
     }),
   )
   .handler(async ({ context, input }): Promise<PublishResult> => {

--- a/packages/db/src/schema/turf-drafts.ts
+++ b/packages/db/src/schema/turf-drafts.ts
@@ -18,6 +18,9 @@ import type { GeoJsonPolygon } from "./turfs";
 // reorganize zones/segments independently). `campaignId` *is* an FK
 // with cascade since drafts are meaningless without their parent
 // campaign.
+//
+// `zoneId` is nullable so the cutter can produce drafts on campaigns
+// without a zone group (scope = whole segment).
 export const turfDrafts = pgTable(
   "turf_drafts",
   {
@@ -25,7 +28,7 @@ export const turfDrafts = pgTable(
     campaignId: uuid()
       .notNull()
       .references(() => campaigns.campaignId, { onDelete: "cascade" }),
-    zoneId: uuid().notNull(),
+    zoneId: uuid(),
     segmentId: uuid().notNull(),
     // GeoJSON Polygon — interoperable with PostGIS / turf.js / mapbox-gl.
     // The cutter's in-memory shape is a flat `[[lng,lat],...]`; we

--- a/packages/db/src/schema/turfs.ts
+++ b/packages/db/src/schema/turfs.ts
@@ -15,6 +15,9 @@ import { users } from "./auth/users";
 // breaking historical turfs. Stale-tracking based on whether the
 // referenced row still exists is a follow-up.
 //
+// `zoneId` and `zoneGroupId` are nullable: turfs cut on a campaign
+// without a zone group hang off the campaign's segment directly.
+//
 // `status` gates the canvasser-facing lifecycle: only `'active'`
 // turfs honor their `turfCode` (the partial unique index enforces
 // uniqueness only across active turfs, so archived turfs hold
@@ -31,9 +34,10 @@ export const turfs = pgTable(
       .references(() => campaigns.campaignId),
     segmentId: uuid().notNull(),
     // Source zone (the cutter scope) and its parent group. Both kept
-    // as plain values rather than FKs — see comment above.
-    zoneId: uuid().notNull(),
-    zoneGroupId: uuid().notNull(),
+    // as plain values rather than FKs — see comment above. Null when
+    // the campaign has no zone group (cut against the full segment).
+    zoneId: uuid(),
+    zoneGroupId: uuid(),
     scriptId: uuid()
       .notNull()
       .references(() => scripts.scriptId),


### PR DESCRIPTION
This PR adds a simpler shortcut for cutting turf from a segment without first defining a zone group. For small campaigns with highly focused segments, explicitly requiring the extra abstraction of zones adds burden without much gain. We also essentially already handle the same thing by letting users create a synthetic "zone" that encompasses the full segment. But that synthetic zone approach has unresolved issues: it creates an actual zone group that's then confusing to have stick around, and requires some extra machinery that we haven't yet implemented to avoid bugs (for example, updating the synthetic zones on segment changes).

With this new approach, we pay the price of some branching logic (depending on whether zone group is defined or not), but the schema is more clear and honest, and there's no duplicate data to keep in sync. And the happy path from segment -> cutting feels smoother and simpler.