### PR TITLE
feat: archived response options

### DIFF
--- a/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
+++ b/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
@@ -866,20 +866,48 @@ function CanvassResponseEditor({
   // dropdown closes, not a tick later when the criteria write notifies.
   const [localQuestionId, setLocalQuestionId] = useState(filter.questionId);
   useEffect(() => setLocalQuestionId(filter.questionId), [filter.questionId]);
+  const [showArchived, setShowArchived] = useState(false);
+  const [showArchivedQuestions, setShowArchivedQuestions] = useState(false);
 
   const selected = questions?.find((q) => q.questionId === localQuestionId);
   const triggerLabel = selected
-    ? selected.name
+    ? selected.archived
+      ? `${selected.name} (archived)`
+      : selected.name
     : localQuestionId && questions
       ? "(deleted)"
       : "Select question…";
+  const activeQuestions = questions?.filter((q) => !q.archived) ?? [];
+  const archivedQuestions = questions?.filter((q) => q.archived) ?? [];
+  // Keep the selected question in the menu even if it's archived (so a saved
+  // filter's question doesn't vanish on load); "Show archived" reveals the rest.
+  const visibleArchivedQuestions = showArchivedQuestions
+    ? archivedQuestions
+    : archivedQuestions.filter((q) => q.questionId === localQuestionId);
+  const archivedQuestionsHidden = archivedQuestions.some((q) => q.questionId !== localQuestionId);
   const options = selected?.options ?? [];
+  // Show active options; keep a referenced archived option visible (so it can
+  // be removed), and reveal the rest when "Show archived" is on.
+  const visibleOptions = options.filter(
+    (o) => showArchived || !o.archived || filter.optionIds.includes(o.responseOptionId),
+  );
+  // Only offer the toggle when there's a hidden archived option to reveal.
+  const archivedHidden = options.some(
+    (o) => o.archived && !filter.optionIds.includes(o.responseOptionId),
+  );
 
   const toggle = (optionId: string) => {
     const next = filter.optionIds.includes(optionId)
       ? filter.optionIds.filter((v) => v !== optionId)
       : [...filter.optionIds, optionId];
     onChange({ ...filter, optionIds: next });
+  };
+
+  // Switching questions clears the now-irrelevant option set.
+  const selectQuestion = (questionId: string) => {
+    setLocalQuestionId(questionId);
+    setShowArchived(false);
+    onChange({ ...filter, questionId, optionIds: [] });
   };
 
   return (
@@ -897,24 +925,34 @@ function CanvassResponseEditor({
           {!questions || questions.length === 0 ? (
             <DropdownMenuItem disabled>No questions available</DropdownMenuItem>
           ) : (
-            questions.map((q) => (
-              <DropdownMenuItem
-                key={q.questionId}
-                // Switching questions clears the now-irrelevant option set.
-                onClick={() => {
-                  setLocalQuestionId(q.questionId);
-                  onChange({ ...filter, questionId: q.questionId, optionIds: [] });
-                }}
-              >
-                {q.name}
-              </DropdownMenuItem>
-            ))
+            <>
+              {activeQuestions.map((q) => (
+                <DropdownMenuItem key={q.questionId} onClick={() => selectQuestion(q.questionId)}>
+                  {q.name}
+                </DropdownMenuItem>
+              ))}
+              {visibleArchivedQuestions.map((q) => (
+                <DropdownMenuItem key={q.questionId} onClick={() => selectQuestion(q.questionId)}>
+                  {q.name}
+                  {" (archived)"}
+                </DropdownMenuItem>
+              ))}
+              {archivedQuestionsHidden ? (
+                <DropdownMenuItem
+                  className="text-muted-foreground"
+                  closeOnClick={false}
+                  onClick={() => setShowArchivedQuestions((v) => !v)}
+                >
+                  {showArchivedQuestions ? "Hide archived" : "Show archived"}
+                </DropdownMenuItem>
+              ) : null}
+            </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>
-      {localQuestionId && options.length > 0 ? (
-        <div className="flex flex-wrap gap-1.5">
-          {options.map((o) => (
+      {localQuestionId && (visibleOptions.length > 0 || archivedHidden) ? (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {visibleOptions.map((o) => (
             <Toggle
               key={o.responseOptionId}
               size="sm"
@@ -928,8 +966,19 @@ function CanvassResponseEditor({
               ) : (
                 <span className="italic text-muted-foreground">Empty option</span>
               )}
+              {o.archived ? " (archived)" : null}
             </Toggle>
           ))}
+          {archivedHidden ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-[0.8rem] text-muted-foreground"
+              onClick={() => setShowArchived((v) => !v)}
+            >
+              {showArchived ? "Hide archived" : "Show archived"}
+            </Button>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/apps/web/src/rpc/native/scripts.ts
+++ b/apps/web/src/rpc/native/scripts.ts
@@ -1,4 +1,4 @@
-import { asc, eq, inArray } from "@turf-tools/db";
+import { and, asc, eq, inArray, isNull } from "@turf-tools/db";
 import { scripts, scriptSteps, questions, responseOptions } from "@turf-tools/db/schema";
 import { z } from "zod";
 import { nativePub as pub } from "../context";
@@ -66,7 +66,12 @@ export const get = pub
               order: responseOptions.order,
             })
             .from(responseOptions)
-            .where(inArray(responseOptions.questionId, questionIds))
+            .where(
+              and(
+                inArray(responseOptions.questionId, questionIds),
+                isNull(responseOptions.archivedAt),
+              ),
+            )
             .orderBy(asc(responseOptions.order));
     const optionsByQuestion = new Map<string, typeof optionRows>();
     for (const opt of optionRows) {

--- a/apps/web/src/rpc/web/questions.ts
+++ b/apps/web/src/rpc/web/questions.ts
@@ -70,14 +70,19 @@ export const list = pub
     return rows.map((r) => ({ ...r, usedCount: countMap.get(r.questionId) ?? 0 }));
   });
 
-// Active questions with their response options inlined — one round-trip so
-// pickers (the canvass-response filter editor) get names + options without a
-// per-question follow-up.
+// Questions (active + archived, flagged) with their response options inlined —
+// one round-trip so the canvass-response filter editor gets names + options
+// without a per-question follow-up. It offers active by default and reveals
+// archived on demand (so filters on since-archived questions/options resolve).
 export const listWithOptions = pub.handler(async ({ context }) => {
   const qs = await context.db
-    .select({ questionId: questions.questionId, name: questions.name })
+    .select({
+      questionId: questions.questionId,
+      name: questions.name,
+      archivedAt: questions.archivedAt,
+    })
     .from(questions)
-    .where(and(eq(questions.organizationId, context.organizationId), isNull(questions.archivedAt)))
+    .where(eq(questions.organizationId, context.organizationId))
     .orderBy(asc(questions.createdAt));
   if (qs.length === 0) return [];
 
@@ -86,6 +91,7 @@ export const listWithOptions = pub.handler(async ({ context }) => {
       questionId: responseOptions.questionId,
       responseOptionId: responseOptions.responseOptionId,
       text: responseOptions.text,
+      archivedAt: responseOptions.archivedAt,
     })
     .from(responseOptions)
     .where(
@@ -96,13 +102,28 @@ export const listWithOptions = pub.handler(async ({ context }) => {
     )
     .orderBy(asc(responseOptions.order));
 
-  const byQuestion = new Map<string, { responseOptionId: string; text: string }[]>();
+  // Include archived options (flagged). The segment editor must still render an
+  // archived option an existing filter references, so it stays removable;
+  // offering only active options is done client-side.
+  const byQuestion = new Map<
+    string,
+    { responseOptionId: string; text: string; archived: boolean }[]
+  >();
   for (const o of opts) {
     const list = byQuestion.get(o.questionId) ?? [];
-    list.push({ responseOptionId: o.responseOptionId, text: o.text });
+    list.push({
+      responseOptionId: o.responseOptionId,
+      text: o.text,
+      archived: o.archivedAt !== null,
+    });
     byQuestion.set(o.questionId, list);
   }
-  return qs.map((q) => ({ ...q, options: byQuestion.get(q.questionId) ?? [] }));
+  return qs.map((q) => ({
+    questionId: q.questionId,
+    name: q.name,
+    archived: q.archivedAt !== null,
+    options: byQuestion.get(q.questionId) ?? [],
+  }));
 });
 
 export const getById = pub
@@ -123,7 +144,9 @@ export const getById = pub
     const options = await context.db
       .select(optionSelect)
       .from(responseOptions)
-      .where(eq(responseOptions.questionId, input.questionId))
+      .where(
+        and(eq(responseOptions.questionId, input.questionId), isNull(responseOptions.archivedAt)),
+      )
       .orderBy(asc(responseOptions.order));
 
     return { ...question, options };
@@ -298,8 +321,11 @@ export const removeResponseOption = pub
         ),
       );
     if (owned.length === 0) throw new ORPCError("NOT_FOUND", { message: "Question not found" });
+    // Soft-delete: canvass responses + segment filters reference this option id
+    // and must stay resolvable.
     await context.db
-      .delete(responseOptions)
+      .update(responseOptions)
+      .set({ archivedAt: new Date() })
       .where(
         and(
           eq(responseOptions.responseOptionId, input.responseOptionId),

--- a/packages/db/src/schema/questions.ts
+++ b/packages/db/src/schema/questions.ts
@@ -32,4 +32,7 @@ export const responseOptions = pgTable("response_options", {
     .notNull()
     .references(() => users.id),
   createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+  // Soft-delete: keep the row so responses/segment filters referencing this
+  // option id stay resolvable; hidden from active pickers + the live script.
+  archivedAt: timestamp({ withTimezone: true }),
 });


### PR DESCRIPTION
A small PR to make response options archivable the same way questions are. Now, when deleting a response option, it's a soft-delete, so the reference will remain forever. That way, scripts with questions that reference archived response options can still be referenced. I also made it so you can reference archived response options (and archived questions) in the Segment editor.

Editing (rather than deleting) the text of questions or responses will still result in potential drift between the current version and the version used to canvass. For that, I'll separately add a warning while editing the text if the question is part of a script that has been used in published turf.