### PR TITLE
feat: magic link confirmation

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -30,3 +30,10 @@ BETTER_AUTH_URL=http://localhost:3000
 # Optional: set to "1" to bypass auth entirely and impersonate the seeded
 # admin. For local dev when you don't want to exercise the magic-link flow.
 # AUTH_DISABLED=1
+
+# Optional (per-deployment): set to "1" to require a click on the magic-link
+# verify page instead of verifying on page load. Defeats email "detonation"
+# scanners (e.g. Microsoft Safe Links) that execute the page's JS and would
+# otherwise burn the single-use link before the user clicks. Costs one click;
+# leave unset for deployments whose users aren't behind such gateways.
+# AUTH_REQUIRE_LINK_CONFIRMATION=1

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -113,13 +113,11 @@ export const auth = betterAuth({
     emailOTP({
       disableSignUp: true,
       expiresIn: 60 * 60,
-      // Two-channel delivery to defeat email security scanners. The OTP
-      // sits in the verify-page URL — link click triggers a client-side
-      // POST on mount that GET-based scanners can't fire by pre-fetching
-      // the page. The same OTP is also rendered as a human-typeable string
-      // in the email body and `/login`'s code-entry step accepts it as a
-      // manual fallback for the minority of scanners that execute JS and
-      // would otherwise burn the link.
+      // The OTP rides only in the verify-page URL; that page verifies via a
+      // client POST (never a GET), so scanners that pre-fetch the link can't
+      // burn it. Deployments behind JS-executing scanners set
+      // AUTH_REQUIRE_LINK_CONFIRMATION so the verify fires on a click rather
+      // than on mount — see routes/auth.email.$email.$code.tsx.
       sendVerificationOTP: async ({ email, otp, type }) => {
         // We only use the sign-in flow; other types (email-verification,
         // forget-password, change-email) aren't wired up.
@@ -162,10 +160,6 @@ export const auth = betterAuth({
       Log in to Field Tools
     </a>
   </p>
-
-  <p style="font-size: 16px;">If you have trouble with magic links, you can also enter this code on the login page:</p>
-
-  <p><span style="font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 18px; color: #333; background-color: #f3f3f3; padding: 4px 8px; border-radius: 4px; display: inline-block;">${otp}</span></p>
 
   <p style="font-size: 16px;">If you didn't request this email, you can safely ignore it.</p>
 

--- a/apps/web/src/lib/server/auth-flags.ts
+++ b/apps/web/src/lib/server/auth-flags.ts
@@ -1,0 +1,12 @@
+import { createServerFn } from "@tanstack/react-start";
+
+// Per-deployment auth toggles, read from server env (never bundled to the
+// client). `AUTH_REQUIRE_LINK_CONFIRMATION` makes the magic-link verify page
+// fire the OTP POST on a button click instead of on mount. Detonation engines
+// (e.g. Microsoft Safe Links) execute the page's JS — so an on-mount POST gets
+// burned before the user acts — but they don't click buttons, so the click
+// gate keeps the OTP alive. Off by default; deployments whose users sit behind
+// such gateways flip it on, trading one click for scanner resistance.
+export const getRequireLinkConfirmation = createServerFn({ method: "GET" }).handler(
+  async (): Promise<boolean> => process.env.AUTH_REQUIRE_LINK_CONFIRMATION === "1",
+);

--- a/apps/web/src/routes/auth.email.$email.$code.tsx
+++ b/apps/web/src/routes/auth.email.$email.$code.tsx
@@ -4,14 +4,20 @@ import { Button } from "~/components/button";
 import { LightDarkToggle } from "~/components/light-dark-toggle";
 import { LoadingIndicator } from "~/components/loading-indicator";
 import { authClient } from "~/lib/auth-client";
+import { getRequireLinkConfirmation } from "~/lib/server/auth-flags";
 import { getSession } from "~/lib/server/session";
 
-// Verify landing for the OTP embedded in email links. The GET serves an
-// inert page; verification fires from a client-side effect on mount, so
-// GET-based email scanners that pre-fetch the URL can't trigger the POST
-// and can't burn the OTP. Real browsers execute the effect and redirect
-// into the app. On failure (already used, expired, etc.) we surface a
-// message with a button back to /login.
+// Verify landing for the OTP embedded in email links. Verification always
+// fires from a client-side POST, never a GET, so scanners that merely
+// pre-fetch the URL can't burn the single-use OTP. Two modes, chosen
+// per-deployment by AUTH_REQUIRE_LINK_CONFIRMATION:
+//   - off (default): the POST fires on mount — zero-click magic link. Beats
+//     pre-fetch scanners, but not detonation engines that execute page JS.
+//   - on: the POST fires only on a button click. Detonation engines run the
+//     JS but don't click, so the OTP survives the scan until the real user
+//     acts. Costs one click; for deployments behind Safe-Links-style gateways.
+// On failure (already used, expired, etc.) we surface a message + a button
+// back to /login.
 export const Route = createFileRoute("/auth/email/$email/$code")({
   beforeLoad: async () => {
     // Already signed in — skip the verify and bounce home. `reloadDocument`
@@ -20,39 +26,48 @@ export const Route = createFileRoute("/auth/email/$email/$code")({
     const session = await getSession();
     if (session) throw redirect({ to: "/", reloadDocument: true });
   },
+  loader: async () => ({ requireConfirmation: await getRequireLinkConfirmation() }),
   component: VerifyPage,
 });
 
 function VerifyPage() {
   const { email, code } = Route.useParams();
+  const { requireConfirmation } = Route.useLoaderData();
   const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
   // Guards a single component instance from firing the verify POST twice
-  // (notably React's dev-mode double-effect). Separate navigations get a
-  // fresh component + fresh ref and are unaffected.
+  // (React's dev-mode double-effect, or a double button tap). Separate
+  // navigations get a fresh component + fresh ref and are unaffected.
   const fired = useRef(false);
 
-  useEffect(() => {
+  const verify = async () => {
     if (fired.current) return;
     fired.current = true;
-    void (async () => {
-      const res = await authClient.signIn.emailOtp({ email, otp: code });
-      if (res.error) {
-        // All failure modes (already-used, expired, never-existed) collapse
-        // here — the recovery is the same in every case: request a new link.
-        setError("This link is no longer valid, please try again.");
-        return;
-      }
-      // Hard-load to "/" — root's mount-time effect broadcasts the
-      // logged-in signal with the user id. Broadcasting from this page
-      // would lack a userId and trip the root listener's user-switch
-      // detection → reload loop.
-      window.location.replace("/");
-    })();
+    setPending(true);
+    const res = await authClient.signIn.emailOtp({ email, otp: code });
+    if (res.error) {
+      // All failure modes (already-used, expired, never-existed) collapse
+      // here — the recovery is the same in every case: request a new link.
+      setError("This link is no longer valid, please try again.");
+      setPending(false);
+      return;
+    }
+    // Hard-load to "/" — root's mount-time effect broadcasts the logged-in
+    // signal with the user id. Broadcasting from this page would lack a
+    // userId and trip the root listener's user-switch detection → reload loop.
+    window.location.replace("/");
+  };
+
+  // Zero-click mode fires on mount; confirmation mode waits for the click.
+  useEffect(() => {
+    if (!requireConfirmation) void verify();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Truly blank during the in-flight POST so the redirect feels instant.
-  if (!error) return null;
+  // Auto-fire mode renders nothing until/unless it errors, so the redirect
+  // feels instant.
+  if (!error && !requireConfirmation) return null;
+
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <div className="fixed top-3 right-4 flex items-center gap-3">
@@ -61,10 +76,30 @@ function VerifyPage() {
       </div>
       <div className="w-full max-w-sm -mt-16 animate-in fade-in duration-100">
         <h1 className="mb-5 text-center text-5xl italic font-bold tracking-tight">Field Tools</h1>
-        <p className="mb-8 text-center text-[16px] text-muted-foreground">{error}</p>
-        <Link to="/login" className="block">
-          <Button className="h-10 w-full text-[16px]">Return to login</Button>
-        </Link>
+        {error ? (
+          <>
+            <p className="mb-8 text-center text-[16px] text-muted-foreground">{error}</p>
+            <Link to="/login" className="block">
+              <Button variant="outline" className="h-10 w-full text-[16px]">
+                Return to login
+              </Button>
+            </Link>
+          </>
+        ) : (
+          <>
+            <p className="mb-8 text-center text-[16px] text-muted-foreground">
+              Click below to finish logging in.
+            </p>
+            <Button
+              type="button"
+              onClick={() => void verify()}
+              loading={pending}
+              className="h-10 w-full text-[16px]"
+            >
+              Log in to Field Tools
+            </Button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -17,19 +17,16 @@ export const Route = createFileRoute("/login")({
   component: LoginPage,
 });
 
-// Four-state flow:
-//   email   – user types their email and submits
-//   sent    – we sent the email; user can wait for the link OR click "Enter
-//             code manually" to switch to the code-entry state
-//   code    – user pastes the OTP from the email and submits
-//   invalid – code didn't verify (typo, expired, already-burned by scanner)
-// "Back to login" links + the invalid-state button all reset to `email`.
-type Step = "email" | "sent" | "code" | "invalid";
+// Two-state flow:
+//   email – user types their email and submits
+//   sent  – we sent the login link; user clicks through from their inbox.
+// Verification happens entirely on the verify page (the email link); there's
+// no manual code-entry path — the link is the only channel.
+type Step = "email" | "sent";
 
 function LoginPage() {
   const [step, setStep] = useState<Step>("email");
   const [email, setEmail] = useState("");
-  const [code, setCode] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   // Cross-tab login signal — see __root's beforeLoad.
@@ -43,22 +40,12 @@ function LoginPage() {
     return () => channel.close();
   }, []);
 
-  // 600ms floor on both mutations so button-state transitions read as
-  // intentional even on fast networks.
+  // 600ms floor so the button-state transition reads as intentional even on
+  // fast networks.
   const sendCode = useMutation({
     mutationFn: async (target: string) => {
       const [res] = await Promise.all([
         authClient.emailOtp.sendVerificationOtp({ email: target, type: "sign-in" }),
-        new Promise((r) => setTimeout(r, 600)),
-      ]);
-      return res;
-    },
-  });
-
-  const verifyCode = useMutation({
-    mutationFn: async (input: { email: string; otp: string }) => {
-      const [res] = await Promise.all([
-        authClient.signIn.emailOtp(input),
         new Promise((r) => setTimeout(r, 600)),
       ]);
       return res;
@@ -77,24 +64,10 @@ function LoginPage() {
     setStep("sent");
   };
 
-  const onSubmitCode = async (e: FormEvent) => {
-    e.preventDefault();
-    const res = await verifyCode.mutateAsync({ email, otp: code.trim() });
-    if (res.error) {
-      setStep("invalid");
-      return;
-    }
-    // Hard-load to "/" — root's mount-time effect broadcasts the
-    // logged-in signal (with userId). Broadcasting from here would
-    // lack a userId and trip the root listener's user-switch reload.
-    window.location.replace("/");
-  };
-
-  // "Back to login" / "Return to login" — full reset.
+  // "Back to login" — full reset.
   const reset = () => {
     setStep("email");
     setEmail("");
-    setCode("");
     setError(null);
   };
 
@@ -120,18 +93,8 @@ function LoginPage() {
             onSubmit={onSubmitEmail}
             error={error}
           />
-        ) : step === "sent" ? (
-          <SentStep email={email} onEnterCode={() => setStep("code")} onBack={reset} />
-        ) : step === "code" ? (
-          <CodeStep
-            code={code}
-            setCode={setCode}
-            pending={verifyCode.isPending}
-            onSubmit={onSubmitCode}
-            onBack={reset}
-          />
         ) : (
-          <InvalidStep onReturn={reset} />
+          <SentStep email={email} onBack={reset} />
         )}
       </div>
     </div>
@@ -183,96 +146,16 @@ function EmailStep({
   );
 }
 
-function SentStep({
-  email,
-  onEnterCode,
-  onBack,
-}: {
-  email: string;
-  onEnterCode: () => void;
-  onBack: () => void;
-}) {
+function SentStep({ email, onBack }: { email: string; onBack: () => void }) {
   return (
     <>
       <p className="mb-8 text-center text-[16px] text-muted-foreground">
         We've sent a temporary login link, please check your inbox at{" "}
-        <span className="text-foreground">{email}</span>. If you have trouble with magic links, you
-        can also check the email for a code and click below to manually enter it.
+        <span className="text-foreground">{email}</span>.
       </p>
-      <Button
-        variant="outline"
-        type="button"
-        onClick={onEnterCode}
-        className="h-10 w-full text-[16px]"
-      >
-        Enter code manually
-      </Button>
-      <BackToLogin onClick={onBack} />
-    </>
-  );
-}
-
-function CodeStep({
-  code,
-  setCode,
-  pending,
-  onSubmit,
-  onBack,
-}: {
-  code: string;
-  setCode: (v: string) => void;
-  pending: boolean;
-  onSubmit: (e: FormEvent) => void;
-  onBack: () => void;
-}) {
-  return (
-    <>
-      <p className="mb-8 text-center text-[16px] text-muted-foreground">
-        Check your email for a temporary login code and enter it below.
-      </p>
-      <form onSubmit={onSubmit} className="flex flex-col gap-3">
-        <Input
-          type="text"
-          placeholder="Login code (6 digits)"
-          value={code}
-          onChange={(e) => setCode(e.target.value)}
-          required
-          autoFocus
-          autoComplete="one-time-code"
-          className="text-[16px] tabular-nums"
-        />
-        <Button type="submit" className="h-10 disabled:opacity-100 text-[16px]" disabled={pending}>
-          {pending ? "Signing in…" : "Continue with login code"}
-        </Button>
-      </form>
-      <BackToLogin onClick={onBack} />
-    </>
-  );
-}
-
-function InvalidStep({ onReturn }: { onReturn: () => void }) {
-  return (
-    <>
-      <p className="mb-8 text-center text-[16px] text-muted-foreground">
-        This code is no longer valid, please try again.
-      </p>
-      <Button type="button" onClick={onReturn} className="h-10 w-full text-[16px]">
-        Return to login
-      </Button>
-    </>
-  );
-}
-
-function BackToLogin({ onClick }: { onClick: () => void }) {
-  return (
-    <div className="mt-4 text-center">
-      <button
-        type="button"
-        onClick={onClick}
-        className="text-sm text-muted-foreground hover:text-foreground"
-      >
+      <Button variant="outline" type="button" onClick={onBack} className="h-10 w-full text-[16px]">
         Back to login
-      </button>
-    </div>
+      </Button>
+    </>
   );
 }


### PR DESCRIPTION
This PR adds a more robust fix for fighting corporate email scanners. The new setup has two layers:

- Same as before, the main "magic link" flow uses an OTP and route that requires a POST rather than just a GET, so this alone will defeat GET based scanners
- With the new env var flag AUTH_REQUIRE_LINK_CONFIRMATION set to 1, the "magic link" will route to a confirmation page that requires a human click to proceed. This should defeat scanners that run javascript.

Previously, we included a token as a backup, but JS-based scanners burned the token so it didn't actually work as a fallback as intended. This should be more robust, but we're putting it behind a flag because most deployments won't require it.