### PR TITLE
feat: more robust magic link

### DIFF
--- a/apps/web/src/components/button.tsx
+++ b/apps/web/src/components/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-primary hover:text-primary/80",
       },
       size: {
         default:

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,6 +1,6 @@
 import { createAuthClient } from "better-auth/react";
-import { magicLinkClient } from "better-auth/client/plugins";
+import { emailOTPClient } from "better-auth/client/plugins";
 
 export const authClient = createAuthClient({
-  plugins: [magicLinkClient()],
+  plugins: [emailOTPClient()],
 });

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -17,10 +17,9 @@ function getResend(): Resend | null {
 }
 
 export const auth = betterAuth({
-  // Default logger level is "warn"; "info" surfaces config-validation
-  // warnings + internal errors. BA itself doesn't log around magic-link
-  // operations, so for per-request auth tracing we instrument in `hooks`
-  // below rather than relying on this.
+  // "info" surfaces BA's config-validation + internal errors. Per-request
+  // OTP send/verify tracing is in the hooks below — BA itself doesn't log
+  // around those.
   logger: { level: "info" },
   database: drizzleAdapter(db, {
     provider: "pg",
@@ -53,10 +52,8 @@ export const auth = betterAuth({
   },
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
-      // One-line trace of every auth request — gives us OTP send + verify
-      // visibility. BA's own logger doesn't instrument these. The OTP
-      // value itself is never logged. `/get-session` is excluded because
-      // it fires on every page load and would drown out the signal.
+      // Per-request trace; OTP values never logged. `/get-session` fires
+      // on every page load and would drown out the signal.
       if (ctx.path !== "/get-session") {
         const emailHint =
           typeof ctx.body?.email === "string" ? ctx.body.email.slice(0, 3) + "…" : null;
@@ -75,15 +72,10 @@ export const auth = betterAuth({
         ctx.body.email = normalizeEmail(ctx.body.email);
       }
 
-      // Membership gate for OTP send. BA's emailOTP plugin silently
-      // no-ops for unknown emails when `disableSignUp: true` (avoids
-      // leaking user existence — see /email-otp/send-verification-otp
-      // route source). That's the right default for a public SaaS, but
-      // for an invite-only internal tool it's worse UX than a visible
-      // error: the user types the wrong address, sees "we sent it",
-      // waits forever. We gate here in the before-hook so the failure
-      // is a visible 4xx instead of a silent success, accepting the
-      // small existence-leak.
+      // Membership gate for OTP send — invite-only tool, surface a visible
+      // "no account found" instead of the silent no-op BA's emailOTP plugin
+      // returns for unknown emails under `disableSignUp: true`. We accept
+      // the small existence-leak.
       if (ctx.path === "/email-otp/send-verification-otp" && typeof ctx.body?.email === "string") {
         const row = (
           await db
@@ -101,12 +93,9 @@ export const auth = betterAuth({
       }
     }),
     after: createAuthMiddleware(async (ctx) => {
-      // Verify-outcome trace for `/sign-in/email-otp`. The client knows
-      // the outcome (it's how /login decides whether to flip to the
-      // invalid-code state), but server logs would otherwise be silent
-      // — which is exactly the visibility we want when debugging
-      // scanner-burned-token failures on pilot. The OTP value is never
-      // logged.
+      // Verify-outcome trace. Without this, server logs are silent on
+      // success vs failure — exactly the visibility we need when
+      // diagnosing scanner-burned-token failures.
       if (ctx.path !== "/sign-in/email-otp") return;
       const returned = ctx.context.returned;
       const headers = ctx.context.responseHeaders;
@@ -124,22 +113,20 @@ export const auth = betterAuth({
     emailOTP({
       disableSignUp: true,
       expiresIn: 60 * 60,
-      // The OTP is embedded in the verify-page URL (`/auth/email/:email/:code`)
-      // and never displayed to the user in Phase 1 — the email contains
-      // only the clickable link. The verify page POSTs the code to BA
-      // from a client-side effect on mount, so GET-based email scanners
-      // (the dominant kind) pre-fetch the URL but never trigger the POST
-      // and never burn the code. Phase 2 will also surface the code as a
-      // human-typeable string in the email body + a code input on /login
-      // for the small minority of scanners that execute JS.
+      // Two-channel delivery to defeat email security scanners. The OTP
+      // sits in the verify-page URL — link click triggers a client-side
+      // POST on mount that GET-based scanners can't fire by pre-fetching
+      // the page. The same OTP is also rendered as a human-typeable string
+      // in the email body and `/login`'s code-entry step accepts it as a
+      // manual fallback for the minority of scanners that execute JS and
+      // would otherwise burn the link.
       sendVerificationOTP: async ({ email, otp, type }) => {
         // We only use the sign-in flow; other types (email-verification,
         // forget-password, change-email) aren't wired up.
         if (type !== "sign-in") return;
-        // `email` is canonical thanks to the before-hook, and the
-        // before-hook has already gated on active membership — so this
-        // user definitely exists. We just need their displayEmail for
-        // the `to` field on the outbound message.
+        // The before-hook has already canonicalised `email` and confirmed
+        // an active membership exists. This lookup is just to grab the
+        // displayEmail for the outbound `to`.
         const row = (
           await db
             .select({ displayEmail: users.displayEmail })
@@ -148,8 +135,7 @@ export const auth = betterAuth({
             .limit(1)
         )[0];
         if (!row) {
-          // Shouldn't be reachable — the before-hook guarantees a user
-          // row exists for this email. Log loudly if it ever fires.
+          // Unreachable per the before-hook guarantee. Log loudly if it fires.
           console.error(`[auth] sendVerificationOTP: no user row for ${email}`);
           return;
         }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,14 +1,14 @@
 import { betterAuth } from "better-auth";
 import { APIError, createAuthMiddleware } from "better-auth/api";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { magicLink } from "better-auth/plugins";
+import { emailOTP } from "better-auth/plugins";
 import { Resend } from "resend";
 import { and, db, eq, isNull } from "@field-tools/db";
 import { accounts, memberships, sessions, users, verifications } from "@field-tools/db/schema";
 import { normalizeEmail } from "./normalize-email";
 
-// Resolved lazily so dev can boot without RESEND_API_KEY; magic links print
-// to the server console in that case.
+// Resolved lazily so dev can boot without RESEND_API_KEY; the login URL +
+// OTP code print to the server console in that case.
 let resendClient: Resend | null = null;
 function getResend(): Resend | null {
   if (!process.env.RESEND_API_KEY) return null;
@@ -53,63 +53,46 @@ export const auth = betterAuth({
   },
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
-      // One-line trace of every auth request — gives us magic-link send +
-      // verify visibility (BA's own logger doesn't instrument these).
-      // `?` masks the token value, just records whether one was present.
-      const hasToken = typeof ctx.query?.token === "string";
+      // One-line trace of every auth request — gives us OTP send + verify
+      // visibility. BA's own logger doesn't instrument these. The OTP
+      // value itself is never logged.
       const emailHint =
         typeof ctx.body?.email === "string" ? ctx.body.email.slice(0, 3) + "…" : null;
       console.log(
-        `[auth] ${ctx.method ?? "?"} ${ctx.path}` +
-          (hasToken ? " token=<present>" : "") +
-          (emailHint ? ` email=${emailHint}` : ""),
+        `[auth] ${ctx.method ?? "?"} ${ctx.path}` + (emailHint ? ` email=${emailHint}` : ""),
       );
 
       // Normalize the typed email to its canonical form before BA's own
-      // logic sees it — the verification record and any downstream user
-      // lookups all key on `users.email`, which we store canonicalised.
-      if (ctx.path === "/sign-in/magic-link" && typeof ctx.body?.email === "string") {
+      // logic sees it — verification records and user lookups all key on
+      // `users.email`, which we store canonicalised.
+      if (
+        (ctx.path === "/email-otp/send-verification-otp" || ctx.path === "/sign-in/email-otp") &&
+        typeof ctx.body?.email === "string"
+      ) {
         ctx.body.email = normalizeEmail(ctx.body.email);
       }
     }),
-    after: createAuthMiddleware(async (ctx) => {
-      // Magic-link verify always 302s — to the callbackURL on success
-      // (with a Set-Cookie carrying the session) or to errorCallbackURL
-      // with `?error=<reason>` on failure. Logging both lets us tell
-      // "token consumed by a scanner" (error=INVALID_TOKEN) from
-      // "succeeded but cookie didn't stick" (no error, cookie present
-      // in our logs but missing from the user's browser later) from
-      // any path we haven't anticipated yet.
-      if (ctx.path !== "/magic-link/verify") return;
-      const headers = ctx.context.responseHeaders;
-      const location = headers?.get("location") ?? null;
-      const setCookie = headers?.get("set-cookie") ?? null;
-      const cookieSet = !!setCookie && setCookie.includes("session");
-      let error: string | null = null;
-      if (location) {
-        try {
-          // `location` may be absolute or path-relative; the base is
-          // unused since we only read the query string.
-          error = new URL(location, "http://placeholder").searchParams.get("error");
-        } catch {
-          /* malformed Location header — ignore */
-        }
-      }
-      console.log(
-        `[auth] verify result: location=${location ?? "?"} cookie=${cookieSet ? "set" : "missing"}` +
-          (error ? ` error=${error}` : ""),
-      );
-    }),
   },
   plugins: [
-    magicLink({
+    emailOTP({
       disableSignUp: true,
       expiresIn: 60 * 60,
-      sendMagicLink: async ({ email, url }) => {
+      // The OTP is embedded in the verify-page URL (`/auth/email/:email/:code`)
+      // and never displayed to the user in Phase 1 — the email contains
+      // only the clickable link. The verify page POSTs the code to BA
+      // from a client-side effect on mount, so GET-based email scanners
+      // (the dominant kind) pre-fetch the URL but never trigger the POST
+      // and never burn the code. Phase 2 will also surface the code as a
+      // human-typeable string in the email body + a code input on /login
+      // for the small minority of scanners that execute JS.
+      sendVerificationOTP: async ({ email, otp, type }) => {
+        // We only use the sign-in flow; other types (email-verification,
+        // forget-password, change-email) aren't wired up.
+        if (type !== "sign-in") return;
         // `email` is already canonical thanks to the before-hook. Membership
         // gate — BA's disableSignUp only fires at verify-time, so without
-        // this check the link gets sent first and the user only sees the
-        // failure after clicking it. We gate on an *active* (non-archived)
+        // this check the OTP gets sent first and the user only sees the
+        // failure after using it. We gate on an *active* (non-archived)
         // membership rather than just users-row existence, so removed/archived
         // people get the same rejection as strangers.
         const row = (
@@ -126,9 +109,11 @@ export const auth = betterAuth({
           });
         }
         const to = row.displayEmail;
+        const baseUrl = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
+        const verifyUrl = `${baseUrl}/auth/email/${encodeURIComponent(email)}/${otp}`;
         const resend = getResend();
         if (!resend) {
-          console.log(`[auth] magic link for ${to}: ${url}`);
+          console.log(`[auth] otp for ${to}: ${otp} (${verifyUrl})`);
           return;
         }
         const from = process.env.RESEND_FROM ?? "Field Tools <onboarding@resend.dev>";
@@ -142,7 +127,7 @@ export const auth = betterAuth({
   <p style="font-size: 16px;">Click the button below to log in securely:</p>
 
   <p style="text-align: left; margin: 30px 0;">
-    <a href="${url}" style="background-color: #222222; color: white; padding: 12px 20px; text-decoration: none; border-radius: 6px; font-size: 16px; display: inline-block;">
+    <a href="${verifyUrl}" style="background-color: #222222; color: white; padding: 12px 20px; text-decoration: none; border-radius: 6px; font-size: 16px; display: inline-block;">
       Log in to Field Tools
     </a>
   </p>

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from "better-auth";
-import { APIError, createAuthMiddleware } from "better-auth/api";
+import { APIError, createAuthMiddleware, isAPIError } from "better-auth/api";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { emailOTP } from "better-auth/plugins";
 import { Resend } from "resend";
@@ -55,12 +55,15 @@ export const auth = betterAuth({
     before: createAuthMiddleware(async (ctx) => {
       // One-line trace of every auth request — gives us OTP send + verify
       // visibility. BA's own logger doesn't instrument these. The OTP
-      // value itself is never logged.
-      const emailHint =
-        typeof ctx.body?.email === "string" ? ctx.body.email.slice(0, 3) + "…" : null;
-      console.log(
-        `[auth] ${ctx.method ?? "?"} ${ctx.path}` + (emailHint ? ` email=${emailHint}` : ""),
-      );
+      // value itself is never logged. `/get-session` is excluded because
+      // it fires on every page load and would drown out the signal.
+      if (ctx.path !== "/get-session") {
+        const emailHint =
+          typeof ctx.body?.email === "string" ? ctx.body.email.slice(0, 3) + "…" : null;
+        console.log(
+          `[auth] ${ctx.method ?? "?"} ${ctx.path}` + (emailHint ? ` email=${emailHint}` : ""),
+        );
+      }
 
       // Normalize the typed email to its canonical form before BA's own
       // logic sees it — verification records and user lookups all key on
@@ -71,6 +74,50 @@ export const auth = betterAuth({
       ) {
         ctx.body.email = normalizeEmail(ctx.body.email);
       }
+
+      // Membership gate for OTP send. BA's emailOTP plugin silently
+      // no-ops for unknown emails when `disableSignUp: true` (avoids
+      // leaking user existence — see /email-otp/send-verification-otp
+      // route source). That's the right default for a public SaaS, but
+      // for an invite-only internal tool it's worse UX than a visible
+      // error: the user types the wrong address, sees "we sent it",
+      // waits forever. We gate here in the before-hook so the failure
+      // is a visible 4xx instead of a silent success, accepting the
+      // small existence-leak.
+      if (ctx.path === "/email-otp/send-verification-otp" && typeof ctx.body?.email === "string") {
+        const row = (
+          await db
+            .select({ id: users.id })
+            .from(users)
+            .innerJoin(memberships, eq(memberships.userId, users.id))
+            .where(and(eq(users.email, ctx.body.email), isNull(memberships.archivedAt)))
+            .limit(1)
+        )[0];
+        if (!row) {
+          throw new APIError("BAD_REQUEST", {
+            message: "No account found for this email",
+          });
+        }
+      }
+    }),
+    after: createAuthMiddleware(async (ctx) => {
+      // Verify-outcome trace for `/sign-in/email-otp`. The client knows
+      // the outcome (it's how /login decides whether to flip to the
+      // invalid-code state), but server logs would otherwise be silent
+      // — which is exactly the visibility we want when debugging
+      // scanner-burned-token failures on pilot. The OTP value is never
+      // logged.
+      if (ctx.path !== "/sign-in/email-otp") return;
+      const returned = ctx.context.returned;
+      const headers = ctx.context.responseHeaders;
+      const cookieSet = !!headers?.get("set-cookie")?.includes("session");
+      if (isAPIError(returned)) {
+        const status = returned.status ?? "?";
+        const message = returned.body?.message ?? "(no message)";
+        console.log(`[auth] verify failed: status=${status} message=${message}`);
+        return;
+      }
+      console.log(`[auth] verify ok: cookie=${cookieSet ? "set" : "missing"}`);
     }),
   },
   plugins: [
@@ -89,24 +136,22 @@ export const auth = betterAuth({
         // We only use the sign-in flow; other types (email-verification,
         // forget-password, change-email) aren't wired up.
         if (type !== "sign-in") return;
-        // `email` is already canonical thanks to the before-hook. Membership
-        // gate — BA's disableSignUp only fires at verify-time, so without
-        // this check the OTP gets sent first and the user only sees the
-        // failure after using it. We gate on an *active* (non-archived)
-        // membership rather than just users-row existence, so removed/archived
-        // people get the same rejection as strangers.
+        // `email` is canonical thanks to the before-hook, and the
+        // before-hook has already gated on active membership — so this
+        // user definitely exists. We just need their displayEmail for
+        // the `to` field on the outbound message.
         const row = (
           await db
-            .select({ id: users.id, displayEmail: users.displayEmail })
+            .select({ displayEmail: users.displayEmail })
             .from(users)
-            .innerJoin(memberships, eq(memberships.userId, users.id))
-            .where(and(eq(users.email, email), isNull(memberships.archivedAt)))
+            .where(eq(users.email, email))
             .limit(1)
         )[0];
         if (!row) {
-          throw new APIError("BAD_REQUEST", {
-            message: "No account found for this email",
-          });
+          // Shouldn't be reachable — the before-hook guarantees a user
+          // row exists for this email. Log loudly if it ever fires.
+          console.error(`[auth] sendVerificationOTP: no user row for ${email}`);
+          return;
         }
         const to = row.displayEmail;
         const baseUrl = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
@@ -131,6 +176,10 @@ export const auth = betterAuth({
       Log in to Field Tools
     </a>
   </p>
+
+  <p style="font-size: 16px;">If you have trouble with magic links, you can also enter this code on the login page:</p>
+
+  <p><span style="font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 18px; color: #333; background-color: #f3f3f3; padding: 4px 8px; border-radius: 4px; display: inline-block;">${otp}</span></p>
 
   <p style="font-size: 16px;">If you didn't request this email, you can safely ignore it.</p>
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -43,7 +43,11 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     ],
   }),
   beforeLoad: async ({ location }) => {
-    if (location.pathname === "/login") return { session: null };
+    // Auth-flow routes can be hit without a session (that's the whole
+    // point — the verify route is mid-login). Skip the gate for them.
+    const isAuthFlow =
+      location.pathname === "/login" || location.pathname.startsWith("/auth/email/");
+    if (isAuthFlow) return { session: null };
     const session = await getSession();
     if (!session) throw redirect({ to: "/login" });
     return { session };

--- a/apps/web/src/routes/auth.email.$email.$code.tsx
+++ b/apps/web/src/routes/auth.email.$email.$code.tsx
@@ -20,8 +20,12 @@ export const Route = createFileRoute("/auth/email/$email/$code")({
   beforeLoad: async () => {
     // If they're already signed in (e.g. clicked the same link twice in
     // the same session), skip the verify entirely and bounce home.
+    // `reloadDocument` forces a full-document navigation so root's
+    // beforeLoad re-runs with a fresh session lookup — an internal
+    // redirect would reuse the auth-flow bypass context (session=null)
+    // from this route and bounce back through /login in a loop.
     const session = await getSession();
-    if (session) throw redirect({ to: "/" });
+    if (session) throw redirect({ to: "/", reloadDocument: true });
   },
   component: VerifyPage,
 });
@@ -40,7 +44,7 @@ function VerifyPage() {
         // burned it, or user clicked twice from different sessions),
         // expired, or never existed. Recovery is the same — request a
         // new link.
-        setError("This link is no longer valid.");
+        setError("This link is no longer valid, please try again.");
         return;
       }
       // Hard-load to "/" — root's mount-time effect broadcasts the

--- a/apps/web/src/routes/auth.email.$email.$code.tsx
+++ b/apps/web/src/routes/auth.email.$email.$code.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "~/components/button";
 import { LightDarkToggle } from "~/components/light-dark-toggle";
 import { LoadingIndicator } from "~/components/loading-indicator";
@@ -33,12 +33,17 @@ export const Route = createFileRoute("/auth/email/$email/$code")({
 function VerifyPage() {
   const { email, code } = Route.useParams();
   const [error, setError] = useState<string | null>(null);
+  // Guards against React's dev-mode double-effect (and any other mount-
+  // remount within the same component instance) from firing the verify
+  // POST twice. A genuinely separate navigation gets a fresh component
+  // and a fresh ref, so it isn't affected.
+  const fired = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
+    if (fired.current) return;
+    fired.current = true;
     void (async () => {
       const res = await authClient.signIn.emailOtp({ email, otp: code });
-      if (cancelled) return;
       if (res.error) {
         // Common reasons collapse into one message: already used (scanner
         // burned it, or user clicked twice from different sessions),
@@ -53,9 +58,6 @@ function VerifyPage() {
       // trip the root listener's user-switch detection → reload loop.
       window.location.replace("/");
     })();
-    return () => {
-      cancelled = true;
-    };
     // Run once on mount — `email`/`code` come from URL params and don't change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/apps/web/src/routes/auth.email.$email.$code.tsx
+++ b/apps/web/src/routes/auth.email.$email.$code.tsx
@@ -1,0 +1,78 @@
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { Button } from "~/components/button";
+import { LightDarkToggle } from "~/components/light-dark-toggle";
+import { LoadingIndicator } from "~/components/loading-indicator";
+import { authClient } from "~/lib/auth-client";
+import { getSession } from "~/lib/server/session";
+
+// Linear-style verify landing. The email contains a link to this URL with
+// the OTP in the path. We deliberately do NOT verify on GET — the server
+// just renders the page. Verification fires from a client-side effect, so
+// scanner pre-fetches (which don't execute JS) never trigger the POST and
+// can't burn the OTP. A real user's browser executes the effect and
+// redirects them straight into the app.
+//
+// If a verify fails (already used, expired, JS-executing scanner, double
+// click) the user sees a "link can't be used" message with a button back
+// to /login where they can request a new one.
+export const Route = createFileRoute("/auth/email/$email/$code")({
+  beforeLoad: async () => {
+    // If they're already signed in (e.g. clicked the same link twice in
+    // the same session), skip the verify entirely and bounce home.
+    const session = await getSession();
+    if (session) throw redirect({ to: "/" });
+  },
+  component: VerifyPage,
+});
+
+function VerifyPage() {
+  const { email, code } = Route.useParams();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await authClient.signIn.emailOtp({ email, otp: code });
+      if (cancelled) return;
+      if (res.error) {
+        // Common reasons collapse into one message: already used (scanner
+        // burned it, or user clicked twice from different sessions),
+        // expired, or never existed. Recovery is the same — request a
+        // new link.
+        setError("This link is no longer valid.");
+        return;
+      }
+      // Hard-load to "/" — root's mount-time effect broadcasts the
+      // logged-in signal (with userId) so any sibling /login tabs
+      // transition too. Broadcasting from here would lack a userId and
+      // trip the root listener's user-switch detection → reload loop.
+      window.location.replace("/");
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // Run once on mount — `email`/`code` come from URL params and don't change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Truly blank during the in-flight POST so the redirect lands as fast
+  // as the prior magic-link flow — even the spinner briefly visible feels
+  // distracting at this scale.
+  if (!error) return null;
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="fixed top-3 right-4 flex items-center gap-3">
+        <LoadingIndicator />
+        <LightDarkToggle />
+      </div>
+      <div className="w-full max-w-sm -mt-16 animate-in fade-in duration-100">
+        <h1 className="mb-5 text-center text-5xl italic font-bold tracking-tight">Field Tools</h1>
+        <p className="mb-8 text-center text-[16px] text-muted-foreground">{error}</p>
+        <Link to="/login" className="block">
+          <Button className="h-10 w-full text-[16px]">Return to login</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/auth.email.$email.$code.tsx
+++ b/apps/web/src/routes/auth.email.$email.$code.tsx
@@ -6,24 +6,17 @@ import { LoadingIndicator } from "~/components/loading-indicator";
 import { authClient } from "~/lib/auth-client";
 import { getSession } from "~/lib/server/session";
 
-// Linear-style verify landing. The email contains a link to this URL with
-// the OTP in the path. We deliberately do NOT verify on GET — the server
-// just renders the page. Verification fires from a client-side effect, so
-// scanner pre-fetches (which don't execute JS) never trigger the POST and
-// can't burn the OTP. A real user's browser executes the effect and
-// redirects them straight into the app.
-//
-// If a verify fails (already used, expired, JS-executing scanner, double
-// click) the user sees a "link can't be used" message with a button back
-// to /login where they can request a new one.
+// Verify landing for the OTP embedded in email links. The GET serves an
+// inert page; verification fires from a client-side effect on mount, so
+// GET-based email scanners that pre-fetch the URL can't trigger the POST
+// and can't burn the OTP. Real browsers execute the effect and redirect
+// into the app. On failure (already used, expired, etc.) we surface a
+// message with a button back to /login.
 export const Route = createFileRoute("/auth/email/$email/$code")({
   beforeLoad: async () => {
-    // If they're already signed in (e.g. clicked the same link twice in
-    // the same session), skip the verify entirely and bounce home.
-    // `reloadDocument` forces a full-document navigation so root's
-    // beforeLoad re-runs with a fresh session lookup — an internal
-    // redirect would reuse the auth-flow bypass context (session=null)
-    // from this route and bounce back through /login in a loop.
+    // Already signed in — skip the verify and bounce home. `reloadDocument`
+    // is load-bearing: an internal redirect would reuse this route's auth-
+    // flow bypass context (session=null) and loop back through /login.
     const session = await getSession();
     if (session) throw redirect({ to: "/", reloadDocument: true });
   },
@@ -33,10 +26,9 @@ export const Route = createFileRoute("/auth/email/$email/$code")({
 function VerifyPage() {
   const { email, code } = Route.useParams();
   const [error, setError] = useState<string | null>(null);
-  // Guards against React's dev-mode double-effect (and any other mount-
-  // remount within the same component instance) from firing the verify
-  // POST twice. A genuinely separate navigation gets a fresh component
-  // and a fresh ref, so it isn't affected.
+  // Guards a single component instance from firing the verify POST twice
+  // (notably React's dev-mode double-effect). Separate navigations get a
+  // fresh component + fresh ref and are unaffected.
   const fired = useRef(false);
 
   useEffect(() => {
@@ -45,26 +37,21 @@ function VerifyPage() {
     void (async () => {
       const res = await authClient.signIn.emailOtp({ email, otp: code });
       if (res.error) {
-        // Common reasons collapse into one message: already used (scanner
-        // burned it, or user clicked twice from different sessions),
-        // expired, or never existed. Recovery is the same — request a
-        // new link.
+        // All failure modes (already-used, expired, never-existed) collapse
+        // here — the recovery is the same in every case: request a new link.
         setError("This link is no longer valid, please try again.");
         return;
       }
       // Hard-load to "/" — root's mount-time effect broadcasts the
-      // logged-in signal (with userId) so any sibling /login tabs
-      // transition too. Broadcasting from here would lack a userId and
-      // trip the root listener's user-switch detection → reload loop.
+      // logged-in signal with the user id. Broadcasting from this page
+      // would lack a userId and trip the root listener's user-switch
+      // detection → reload loop.
       window.location.replace("/");
     })();
-    // Run once on mount — `email`/`code` come from URL params and don't change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Truly blank during the in-flight POST so the redirect lands as fast
-  // as the prior magic-link flow — even the spinner briefly visible feels
-  // distracting at this scale.
+  // Truly blank during the in-flight POST so the redirect feels instant.
   if (!error) return null;
   return (
     <div className="flex min-h-screen items-center justify-center px-4">

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -44,7 +44,7 @@ function LoginPage() {
   const mutation = useMutation({
     mutationFn: async (target: string) => {
       const [res] = await Promise.all([
-        authClient.signIn.magicLink({ email: target, callbackURL: "/" }),
+        authClient.emailOtp.sendVerificationOtp({ email: target, type: "sign-in" }),
         new Promise((r) => setTimeout(r, 600)),
       ]);
       return res;

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -44,7 +44,7 @@ function LoginPage() {
   }, []);
 
   // 600ms floor on both mutations so button-state transitions read as
-  // intentional even on fast networks (matches the prior magic-link flow).
+  // intentional even on fast networks.
   const sendCode = useMutation({
     mutationFn: async (target: string) => {
       const [res] = await Promise.all([
@@ -111,9 +111,9 @@ function LoginPage() {
             email={email}
             setEmail={(next) => {
               setEmail(next);
-              // Clear the error as soon as the user starts editing — otherwise
-              // a stale "no account found" sits there next to a half-typed
-              // new email, which reads like the field still has the problem.
+              // Clear any stale error as the user starts editing — otherwise
+              // it sits next to a half-typed new email, looking like the
+              // field still has the problem.
               if (error) setError(null);
             }}
             pending={sendCode.isPending}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -17,11 +17,20 @@ export const Route = createFileRoute("/login")({
   component: LoginPage,
 });
 
-type FormState = "idle" | "sending" | "sent";
+// Four-state flow:
+//   email   – user types their email and submits
+//   sent    – we sent the email; user can wait for the link OR click "Enter
+//             code manually" to switch to the code-entry state
+//   code    – user pastes the OTP from the email and submits
+//   invalid – code didn't verify (typo, expired, already-burned by scanner)
+// "Back to login" links + the invalid-state button all reset to `email`.
+type Step = "email" | "sent" | "code" | "invalid";
 
 function LoginPage() {
+  const [step, setStep] = useState<Step>("email");
   const [email, setEmail] = useState("");
-  const [state, setState] = useState<FormState>("idle");
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   // Cross-tab login signal — see __root's beforeLoad.
   useEffect(() => {
@@ -34,14 +43,9 @@ function LoginPage() {
     return () => channel.close();
   }, []);
 
-  // Held separately from state so it stays visible across resubmits — it only
-  // clears on a successful send.
-  const [error, setError] = useState<string | null>(null);
-
-  // Wrapped in useMutation so the global LoadingIndicator picks it up via
-  // useIsMutating. Minimum 600ms floor so "Sending…" reads as intentional
-  // even when the network is fast.
-  const mutation = useMutation({
+  // 600ms floor on both mutations so button-state transitions read as
+  // intentional even on fast networks (matches the prior magic-link flow).
+  const sendCode = useMutation({
     mutationFn: async (target: string) => {
       const [res] = await Promise.all([
         authClient.emailOtp.sendVerificationOtp({ email: target, type: "sign-in" }),
@@ -51,19 +55,47 @@ function LoginPage() {
     },
   });
 
-  const onSubmit = async (e: FormEvent) => {
+  const verifyCode = useMutation({
+    mutationFn: async (input: { email: string; otp: string }) => {
+      const [res] = await Promise.all([
+        authClient.signIn.emailOtp(input),
+        new Promise((r) => setTimeout(r, 600)),
+      ]);
+      return res;
+    },
+  });
+
+  const onSubmitEmail = async (e: FormEvent) => {
     e.preventDefault();
-    setState("sending");
-    const res = await mutation.mutateAsync(email);
+    setError(null);
+    const res = await sendCode.mutateAsync(email);
     if (res.error) {
       // BA's zod errors come prefixed with the field path (e.g. "[body.email] …").
-      const raw = res.error.message ?? "Login failed";
-      setError(raw.replace(/^\[[^\]]+\]\s*/, ""));
-      setState("idle");
+      setError((res.error.message ?? "Login failed").replace(/^\[[^\]]+\]\s*/, ""));
       return;
     }
+    setStep("sent");
+  };
+
+  const onSubmitCode = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await verifyCode.mutateAsync({ email, otp: code.trim() });
+    if (res.error) {
+      setStep("invalid");
+      return;
+    }
+    // Hard-load to "/" — root's mount-time effect broadcasts the
+    // logged-in signal (with userId). Broadcasting from here would
+    // lack a userId and trip the root listener's user-switch reload.
+    window.location.replace("/");
+  };
+
+  // "Back to login" / "Return to login" — full reset.
+  const reset = () => {
+    setStep("email");
+    setEmail("");
+    setCode("");
     setError(null);
-    setState("sent");
   };
 
   return (
@@ -74,55 +106,173 @@ function LoginPage() {
       </div>
       <div className="w-full max-w-sm -mt-16 animate-in fade-in duration-100">
         <h1 className="mb-5 text-center text-5xl italic font-bold tracking-tight">Field Tools</h1>
-        <p className="mb-8 text-center text-[16px] text-muted-foreground">
-          Enter your email to receive a login link
-        </p>
-        <form onSubmit={onSubmit} className="flex flex-col gap-3">
-          <Input
-            type="email"
-            placeholder="you@example.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoFocus
-            className="text-[16px]"
+        {step === "email" ? (
+          <EmailStep
+            email={email}
+            setEmail={(next) => {
+              setEmail(next);
+              // Clear the error as soon as the user starts editing — otherwise
+              // a stale "no account found" sits there next to a half-typed
+              // new email, which reads like the field still has the problem.
+              if (error) setError(null);
+            }}
+            pending={sendCode.isPending}
+            onSubmit={onSubmitEmail}
+            error={error}
           />
-          <Button
-            type="submit"
-            className="h-10 disabled:opacity-100 text-[16px]"
-            disabled={state === "sending"}
-          >
-            {state === "sending" ? "Sending…" : "Send login link"}
-          </Button>
-        </form>
-        <FormMessage state={state} error={error} />
+        ) : step === "sent" ? (
+          <SentStep email={email} onEnterCode={() => setStep("code")} onBack={reset} />
+        ) : step === "code" ? (
+          <CodeStep
+            code={code}
+            setCode={setCode}
+            pending={verifyCode.isPending}
+            onSubmit={onSubmitCode}
+            onBack={reset}
+          />
+        ) : (
+          <InvalidStep onReturn={reset} />
+        )}
       </div>
     </div>
   );
 }
 
-function FormMessage({ state, error }: { state: FormState; error: string | null }) {
-  if (state === "sent") {
-    return (
-      <p
-        className={cn(
-          "mt-4 rounded-md border border-success/30 bg-success/5 p-3 text-sm text-success",
-        )}
-      >
-        Check your inbox for a login link
+function EmailStep({
+  email,
+  setEmail,
+  pending,
+  onSubmit,
+  error,
+}: {
+  email: string;
+  setEmail: (v: string) => void;
+  pending: boolean;
+  onSubmit: (e: FormEvent) => void;
+  error: string | null;
+}) {
+  return (
+    <>
+      <p className="mb-8 text-center text-[16px] text-muted-foreground">
+        Enter your email to receive a login link
       </p>
-    );
-  }
-  if (error) {
-    return (
-      <p
-        className={cn(
-          "mt-4 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive",
-        )}
-      >
-        {error}
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <Input
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoFocus
+          className="text-[16px]"
+        />
+        <Button type="submit" className="h-10 disabled:opacity-100 text-[16px]" disabled={pending}>
+          {pending ? "Sending…" : "Send login link"}
+        </Button>
+      </form>
+      {error ? (
+        <p
+          className={cn(
+            "mt-4 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive",
+          )}
+        >
+          {error}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+function SentStep({
+  email,
+  onEnterCode,
+  onBack,
+}: {
+  email: string;
+  onEnterCode: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <>
+      <p className="mb-8 text-center text-[16px] text-muted-foreground">
+        We've sent a temporary login link, please check your inbox at{" "}
+        <span className="text-foreground">{email}</span>. If you have trouble with magic links, you
+        can also check the email for a code and click below to manually enter it.
       </p>
-    );
-  }
-  return null;
+      <Button
+        variant="outline"
+        type="button"
+        onClick={onEnterCode}
+        className="h-10 w-full text-[16px]"
+      >
+        Enter code manually
+      </Button>
+      <BackToLogin onClick={onBack} />
+    </>
+  );
+}
+
+function CodeStep({
+  code,
+  setCode,
+  pending,
+  onSubmit,
+  onBack,
+}: {
+  code: string;
+  setCode: (v: string) => void;
+  pending: boolean;
+  onSubmit: (e: FormEvent) => void;
+  onBack: () => void;
+}) {
+  return (
+    <>
+      <p className="mb-8 text-center text-[16px] text-muted-foreground">
+        Check your email for a temporary login code and enter it below.
+      </p>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <Input
+          type="text"
+          placeholder="Login code (6 digits)"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          required
+          autoFocus
+          autoComplete="one-time-code"
+          className="text-[16px] tabular-nums"
+        />
+        <Button type="submit" className="h-10 disabled:opacity-100 text-[16px]" disabled={pending}>
+          {pending ? "Signing in…" : "Continue with login code"}
+        </Button>
+      </form>
+      <BackToLogin onClick={onBack} />
+    </>
+  );
+}
+
+function InvalidStep({ onReturn }: { onReturn: () => void }) {
+  return (
+    <>
+      <p className="mb-8 text-center text-[16px] text-muted-foreground">
+        This code is no longer valid, please try again.
+      </p>
+      <Button type="button" onClick={onReturn} className="h-10 w-full text-[16px]">
+        Return to login
+      </Button>
+    </>
+  );
+}
+
+function BackToLogin({ onClick }: { onClick: () => void }) {
+  return (
+    <div className="mt-4 text-center">
+      <button
+        type="button"
+        onClick={onClick}
+        className="text-sm text-muted-foreground hover:text-foreground"
+      >
+        Back to login
+      </button>
+    </div>
+  );
 }

--- a/apps/web/src/rpc/web/users.ts
+++ b/apps/web/src/rpc/web/users.ts
@@ -103,8 +103,8 @@ export const invite = webMut
     });
 
     if (input.sendEmail) {
-      await auth.api.signInMagicLink({
-        body: { email: displayEmail, callbackURL: "/" },
+      await auth.api.sendVerificationOTP({
+        body: { email: displayEmail, type: "sign-in" },
         headers: new Headers(),
       });
     }
@@ -240,8 +240,8 @@ export const resendInvite = webMut
     )[0];
     if (!row) throw new ORPCError("NOT_FOUND");
 
-    await auth.api.signInMagicLink({
-      body: { email: row.displayEmail, callbackURL: "/" },
+    await auth.api.sendVerificationOTP({
+      body: { email: row.displayEmail, type: "sign-in" },
       headers: new Headers(),
     });
 

--- a/apps/web/src/rpc/web/users.ts
+++ b/apps/web/src/rpc/web/users.ts
@@ -25,8 +25,8 @@ async function countActiveOwners(db: Db, organizationId: string): Promise<number
 
 // List memberships in the current org. Status is derived per-row:
 //   archived → membership has archivedAt set
-//   active   → users.emailVerified (BA flips this on first magic-link click)
-//   pending  → invite sent, link never clicked
+//   active   → users.emailVerified (BA flips this on first OTP verify)
+//   pending  → invite sent, never verified
 export const list = webPub.input(z.object({}).optional()).handler(async ({ context }) => {
   const rows = await context.db
     .select({
@@ -219,7 +219,7 @@ export const unarchive = webMut
     return { ok: true as const };
   });
 
-// Re-send the magic link for an active member of this org.
+// Re-send the login email for an active member of this org.
 export const resendInvite = webMut
   .input(z.object({ userId: z.string().uuid() }))
   .handler(async ({ context, input }) => {


### PR DESCRIPTION
This PR makes our magic link flow more robust. The primary issue surfacing was email environments where emails are scanned, which burns the token, and results in a confusing experience (click the magic link, get routed back to login).

The new setup preserves the happy path for most users, while creating an escape hatch. First, rather than a pure magic link, we send a OTP, and the email includes both a "magic" link and a code. The link goes to a page that simply fires a POST that verifies the OTP and email and creates the session. Because the POST only fires from JavaScript on page mount (not from the GET that loads the page) most scanner pre-fetches shouldn't trigger verification and won't burn the OTP. 

If a scanner does execute JS, we have an extra fallback. The login page now shows a "Enter code manually" button after submitting an emai. If you click that button, and enter the code from your email, you'll get logged in. So users with no scanning or normal scanners get the original one-click experience; users with aggressive scanners breaking magic links have an escape hatch.