### PR TITLE
feat: segment by results

### DIFF
--- a/apps/data/src/dsl/compile.py
+++ b/apps/data/src/dsl/compile.py
@@ -19,7 +19,8 @@ from .criteria import (
     AgeRangeFieldDef,
     AgeRangeFilter,
     AllFilter,
-    CanvassResultFilter,
+    CanvassOutcomeFilter,
+    CanvassResponseFilter,
     Criteria,
     DateRangeFieldDef,
     DateRangeFilter,
@@ -201,9 +202,9 @@ def _filter_clause(f: Filter, params: list[Any]) -> str:
         placeholders = ", ".join("?" for _ in f.ids)
         params.extend(f.ids)
         return f"external_id IN ({placeholders})"
-    if isinstance(f, CanvassResultFilter):
+    if isinstance(f, (CanvassOutcomeFilter, CanvassResponseFilter)):
         # Should have been reduced to a PersonIdSetFilter in resolve.py.
-        raise CriteriaError("CanvassResultFilter reached the compiler unresolved")
+        raise CriteriaError(f"{type(f).__name__} reached the compiler unresolved")
     raise CriteriaError(f"Unknown filter kind: {type(f).__name__}")
 
 

--- a/apps/data/src/dsl/compile.py
+++ b/apps/data/src/dsl/compile.py
@@ -19,6 +19,7 @@ from .criteria import (
     AgeRangeFieldDef,
     AgeRangeFilter,
     AllFilter,
+    CanvassResultFilter,
     Criteria,
     DateRangeFieldDef,
     DateRangeFilter,
@@ -28,6 +29,7 @@ from .criteria import (
     Filter,
     KeyFilter,
     NestedFilter,
+    PersonIdSetFilter,
     TextFieldDef,
     TextFilter,
     TextMultiFieldDef,
@@ -191,6 +193,17 @@ def _filter_clause(f: Filter, params: list[Any]) -> str:
         # Empty inner → 1=1 to match the standalone "empty segment matches everyone" semantic.
         inner = _criteria_bool_expr(f.criteria, params)
         return f"({inner})" if inner else "1=1"
+    if isinstance(f, PersonIdSetFilter):
+        # Resolved canvass / operational-data filter: a literal person set.
+        # Empty set → 1=0 (no one matched), distinct from an inactive filter.
+        if not f.ids:
+            return "1=0"
+        placeholders = ", ".join("?" for _ in f.ids)
+        params.extend(f.ids)
+        return f"external_id IN ({placeholders})"
+    if isinstance(f, CanvassResultFilter):
+        # Should have been reduced to a PersonIdSetFilter in resolve.py.
+        raise CriteriaError("CanvassResultFilter reached the compiler unresolved")
     raise CriteriaError(f"Unknown filter kind: {type(f).__name__}")
 
 

--- a/apps/data/src/dsl/criteria.py
+++ b/apps/data/src/dsl/criteria.py
@@ -93,19 +93,32 @@ class AddressFilter(BaseModel):
     zip: str  # noqa: A003
 
 
-class CanvassResultFilter(BaseModel):
+class CanvassOutcomeFilter(BaseModel):
     """Prior canvass dispositions read back from canvass_events. Matches a
     person if any of their per-turf current results has an outcome in
     `outcomes`. Resolved to a `PersonIdSetFilter` by `resolve_canvass_refs`
     before SQL compilation — the compiler never sees this kind."""
 
-    kind: Literal["canvass-result"]
+    kind: Literal["canvass-outcome"]
     outcomes: list[str]
+
+
+class CanvassResponseFilter(BaseModel):
+    """A prior canvass answer to a specific question. Matches a person if any
+    of their per-turf current results answered `question_id` with one of
+    `option_ids`. Resolved to a `PersonIdSetFilter` before SQL compilation —
+    the compiler never sees this kind."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    kind: Literal["canvass-response"]
+    question_id: str = Field(validation_alias="questionId")
+    option_ids: list[str] = Field(validation_alias="optionIds")
 
 
 class PersonIdSetFilter(BaseModel):
     """A literal set of person `external_id`s. Produced by resolving an
-    operational-data filter (e.g. CanvassResultFilter) down to the persons
+    operational-data filter (e.g. CanvassOutcomeFilter) down to the persons
     that match; compiles to ``external_id IN (...)``. Never persisted —
     only exists post-resolution, like NestedFilter."""
 
@@ -143,7 +156,8 @@ Filter = Annotated[
     | DateRangeFilter
     | VotingHistoryFilter
     | AddressFilter
-    | CanvassResultFilter
+    | CanvassOutcomeFilter
+    | CanvassResponseFilter
     | PersonIdSetFilter
     | NestedFilter
     | SegmentFilter,

--- a/apps/data/src/dsl/criteria.py
+++ b/apps/data/src/dsl/criteria.py
@@ -93,6 +93,26 @@ class AddressFilter(BaseModel):
     zip: str  # noqa: A003
 
 
+class CanvassResultFilter(BaseModel):
+    """Prior canvass dispositions read back from canvass_events. Matches a
+    person if any of their per-turf current results has an outcome in
+    `outcomes`. Resolved to a `PersonIdSetFilter` by `resolve_canvass_refs`
+    before SQL compilation — the compiler never sees this kind."""
+
+    kind: Literal["canvass-result"]
+    outcomes: list[str]
+
+
+class PersonIdSetFilter(BaseModel):
+    """A literal set of person `external_id`s. Produced by resolving an
+    operational-data filter (e.g. CanvassResultFilter) down to the persons
+    that match; compiles to ``external_id IN (...)``. Never persisted —
+    only exists post-resolution, like NestedFilter."""
+
+    kind: Literal["person-id-set"]
+    ids: list[str]
+
+
 class NestedFilter(BaseModel):
     """Wraps a complete sub-criteria as a single filter. Produced by
     `expand_segment_refs` when resolving segment references; the SQL
@@ -123,6 +143,8 @@ Filter = Annotated[
     | DateRangeFilter
     | VotingHistoryFilter
     | AddressFilter
+    | CanvassResultFilter
+    | PersonIdSetFilter
     | NestedFilter
     | SegmentFilter,
     Field(discriminator="kind"),

--- a/apps/data/src/dsl/resolve.py
+++ b/apps/data/src/dsl/resolve.py
@@ -9,7 +9,7 @@ Criteria that do reference segments pay the lookup once per request
 
 Operational-data-aware kinds each contribute a short-circuit check plus a
 resolution pass here: `SegmentFilter` inlines to `NestedFilter`, and
-`CanvassResultFilter` reduces the canvass log to the matching person-id set
+`CanvassOutcomeFilter` reduces the canvass log to the matching person-id set
 (`PersonIdSetFilter`). Segments are expanded first so a referenced segment
 that itself contains a canvass filter gets inlined before canvass resolution
 walks the tree.
@@ -23,7 +23,8 @@ from typing import TYPE_CHECKING
 from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres
 
 from .criteria import (
-    CanvassResultFilter,
+    CanvassOutcomeFilter,
+    CanvassResponseFilter,
     Criteria,
     NestedFilter,
     PersonIdSetFilter,
@@ -71,7 +72,7 @@ def _has_segment_refs(criteria: Criteria) -> bool:
 def _has_canvass_refs(criteria: Criteria) -> bool:
     for step in criteria.steps:
         f = step.filter
-        if isinstance(f, CanvassResultFilter):
+        if isinstance(f, (CanvassOutcomeFilter, CanvassResponseFilter)):
             return True
         if isinstance(f, NestedFilter) and _has_canvass_refs(f.criteria):
             return True
@@ -83,17 +84,23 @@ def _resolve_canvass_refs(
     conn: duckdb.DuckDBPyConnection,
     org_slug: str,
 ) -> Criteria:
-    """Replace each `CanvassResultFilter` with the `PersonIdSetFilter` of
-    persons whose current result matches. A filter with no outcomes selected
-    is inactive — dropped entirely, exactly as the compiler skips an empty
-    filter clause (no effect under any verb), avoiding an invalid `IN ()`."""
+    """Replace each canvass filter (`CanvassOutcomeFilter`,
+    `CanvassResponseFilter`) with the `PersonIdSetFilter` of persons whose
+    current result matches. A filter with nothing selected is inactive —
+    dropped entirely, exactly as the compiler skips an empty filter clause (no
+    effect under any verb), avoiding an invalid `IN ()`."""
     new_steps: list[Step] = []
     for step in criteria.steps:
         f = step.filter
-        if isinstance(f, CanvassResultFilter):
+        if isinstance(f, CanvassOutcomeFilter):
             if not f.outcomes:
                 continue
-            ids = _canvass_person_ids(conn, org_slug, f.outcomes)
+            ids = _canvass_outcome_person_ids(conn, org_slug, f.outcomes)
+            new_steps.append(Step(verb=step.verb, filter=PersonIdSetFilter(kind="person-id-set", ids=ids)))
+        elif isinstance(f, CanvassResponseFilter):
+            if not f.option_ids:
+                continue
+            ids = _canvass_response_person_ids(conn, org_slug, f.question_id, f.option_ids)
             new_steps.append(Step(verb=step.verb, filter=PersonIdSetFilter(kind="person-id-set", ids=ids)))
         elif isinstance(f, NestedFilter):
             inner = _resolve_canvass_refs(f.criteria, conn, org_slug)
@@ -103,7 +110,7 @@ def _resolve_canvass_refs(
     return Criteria(steps=new_steps)
 
 
-def _canvass_person_ids(
+def _canvass_outcome_person_ids(
     conn: duckdb.DuckDBPyConnection,
     org_slug: str,
     outcomes: list[str],
@@ -137,6 +144,47 @@ def _canvass_person_ids(
         WHERE outcome IN ({placeholders})
         """,
         [org_slug, *outcomes],
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _canvass_response_person_ids(
+    conn: duckdb.DuckDBPyConnection,
+    org_slug: str,
+    question_id: str,
+    option_ids: list[str],
+) -> list[str]:
+    """Persons (by `external_id`) whose *current* result in some turf answered
+    `question_id` with one of `option_ids`. Same latest-per-(turf, person)
+    reduction as `_canvass_outcome_person_ids`; then overlaps the question's selected
+    option ids against the filter set. Free-text answers and unanswered
+    questions never match (no `optionIds` → NULL list). v1 is existential
+    across turfs, unscoped — see `_canvass_outcome_person_ids`."""
+    # Built here but passed as a bind param (never interpolated into the SQL),
+    # so the question id can't inject. Same json_extract idiom as the outcome
+    # query above, just pulling an array rather than a scalar.
+    options_path = f'$.responses."{question_id}".optionIds'
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT person_id FROM (
+            SELECT
+                e.person_id,
+                CAST(json_extract(CAST(e.payload AS VARCHAR), ?) AS VARCHAR[]) AS selected
+            FROM {OPERATIONAL_PG_ALIAS}.public.canvass_events e
+            JOIN {OPERATIONAL_PG_ALIAS}.public.turfs t ON t.turf_id = e.turf_id
+            JOIN {OPERATIONAL_PG_ALIAS}.public.campaigns c ON c.campaign_id = t.campaign_id
+            JOIN {OPERATIONAL_PG_ALIAS}.public.organizations o
+                ON o.organization_id = c.organization_id
+            WHERE e.kind = 'result'
+                AND e.person_id IS NOT NULL
+                AND o.slug = ?
+            QUALIFY row_number() OVER (
+                PARTITION BY e.turf_id, e.person_id ORDER BY e.sequence DESC
+            ) = 1
+        )
+        WHERE list_has_any(selected, ?)
+        """,
+        [options_path, org_slug, option_ids],
     ).fetchall()
     return [r[0] for r in rows]
 

--- a/apps/data/src/dsl/resolve.py
+++ b/apps/data/src/dsl/resolve.py
@@ -7,9 +7,12 @@ filter kinds skip the operational PG attach + segments lookup entirely.
 Criteria that do reference segments pay the lookup once per request
 (amortized further by DuckDB's cached connection / `ATTACH IF NOT EXISTS`).
 
-When other operational-data-aware filter kinds land (canvass-result
-filter etc.), each contributes its own short-circuit check + resolution
-step here.
+Operational-data-aware kinds each contribute a short-circuit check plus a
+resolution pass here: `SegmentFilter` inlines to `NestedFilter`, and
+`CanvassResultFilter` reduces the canvass log to the matching person-id set
+(`PersonIdSetFilter`). Segments are expanded first so a referenced segment
+that itself contains a canvass filter gets inlined before canvass resolution
+walks the tree.
 """
 
 from __future__ import annotations
@@ -19,7 +22,14 @@ from typing import TYPE_CHECKING
 
 from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres
 
-from .criteria import Criteria, NestedFilter, SegmentFilter
+from .criteria import (
+    CanvassResultFilter,
+    Criteria,
+    NestedFilter,
+    PersonIdSetFilter,
+    SegmentFilter,
+    Step,
+)
 from .expand import SegmentLike, expand_segment_refs
 
 if TYPE_CHECKING:
@@ -33,14 +43,19 @@ def resolve_criteria(
     settings: Settings,
     org_slug: str,
 ) -> Criteria:
-    """Resolve any operational-data-aware filters in `criteria`. Today that's
-    `SegmentFilter`; new kinds plug in here. Returns the original criteria
-    unchanged if it doesn't need resolution."""
-    if not _has_segment_refs(criteria):
+    """Resolve any operational-data-aware filters in `criteria`. Returns the
+    original criteria unchanged if it doesn't need resolution."""
+    needs_segments = _has_segment_refs(criteria)
+    needs_canvass = _has_canvass_refs(criteria)
+    if not needs_segments and not needs_canvass:
         return criteria
     attach_operational_postgres(conn, settings)
-    segments = _load_segments_for_org(conn, org_slug)
-    return expand_segment_refs(criteria, segments)
+    if needs_segments:
+        segments = _load_segments_for_org(conn, org_slug)
+        criteria = expand_segment_refs(criteria, segments)
+    if needs_canvass:
+        criteria = _resolve_canvass_refs(criteria, conn, org_slug)
+    return criteria
 
 
 def _has_segment_refs(criteria: Criteria) -> bool:
@@ -51,6 +66,79 @@ def _has_segment_refs(criteria: Criteria) -> bool:
         if isinstance(f, NestedFilter) and _has_segment_refs(f.criteria):
             return True
     return False
+
+
+def _has_canvass_refs(criteria: Criteria) -> bool:
+    for step in criteria.steps:
+        f = step.filter
+        if isinstance(f, CanvassResultFilter):
+            return True
+        if isinstance(f, NestedFilter) and _has_canvass_refs(f.criteria):
+            return True
+    return False
+
+
+def _resolve_canvass_refs(
+    criteria: Criteria,
+    conn: duckdb.DuckDBPyConnection,
+    org_slug: str,
+) -> Criteria:
+    """Replace each `CanvassResultFilter` with the `PersonIdSetFilter` of
+    persons whose current result matches. A filter with no outcomes selected
+    is inactive — dropped entirely, exactly as the compiler skips an empty
+    filter clause (no effect under any verb), avoiding an invalid `IN ()`."""
+    new_steps: list[Step] = []
+    for step in criteria.steps:
+        f = step.filter
+        if isinstance(f, CanvassResultFilter):
+            if not f.outcomes:
+                continue
+            ids = _canvass_person_ids(conn, org_slug, f.outcomes)
+            new_steps.append(Step(verb=step.verb, filter=PersonIdSetFilter(kind="person-id-set", ids=ids)))
+        elif isinstance(f, NestedFilter):
+            inner = _resolve_canvass_refs(f.criteria, conn, org_slug)
+            new_steps.append(Step(verb=step.verb, filter=NestedFilter(kind="nested", criteria=inner)))
+        else:
+            new_steps.append(step)
+    return Criteria(steps=new_steps)
+
+
+def _canvass_person_ids(
+    conn: duckdb.DuckDBPyConnection,
+    org_slug: str,
+    outcomes: list[str],
+) -> list[str]:
+    """Persons (by `external_id`) whose *current* result in some turf has an
+    outcome in `outcomes`. Reduces the append-only log to the latest result
+    per `(turf, person)` by `sequence` (the snapshot model makes that the whole
+    reduction — newest result is the entity's full current disposition), then
+    keeps those whose outcome is selected. Org-scoped via turf → campaign →
+    organization for tenant isolation. v1 is existential across turfs (no
+    recency / campaign / cross-turf-collapse knobs yet)."""
+    placeholders = ", ".join("?" for _ in outcomes)
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT person_id FROM (
+            SELECT
+                e.person_id,
+                json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome') AS outcome
+            FROM {OPERATIONAL_PG_ALIAS}.public.canvass_events e
+            JOIN {OPERATIONAL_PG_ALIAS}.public.turfs t ON t.turf_id = e.turf_id
+            JOIN {OPERATIONAL_PG_ALIAS}.public.campaigns c ON c.campaign_id = t.campaign_id
+            JOIN {OPERATIONAL_PG_ALIAS}.public.organizations o
+                ON o.organization_id = c.organization_id
+            WHERE e.kind = 'result'
+                AND e.person_id IS NOT NULL
+                AND o.slug = ?
+            QUALIFY row_number() OVER (
+                PARTITION BY e.turf_id, e.person_id ORDER BY e.sequence DESC
+            ) = 1
+        )
+        WHERE outcome IN ({placeholders})
+        """,
+        [org_slug, *outcomes],
+    ).fetchall()
+    return [r[0] for r in rows]
 
 
 def _load_segments_for_org(conn: duckdb.DuckDBPyConnection, org_slug: str) -> dict[str, SegmentLike]:

--- a/apps/data/tests/test_compile.py
+++ b/apps/data/tests/test_compile.py
@@ -13,7 +13,8 @@ from src.dsl.criteria import (
     AddressFilter,
     AgeRangeFilter,
     AllFilter,
-    CanvassResultFilter,
+    CanvassOutcomeFilter,
+    CanvassResponseFilter,
     Criteria,
     DateRangeFilter,
     EnumFilter,
@@ -633,7 +634,7 @@ def test_nested_filter_compiles_recursively() -> None:
 
 # ---------------------------------------------------------------------------
 # PersonIdSetFilter — produced by resolving operational-data filters (e.g.
-# CanvassResultFilter) to a literal set of person external_ids.
+# CanvassOutcomeFilter) to a literal set of person external_ids.
 # ---------------------------------------------------------------------------
 
 
@@ -678,12 +679,22 @@ def test_person_id_set_remove_composes_as_and_not() -> None:
     assert params == ["democratic", "abc"]
 
 
-def test_unresolved_canvass_result_filter_raises() -> None:
-    # CanvassResultFilter must be reduced to a PersonIdSetFilter in resolve.py
+def test_unresolved_canvass_outcome_filter_raises() -> None:
+    # CanvassOutcomeFilter must be reduced to a PersonIdSetFilter in resolve.py
     # before compilation; reaching the compiler is a bug.
     with pytest.raises(CriteriaError):
         criteria_to_where(
-            _narrow(CanvassResultFilter(kind="canvass-result", outcomes=["canvassed"])),
+            _narrow(CanvassOutcomeFilter(kind="canvass-outcome", outcomes=["canvassed"])),
+            None,
+            [],
+        )
+
+
+def test_unresolved_canvass_response_filter_raises() -> None:
+    # Same contract as the result filter — must be resolved before compilation.
+    with pytest.raises(CriteriaError):
+        criteria_to_where(
+            _narrow(CanvassResponseFilter(kind="canvass-response", questionId="q1", optionIds=["supportive"])),
             None,
             [],
         )

--- a/apps/data/tests/test_compile.py
+++ b/apps/data/tests/test_compile.py
@@ -13,11 +13,13 @@ from src.dsl.criteria import (
     AddressFilter,
     AgeRangeFilter,
     AllFilter,
+    CanvassResultFilter,
     Criteria,
     DateRangeFilter,
     EnumFilter,
     KeyFilter,
     NestedFilter,
+    PersonIdSetFilter,
     Step,
     TextFilter,
     TextMultiFilter,
@@ -627,3 +629,61 @@ def test_nested_filter_compiles_recursively() -> None:
     )
     assert where == "WHERE ((enrollment IN (?)))"
     assert params == ["democratic"]
+
+
+# ---------------------------------------------------------------------------
+# PersonIdSetFilter — produced by resolving operational-data filters (e.g.
+# CanvassResultFilter) to a literal set of person external_ids.
+# ---------------------------------------------------------------------------
+
+
+def test_person_id_set_compiles_to_external_id_in() -> None:
+    params: list = []
+    where = criteria_to_where(
+        _narrow(PersonIdSetFilter(kind="person-id-set", ids=["abc", "def"])),
+        None,
+        params,
+    )
+    assert where == "WHERE external_id IN (?, ?)"
+    assert params == ["abc", "def"]
+
+
+def test_empty_person_id_set_matches_nothing() -> None:
+    # Distinct from an inactive filter: an empty *resolved* set means "no
+    # person matched", so it must compile to 1=0 (not drop out).
+    params: list = []
+    where = criteria_to_where(
+        _narrow(PersonIdSetFilter(kind="person-id-set", ids=[])),
+        None,
+        params,
+    )
+    assert where == "WHERE 1=0"
+    assert params == []
+
+
+def test_person_id_set_remove_composes_as_and_not() -> None:
+    # The canonical "remove anyone canvassed" shape.
+    params: list = []
+    where = criteria_to_where(
+        Criteria(
+            steps=[
+                Step(verb="narrow", filter=EnumFilter(kind="enum", key="enrollment", values=["democratic"])),
+                Step(verb="remove", filter=PersonIdSetFilter(kind="person-id-set", ids=["abc"])),
+            ]
+        ),
+        None,
+        params,
+    )
+    assert where == "WHERE (enrollment IN (?)) AND NOT (external_id IN (?))"
+    assert params == ["democratic", "abc"]
+
+
+def test_unresolved_canvass_result_filter_raises() -> None:
+    # CanvassResultFilter must be reduced to a PersonIdSetFilter in resolve.py
+    # before compilation; reaching the compiler is a bug.
+    with pytest.raises(CriteriaError):
+        criteria_to_where(
+            _narrow(CanvassResultFilter(kind="canvass-result", outcomes=["canvassed"])),
+            None,
+            [],
+        )

--- a/apps/web/src/components/question-editor-parts.tsx
+++ b/apps/web/src/components/question-editor-parts.tsx
@@ -86,6 +86,12 @@ export function ResponseOptionsEditor({ questionId }: { questionId: string }) {
     );
   };
 
+  // The option mutations below patch the ["question", id] detail cache directly;
+  // options also feed the questions-with-options projection under the
+  // ["questions"] prefix, so invalidate that on settle to keep them in sync.
+  const refreshQuestionProjections = () =>
+    void queryClient.invalidateQueries({ queryKey: ["questions"] });
+
   // Snapshot the option ids present at mount; anything not in the set
   // was added during the session, used to gate the X button's mount
   // fade-in. Bounded by mount-time count; doesn't grow with usage.
@@ -97,6 +103,7 @@ export function ResponseOptionsEditor({ questionId }: { questionId: string }) {
 
   const addOption = useMutation({
     mutationFn: () => client.questions.addResponseOption({ questionId, text: "" }),
+    onSettled: refreshQuestionProjections,
     onMutate: () => {
       const tempId = `temp-${crypto.randomUUID()}`;
       setDetail((d) => ({
@@ -127,6 +134,7 @@ export function ResponseOptionsEditor({ questionId }: { questionId: string }) {
   const removeOption = useMutation({
     mutationFn: (responseOptionId: string) =>
       client.questions.removeResponseOption({ questionId, responseOptionId }),
+    onSettled: refreshQuestionProjections,
     onMutate: (responseOptionId) => {
       const prev = queryClient.getQueryData<QuestionDetail>(["question", questionId]);
       setDetail((d) => ({
@@ -148,6 +156,7 @@ export function ResponseOptionsEditor({ questionId }: { questionId: string }) {
         questionId,
         responseOptionIds: ids,
       }),
+    onSettled: refreshQuestionProjections,
     onError: (e) => {
       console.error("questions.reorderResponseOptions failed", e);
       toast.error(e.message);
@@ -160,6 +169,7 @@ export function ResponseOptionsEditor({ questionId }: { questionId: string }) {
   const updateOptionText = useMutation({
     mutationFn: (input: { responseOptionId: string; text: string }) =>
       client.questions.updateResponseOptionText({ questionId, ...input }),
+    onSettled: refreshQuestionProjections,
     onMutate: ({ responseOptionId, text }) => {
       setDetail((d) => ({
         ...d,
@@ -232,7 +242,7 @@ export function ResponseOptionsEditor({ questionId }: { questionId: string }) {
       )}
       <motion.div
         layout
-        transition={{ type: "tween", duration: 0.2, ease: "easeOut" }}
+        transition={{ type: "tween", duration: 0.15, ease: "easeOut" }}
         className="flex items-center gap-1.5"
       >
         <Button

--- a/apps/web/src/lib/filters.ts
+++ b/apps/web/src/lib/filters.ts
@@ -62,15 +62,28 @@ export type AddressFilter = {
   zip: string;
 };
 
-// Canvass-result filter — reads prior canvass dispositions back out of
+// Canvass-outcome filter — reads prior canvass dispositions back out of
 // canvass_events; it is NOT a person-row column. Matches a person if any
 // of their per-turf current results has an outcome in `outcomes`.
 // Resolved server-side to a person-id set before SQL compilation (see
 // apps/data/src/dsl/resolve.py), the same way SegmentFilter is.
-export type CanvassResultFilter = {
-  kind: "canvass-result";
-  key: "canvass_result";
+export type CanvassOutcomeFilter = {
+  kind: "canvass-outcome";
+  key: "canvass_outcome";
   outcomes: string[];
+};
+
+// Canvass-response filter — matches a person if any of their per-turf current
+// results answered `questionId` with one of `optionIds`. Like
+// CanvassOutcomeFilter it reads canvass_events and is resolved server-side to a
+// person-id set (see apps/data/src/dsl/resolve.py). Select-type questions
+// only; the option set is fetched live by the editor, so the catalog entry
+// carries no static values.
+export type CanvassResponseFilter = {
+  kind: "canvass-response";
+  key: "canvass_response";
+  questionId: string | null;
+  optionIds: string[];
 };
 
 // Reference to another segment by id. Authored form — what the user
@@ -100,7 +113,8 @@ export type Filter =
   | DateRangeFilter
   | VotingHistoryFilter
   | AddressFilter
-  | CanvassResultFilter
+  | CanvassOutcomeFilter
+  | CanvassResponseFilter
   | SegmentFilter
   | NestedFilter;
 
@@ -159,10 +173,15 @@ export type FilterDef =
       label: string;
     }
   | {
-      kind: "canvass-result";
-      key: "canvass_result";
+      kind: "canvass-outcome";
+      key: "canvass_outcome";
       label: string;
       values: ReadonlyArray<{ value: string; label?: string }>;
+    }
+  | {
+      kind: "canvass-response";
+      key: "canvass_response";
+      label: string;
     }
   | {
       kind: "segment";
@@ -279,9 +298,9 @@ export const FILTER_SECTIONS: ReadonlyArray<ReadonlyArray<FilterDef>> = [
   // like address_not_found / inaccessible aren't person results).
   [
     {
-      kind: "canvass-result",
-      key: "canvass_result",
-      label: "Canvass result",
+      kind: "canvass-outcome",
+      key: "canvass_outcome",
+      label: "Canvass Outcome",
       values: [
         { value: "canvassed", label: "Canvassed" },
         { value: "not_home", label: "Not home" },
@@ -290,6 +309,7 @@ export const FILTER_SECTIONS: ReadonlyArray<ReadonlyArray<FilterDef>> = [
         { value: "moved", label: "Moved" },
       ],
     },
+    { kind: "canvass-response", key: "canvass_response", label: "Canvass Response" },
   ],
   // Composite — reference another segment by id.
   [{ kind: "segment", key: "segment", label: "Segment" }],
@@ -317,8 +337,10 @@ export function emptyFilterFor(def: FilterDef): Filter {
   if (def.kind === "date-range") return { kind: "date-range", key: def.key, min: null, max: null };
   if (def.kind === "address")
     return { kind: "address", key: "address", line1: "", city: "", state: "", zip: "" };
-  if (def.kind === "canvass-result")
-    return { kind: "canvass-result", key: "canvass_result", outcomes: [] };
+  if (def.kind === "canvass-outcome")
+    return { kind: "canvass-outcome", key: "canvass_outcome", outcomes: [] };
+  if (def.kind === "canvass-response")
+    return { kind: "canvass-response", key: "canvass_response", questionId: null, optionIds: [] };
   if (def.kind === "segment") return { kind: "segment", key: "segment", segmentId: null };
   // Voting history default: "voted in 1+ recent primaries" (single prime).
   return {
@@ -346,7 +368,8 @@ export function isActiveFilter(f: Filter): boolean {
       f.state.trim().length > 0 ||
       f.zip.trim().length > 0
     );
-  if (f.kind === "canvass-result") return f.outcomes.length > 0;
+  if (f.kind === "canvass-outcome") return f.outcomes.length > 0;
+  if (f.kind === "canvass-response") return f.questionId != null && f.optionIds.length > 0;
   if (f.kind === "segment") return f.segmentId != null;
   if (f.kind === "nested") return f.criteria.steps.length > 0;
   // voting-history-count: active when window and count are non-degenerate.
@@ -355,6 +378,22 @@ export function isActiveFilter(f: Filter): boolean {
 
 export function isActiveStep(s: Step): boolean {
   return isActiveFilter(s.filter);
+}
+
+// True if the criteria reads a *live*, continuously-drifting source (today, the
+// canvass leaves). Such queries can't use `staleTime: Infinity` — the answer
+// drifts as canvassing happens. A versioned source (e.g. a future tag upload) is
+// different: bake a version into the query key instead, the way boundaries key
+// on `updatedAt`.
+export function criteriaTouchesLiveData(criteria: Criteria): boolean {
+  // Tolerate a steps-less object — callers (e.g. campaignKeyCountsQuery) pass a
+  // `{} as SegmentCriteria` placeholder while the query is disabled.
+  return (criteria.steps ?? []).some((step) => {
+    const f = step.filter;
+    if (f.kind === "canvass-outcome" || f.kind === "canvass-response") return true;
+    if (f.kind === "nested") return criteriaTouchesLiveData(f.criteria);
+    return false;
+  });
 }
 
 // Verb display metadata — label and accent color.

--- a/apps/web/src/lib/filters.ts
+++ b/apps/web/src/lib/filters.ts
@@ -62,6 +62,17 @@ export type AddressFilter = {
   zip: string;
 };
 
+// Canvass-result filter — reads prior canvass dispositions back out of
+// canvass_events; it is NOT a person-row column. Matches a person if any
+// of their per-turf current results has an outcome in `outcomes`.
+// Resolved server-side to a person-id set before SQL compilation (see
+// apps/data/src/dsl/resolve.py), the same way SegmentFilter is.
+export type CanvassResultFilter = {
+  kind: "canvass-result";
+  key: "canvass_result";
+  outcomes: string[];
+};
+
 // Reference to another segment by id. Authored form — what the user
 // composes and what we persist. Resolved to NestedFilter (below) on the
 // data server (see `apps/data/src/dsl/expand.py`).
@@ -89,6 +100,7 @@ export type Filter =
   | DateRangeFilter
   | VotingHistoryFilter
   | AddressFilter
+  | CanvassResultFilter
   | SegmentFilter
   | NestedFilter;
 
@@ -145,6 +157,12 @@ export type FilterDef =
       kind: "address";
       key: "address";
       label: string;
+    }
+  | {
+      kind: "canvass-result";
+      key: "canvass_result";
+      label: string;
+      values: ReadonlyArray<{ value: string; label?: string }>;
     }
   | {
       kind: "segment";
@@ -256,6 +274,23 @@ export const FILTER_SECTIONS: ReadonlyArray<ReadonlyArray<FilterDef>> = [
       source: "column",
     },
   ],
+  // Canvass history — prior results read back from canvass_events.
+  // Only person-level outcomes are exposed (door/building dispositions
+  // like address_not_found / inaccessible aren't person results).
+  [
+    {
+      kind: "canvass-result",
+      key: "canvass_result",
+      label: "Canvass result",
+      values: [
+        { value: "canvassed", label: "Canvassed" },
+        { value: "not_home", label: "Not home" },
+        { value: "deceased", label: "Deceased" },
+        { value: "hostile", label: "Hostile" },
+        { value: "moved", label: "Moved" },
+      ],
+    },
+  ],
   // Composite — reference another segment by id.
   [{ kind: "segment", key: "segment", label: "Segment" }],
 ] as const;
@@ -282,6 +317,8 @@ export function emptyFilterFor(def: FilterDef): Filter {
   if (def.kind === "date-range") return { kind: "date-range", key: def.key, min: null, max: null };
   if (def.kind === "address")
     return { kind: "address", key: "address", line1: "", city: "", state: "", zip: "" };
+  if (def.kind === "canvass-result")
+    return { kind: "canvass-result", key: "canvass_result", outcomes: [] };
   if (def.kind === "segment") return { kind: "segment", key: "segment", segmentId: null };
   // Voting history default: "voted in 1+ recent primaries" (single prime).
   return {
@@ -309,6 +346,7 @@ export function isActiveFilter(f: Filter): boolean {
       f.state.trim().length > 0 ||
       f.zip.trim().length > 0
     );
+  if (f.kind === "canvass-result") return f.outcomes.length > 0;
   if (f.kind === "segment") return f.segmentId != null;
   if (f.kind === "nested") return f.criteria.steps.length > 0;
   // voting-history-count: active when window and count are non-degenerate.

--- a/apps/web/src/lib/queries/campaigns.ts
+++ b/apps/web/src/lib/queries/campaigns.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 import { client } from "~/rpc/client";
-import { fetchSegmentPoints, type SegmentCriteria } from "./segments";
+import { fetchSegmentPoints, liveAwareStaleTime, type SegmentCriteria } from "./segments";
 
 export type KeyFilter = { keyGroup: string; keys: string[] };
 
@@ -29,7 +29,7 @@ export const campaignPointsQuery = (
       keyFilter ? JSON.stringify(keyFilter) : null,
     ] as const,
     queryFn: () => fetchSegmentPoints({ criteria: segmentCriteria, keyFilter }),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: liveAwareStaleTime(segmentCriteria),
     // Releases the multi-MB Float32Array buffer the moment the query
     // goes inactive — accumulating multiple in cache triggers V8 GC
     // pauses on subsequent navigations.
@@ -49,5 +49,5 @@ export const campaignKeyCountsQuery = (
         keyGroup,
         keyFilter: { keyGroup, keys },
       }),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: liveAwareStaleTime(segmentCriteria),
   });

--- a/apps/web/src/lib/queries/questions.ts
+++ b/apps/web/src/lib/queries/questions.ts
@@ -10,6 +10,15 @@ export const questionsListQuery = (status: "active" | "archived" | "all" = "acti
     queryFn: () => client.questions.list({ status }),
   });
 
+// Active questions with options inlined (canvass-response filter editor).
+// Keyed under the `["questions"]` prefix so the question/option mutations'
+// prefix-form invalidations clear it.
+export const questionsWithOptionsQuery = () =>
+  queryOptions({
+    queryKey: ["questions", "with-options"] as const,
+    queryFn: () => client.questions.listWithOptions(),
+  });
+
 export const questionDetailQuery = (questionId: string) =>
   queryOptions({
     queryKey: ["question", questionId] as const,

--- a/apps/web/src/lib/queries/segments.ts
+++ b/apps/web/src/lib/queries/segments.ts
@@ -1,11 +1,20 @@
 import { queryOptions } from "@tanstack/react-query";
 import { getCurrentOrgSlug } from "~/lib/current-route";
-import type { Criteria } from "~/lib/filters";
+import { criteriaTouchesLiveData, type Criteria } from "~/lib/filters";
 import { client } from "~/rpc/client";
 
 export type SegmentCriteria = NonNullable<
   Awaited<ReturnType<typeof client.segments.getById>>
 >["criteria"];
+
+// `staleTime: Infinity` only holds for criteria that are pure functions of the
+// key; canvass leaves read live data and drift, so they fall back to the
+// default. `unknown` arg so loosely-typed `SegmentCriteria` callers pass through
+// without casts. See `criteriaTouchesLiveData`.
+export function liveAwareStaleTime(criteria: unknown): number | undefined {
+  const c = criteria as Criteria | null | undefined;
+  return c && criteriaTouchesLiveData(c) ? undefined : Number.POSITIVE_INFINITY;
+}
 
 export const segmentsListQuery = () =>
   queryOptions({
@@ -23,7 +32,7 @@ export const segmentCountsQuery = (criteria: Criteria) =>
   queryOptions({
     queryKey: ["segment-counts", JSON.stringify(criteria)] as const,
     queryFn: () => client.segments.count({ criteria }),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: liveAwareStaleTime(criteria),
   });
 
 export type SegmentPoints = {
@@ -37,7 +46,7 @@ export const segmentPointsQuery = (criteria: Criteria) =>
   queryOptions({
     queryKey: ["segment-points", JSON.stringify(criteria)] as const,
     queryFn: () => fetchSegmentPoints({ criteria }),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: liveAwareStaleTime(criteria),
     gcTime: 0,
   });
 
@@ -45,14 +54,14 @@ export const segmentSampleQuery = (criteria: Criteria) =>
   queryOptions({
     queryKey: ["segment-sample", JSON.stringify(criteria)] as const,
     queryFn: () => client.segments.sample({ criteria }),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: liveAwareStaleTime(criteria),
   });
 
 export const segmentCascadeQuery = (criteria: Criteria) =>
   queryOptions({
     queryKey: ["segment-cascade", JSON.stringify(criteria)] as const,
     queryFn: () => client.segments.countCascade({ criteria }),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: liveAwareStaleTime(criteria),
   });
 
 // Binary mercator-delta pairs — uploaded directly into a GPU buffer,
@@ -108,5 +117,5 @@ export const cutterBuildingsQuery = (
         criteria: segmentCriteria,
         keyFilter,
       }),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: liveAwareStaleTime(segmentCriteria),
   });

--- a/apps/web/src/routes/$orgSlug/scripts/$scriptId.tsx
+++ b/apps/web/src/routes/$orgSlug/scripts/$scriptId.tsx
@@ -331,7 +331,7 @@ function ReorderStepRow({
       dragControls={controls}
       as="div"
       onDragEnd={onDragEnd}
-      transition={{ layout: { type: "tween", duration: 0.2, ease: "easeOut" } }}
+      transition={{ layout: { type: "tween", duration: 0.15, ease: "easeOut" } }}
       dragTransition={{ bounceStiffness: 10000, bounceDamping: 500, power: 0 }}
     >
       <StepRow {...props} dragControls={controls} />

--- a/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
+++ b/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
@@ -39,6 +39,7 @@ import { ToggleGroup, ToggleGroupItem } from "~/components/toggle-group";
 import {
   type AddressFilter,
   type AgeRangeFilter,
+  type CanvassResultFilter,
   type DateRangeFilter,
   definitionFor,
   emptyFilterFor,
@@ -668,6 +669,9 @@ function StepRow({
       {filter.kind === "address" && def?.kind === "address" ? (
         <AddressFilterEditor filter={filter} onChange={onChange} />
       ) : null}
+      {filter.kind === "canvass-result" && def?.kind === "canvass-result" ? (
+        <CanvassResultEditor filter={filter} def={def} onChange={onChange} />
+      ) : null}
       {filter.kind === "segment" && def?.kind === "segment" ? (
         <SegmentFilterEditor
           filter={filter}
@@ -794,6 +798,39 @@ function EnumFilterEditor({
           size="sm"
           variant="outline"
           pressed={filter.values.includes(v.value)}
+          onPressedChange={() => toggle(v.value)}
+          className="aria-pressed:border-muted-foreground data-[state=on]:border-muted-foreground"
+        >
+          {v.label ?? v.value}
+        </Toggle>
+      ))}
+    </div>
+  );
+}
+
+function CanvassResultEditor({
+  filter,
+  def,
+  onChange,
+}: {
+  filter: CanvassResultFilter;
+  def: Extract<FilterDef, { kind: "canvass-result" }>;
+  onChange: (next: Filter) => void;
+}) {
+  const toggle = (value: string) => {
+    const next = filter.outcomes.includes(value)
+      ? filter.outcomes.filter((v) => v !== value)
+      : [...filter.outcomes, value];
+    onChange({ ...filter, outcomes: next });
+  };
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {def.values.map((v) => (
+        <Toggle
+          key={v.value}
+          size="sm"
+          variant="outline"
+          pressed={filter.outcomes.includes(v.value)}
           onPressedChange={() => toggle(v.value)}
           className="aria-pressed:border-muted-foreground data-[state=on]:border-muted-foreground"
         >

--- a/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
+++ b/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
@@ -39,7 +39,8 @@ import { ToggleGroup, ToggleGroupItem } from "~/components/toggle-group";
 import {
   type AddressFilter,
   type AgeRangeFilter,
-  type CanvassResultFilter,
+  type CanvassResponseFilter,
+  type CanvassOutcomeFilter,
   type DateRangeFilter,
   definitionFor,
   emptyFilterFor,
@@ -66,6 +67,7 @@ import {
   segmentSampleQuery,
   segmentsListQuery,
 } from "~/lib/queries/segments";
+import { questionsWithOptionsQuery } from "~/lib/queries/questions";
 import { findCyclicSegmentIds, type SegmentLike } from "~/lib/segment-refs";
 import type { CascadeStep } from "~/rpc/web/segments";
 import { cn, toTitleCase } from "~/lib/utils";
@@ -79,6 +81,8 @@ export const Route = createFileRoute("/$orgSlug/segments/$segmentId")({
       throw redirect({ to: "/$orgSlug/segments", params: { orgSlug } });
     }
     await queryClient.fetchQuery(segmentDetailQuery(segmentId));
+    // Names + options for the canvass-response filter editor.
+    await queryClient.fetchQuery(questionsWithOptionsQuery());
   },
   component: SegmentEditor,
 });
@@ -576,6 +580,9 @@ function ReorderStepRow({
       dragControls={controls}
       as="div"
       onDragEnd={onDragEnd}
+      // Animate reorder (position) but not size, so a filter's height change
+      // (e.g. switching a canvass-response question) is instant, not animated.
+      layout="position"
       transition={{ layout: { type: "tween", duration: 0.15, ease: "easeOut" } }}
       dragTransition={{ bounceStiffness: 10000, bounceDamping: 500, power: 0 }}
     >
@@ -669,8 +676,11 @@ function StepRow({
       {filter.kind === "address" && def?.kind === "address" ? (
         <AddressFilterEditor filter={filter} onChange={onChange} />
       ) : null}
-      {filter.kind === "canvass-result" && def?.kind === "canvass-result" ? (
-        <CanvassResultEditor filter={filter} def={def} onChange={onChange} />
+      {filter.kind === "canvass-outcome" && def?.kind === "canvass-outcome" ? (
+        <CanvassOutcomeEditor filter={filter} def={def} onChange={onChange} />
+      ) : null}
+      {filter.kind === "canvass-response" && def?.kind === "canvass-response" ? (
+        <CanvassResponseEditor filter={filter} onChange={onChange} />
       ) : null}
       {filter.kind === "segment" && def?.kind === "segment" ? (
         <SegmentFilterEditor
@@ -808,13 +818,13 @@ function EnumFilterEditor({
   );
 }
 
-function CanvassResultEditor({
+function CanvassOutcomeEditor({
   filter,
   def,
   onChange,
 }: {
-  filter: CanvassResultFilter;
-  def: Extract<FilterDef, { kind: "canvass-result" }>;
+  filter: CanvassOutcomeFilter;
+  def: Extract<FilterDef, { kind: "canvass-outcome" }>;
   onChange: (next: Filter) => void;
 }) {
   const toggle = (value: string) => {
@@ -837,6 +847,83 @@ function CanvassResultEditor({
           {v.label ?? v.value}
         </Toggle>
       ))}
+    </div>
+  );
+}
+
+function CanvassResponseEditor({
+  filter,
+  onChange,
+}: {
+  filter: CanvassResponseFilter;
+  onChange: (next: Filter) => void;
+}) {
+  // Names + options in one query, so the dropdown and toggles render off the
+  // same data (no per-question fetch).
+  const { data: questions } = useQuery(questionsWithOptionsQuery());
+
+  const selected = questions?.find((q) => q.questionId === filter.questionId);
+  const triggerLabel = selected
+    ? selected.name
+    : filter.questionId && questions
+      ? "(deleted)"
+      : "Select question…";
+  const options = selected?.options ?? [];
+
+  const toggle = (optionId: string) => {
+    const next = filter.optionIds.includes(optionId)
+      ? filter.optionIds.filter((v) => v !== optionId)
+      : [...filter.optionIds, optionId];
+    onChange({ ...filter, optionIds: next });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={<Button variant="outline" className="w-full justify-between font-normal" />}
+        >
+          <span className={cn("truncate", !selected ? "text-muted-foreground" : null)}>
+            {triggerLabel}
+          </span>
+          <ChevronDown className="text-muted-foreground" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="min-w-48 max-h-[291px] overflow-y-auto">
+          {!questions || questions.length === 0 ? (
+            <DropdownMenuItem disabled>No questions available</DropdownMenuItem>
+          ) : (
+            questions.map((q) => (
+              <DropdownMenuItem
+                key={q.questionId}
+                // Switching questions clears the now-irrelevant option set.
+                onClick={() => onChange({ ...filter, questionId: q.questionId, optionIds: [] })}
+              >
+                {q.name}
+              </DropdownMenuItem>
+            ))
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {filter.questionId && options.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {options.map((o) => (
+            <Toggle
+              key={o.responseOptionId}
+              size="sm"
+              variant="outline"
+              pressed={filter.optionIds.includes(o.responseOptionId)}
+              onPressedChange={() => toggle(o.responseOptionId)}
+              className="aria-pressed:border-muted-foreground data-[state=on]:border-muted-foreground"
+            >
+              {o.text.trim() ? (
+                o.text
+              ) : (
+                <span className="italic text-muted-foreground">Empty option</span>
+              )}
+            </Toggle>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/rpc/index.ts
+++ b/apps/web/src/rpc/index.ts
@@ -87,6 +87,7 @@ export const webRouter = {
   },
   questions: {
     list: questions.list,
+    listWithOptions: questions.listWithOptions,
     getById: questions.getById,
     create: questions.create,
     rename: questions.rename,

--- a/apps/web/src/rpc/web/questions.ts
+++ b/apps/web/src/rpc/web/questions.ts
@@ -70,6 +70,41 @@ export const list = pub
     return rows.map((r) => ({ ...r, usedCount: countMap.get(r.questionId) ?? 0 }));
   });
 
+// Active questions with their response options inlined — one round-trip so
+// pickers (the canvass-response filter editor) get names + options without a
+// per-question follow-up.
+export const listWithOptions = pub.handler(async ({ context }) => {
+  const qs = await context.db
+    .select({ questionId: questions.questionId, name: questions.name })
+    .from(questions)
+    .where(and(eq(questions.organizationId, context.organizationId), isNull(questions.archivedAt)))
+    .orderBy(asc(questions.createdAt));
+  if (qs.length === 0) return [];
+
+  const opts = await context.db
+    .select({
+      questionId: responseOptions.questionId,
+      responseOptionId: responseOptions.responseOptionId,
+      text: responseOptions.text,
+    })
+    .from(responseOptions)
+    .where(
+      inArray(
+        responseOptions.questionId,
+        qs.map((q) => q.questionId),
+      ),
+    )
+    .orderBy(asc(responseOptions.order));
+
+  const byQuestion = new Map<string, { responseOptionId: string; text: string }[]>();
+  for (const o of opts) {
+    const list = byQuestion.get(o.questionId) ?? [];
+    list.push({ responseOptionId: o.responseOptionId, text: o.text });
+    byQuestion.set(o.questionId, list);
+  }
+  return qs.map((q) => ({ ...q, options: byQuestion.get(q.questionId) ?? [] }));
+});
+
 export const getById = pub
   .input(z.object({ questionId: z.string().uuid() }))
   .handler(async ({ context, input }) => {


### PR DESCRIPTION
This PR adds support for filtering segments based on canvass responses and outcomes, for example, to remove anyone already canvassed, or to narrow to people with a given response to a question. Both filters read the append-only `canvass_events` log and resolve server-side into the existing criteria DSL, so they compose with every other filter. For now, we determine the latest response / outcome per turf, and then consider any response / outcome across turfs.