### PR TITLE
feat: voting history detail filter

### DIFF
--- a/apps/data/src/cli.py
+++ b/apps/data/src/cli.py
@@ -16,6 +16,7 @@ from src.dags import (
     quickwit,
     tiger,
 )
+from src.derived import compute_derived_metadata
 from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres, get_connection
 from src.import_progress import NullProgress
 from src.importers.nys_voter_file import NysVoterFileImporter
@@ -372,9 +373,11 @@ def seed_persons() -> None:
     # Land the manifest + row count on the version and mark it `ready`, then
     # activate it for the seeded orgs — only now that the data exists, so a
     # crash mid-pipeline never leaves an org pointing at an empty dataset.
-    person_count = conn.sql(f"SELECT count(*) FROM {geocoded_ref.fqn}").fetchone()[0]
-    finalize_version(conn, settings, version_id, importer.manifest(), person_count)
+    manifest = importer.manifest()
+    derived = compute_derived_metadata(conn, geocoded_ref.fqn, manifest)
+    finalize_version(conn, settings, version_id, manifest, derived)
     _activate_for_all_orgs(conn, version_id)
+    person_count = derived["rowCount"]
     print(f"  → Wrote manifest + row_count={person_count:,}; activated version {version_id} for all orgs.")
 
     if timing is not None:

--- a/apps/data/src/derived.py
+++ b/apps/data/src/derived.py
@@ -1,0 +1,63 @@
+"""Version-level derived metadata — properties computed once from a dataset
+version's data at import time and cached on `dataset_versions.derived_metadata`
+(Postgres), so reads never recompute them over the immutable version's rows.
+
+Computed here (data already hot post-import) and written by `finalize_version`;
+the web reads the blob straight from Postgres, like it reads the manifest. Add a
+new derived property by extending `compute_derived_metadata`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.dsl.elections import ELECTION_MIN_VOTERS, election_key_sql, election_label
+
+if TYPE_CHECKING:
+    import duckdb
+    from src.importers.base import Manifest
+
+
+def compute_derived_metadata(conn: duckdb.DuckDBPyConnection, geocoded_fqn: str, manifest: Manifest) -> dict[str, Any]:
+    """Derive all cached properties for a freshly-built version. `geocoded_fqn`
+    is the persons_geocoded table; `manifest` drives what's derivable. Callers
+    read `rowCount` back from the result (it replaces a separate count query)."""
+    derived: dict[str, Any] = {
+        "rowCount": conn.execute(f"SELECT count(*) FROM {geocoded_fqn}").fetchone()[0],
+    }
+    elections = _compute_elections(conn, geocoded_fqn, manifest)
+    if elections is not None:
+        derived["elections"] = elections
+    return derived
+
+
+def _compute_elections(
+    conn: duckdb.DuckDBPyConnection, geocoded_fqn: str, manifest: Manifest
+) -> list[dict[str, str]] | None:
+    """Distinct (year, type) elections above the voter-count floor — the
+    voting-history-detail picker's options, newest first. None when the dataset
+    has no such field."""
+    field = next(
+        (fd for section in manifest.fields for fd in section if fd.filter_kind == "voting-history-detail"),
+        None,
+    )
+    if field is None:
+        return None
+    column = field.column or field.identifier
+    # Same key expression the detail filter compiles against (`election_key_sql`),
+    # so a picked value always matches a compiled predicate. The floor drops
+    # degenerate keys (corrupt years, phantom off-cycle types) that only a handful
+    # of voters carry.
+    rows = conn.execute(
+        f"""
+        SELECT e.year AS year, e.type AS type, {election_key_sql("e")} AS key
+        FROM {geocoded_fqn}, UNNEST({column}) AS t(e)
+        WHERE e.year IS NOT NULL
+        GROUP BY 1, 2, 3
+        HAVING count(DISTINCT external_id) >= ?
+        """,
+        [ELECTION_MIN_VOTERS],
+    ).fetchall()
+    # Newest first: year desc, then type.
+    rows.sort(key=lambda r: (-r[0], r[1]))
+    return [{"value": key, "label": election_label(year, type_)} for year, type_, key in rows]

--- a/apps/data/src/dsl/compile.py
+++ b/apps/data/src/dsl/compile.py
@@ -34,9 +34,12 @@ from .criteria import (
     TextFilter,
     TextMultiFieldDef,
     TextMultiFilter,
-    VotingHistoryFieldDef,
-    VotingHistoryFilter,
+    VotingHistoryCountFieldDef,
+    VotingHistoryCountFilter,
+    VotingHistoryDetailFieldDef,
+    VotingHistoryDetailFilter,
 )
+from .elections import election_key_sql
 
 
 class CriteriaError(ValueError):
@@ -161,8 +164,10 @@ def _filter_clause(catalog: FieldCatalog, f: Filter, params: list[Any]) -> str:
         return _text_multi_clause(f, _field(catalog, f.key), params)
     if isinstance(f, DateRangeFilter):
         return _date_range_clause(f, _field(catalog, f.key), params)
-    if isinstance(f, VotingHistoryFilter):
-        return _voting_history_clause(f, _field(catalog, f.key), params)
+    if isinstance(f, VotingHistoryCountFilter):
+        return _voting_history_count_clause(f, _field(catalog, f.key), params)
+    if isinstance(f, VotingHistoryDetailFilter):
+        return _voting_history_detail_clause(f, _field(catalog, f.key), params)
     if isinstance(f, AddressFilter):
         return _address_clause(f, _field(catalog, f.key), params)
     if isinstance(f, NestedFilter):
@@ -281,21 +286,40 @@ def _address_clause(f: AddressFilter, def_: FieldDef, params: list[Any]) -> str:
     return "(" + " AND ".join(parts) + ")"
 
 
-def _voting_history_clause(f: VotingHistoryFilter, def_: FieldDef, params: list[Any]) -> str:
-    if not isinstance(def_, VotingHistoryFieldDef):
+def _voting_history_count_clause(f: VotingHistoryCountFilter, def_: FieldDef, params: list[Any]) -> str:
+    if not isinstance(def_, VotingHistoryCountFieldDef):
         raise CriteriaError(f"Field {f.key} is not a voting-history-count field")
     if f.window_years <= 0 or f.count < 0:
         return ""
     types = _VH_TYPE_GROUPS[f.type]
     type_placeholders = ", ".join("?" for _ in types)
     # list_filter + len keeps this a scalar expression (no correlated subquery).
-    # `year(current_date) - ?` keeps the recency window relative to query time.
-    inner = f"len(list_filter({def_.key}, e -> e.year >= year(current_date) - ? AND e.type IN ({type_placeholders})))"
+    # `year > year(current_date) - N` counts the N most recent years inclusive of
+    # the current one — "last 1 year" in 2026 is 2026 only, "last 2" is 2025-2026.
+    inner = (
+        f"len(list_filter({def_.column}, e -> e.year > year(current_date) - ? AND e.type IN ({type_placeholders})))"
+    )
     params.append(f.window_years)
     params.extend(types)
     op = ">=" if f.comparator == "at_least" else "="
     params.append(f.count)
     return f"{inner} {op} ?"
+
+
+def _voting_history_detail_clause(f: VotingHistoryDetailFilter, def_: FieldDef, params: list[Any]) -> str:
+    if not isinstance(def_, VotingHistoryDetailFieldDef):
+        raise CriteriaError(f"Field {f.key} is not a voting-history-detail field")
+    if not f.elections:
+        return ""
+    placeholders = ", ".join("?" for _ in f.elections)
+    params.extend(f.elections)
+    # Project each person's entries to their (year, type) election keys, then
+    # test membership. `election_key_sql` is the same expression the picker
+    # precompute builds its option values from, so keys can't drift. `any` →
+    # overlaps the selected set; `all` → contains every selected election.
+    keys = f"list_transform({def_.column}, e -> {election_key_sql('e')})"
+    fn = "list_has_all" if f.mode == "all" else "list_has_any"
+    return f"{fn}({keys}, [{placeholders}])"
 
 
 def _key_filter_clause(catalog: FieldCatalog, kf: KeyFilter, params: list[Any]) -> str:

--- a/apps/data/src/dsl/criteria.py
+++ b/apps/data/src/dsl/criteria.py
@@ -68,7 +68,7 @@ class DateRangeFilter(BaseModel):
     max: str | None = None
 
 
-class VotingHistoryFilter(BaseModel):
+class VotingHistoryCountFilter(BaseModel):
     """Count of recent elections matching a type within a year window.
 
     ``primary`` covers both `primary` and `presidential_primary` canonical
@@ -83,6 +83,18 @@ class VotingHistoryFilter(BaseModel):
     window_years: int = Field(validation_alias="windowYears")
     comparator: Literal["at_least", "exactly"]
     count: int
+
+
+class VotingHistoryDetailFilter(BaseModel):
+    """Membership in specific named elections, each identified by its stable key
+    (see `dsl/elections.py`), e.g. `2024-06-primary`. `mode` picks the set
+    semantics: ``any`` matches a person who voted in at least one selected
+    election (OR); ``all`` requires every selected election (AND)."""
+
+    kind: Literal["voting-history-detail"]
+    key: str
+    mode: Literal["any", "all"]
+    elections: list[str]
 
 
 class AddressFilter(BaseModel):
@@ -158,7 +170,8 @@ Filter = Annotated[
     | TextFilter
     | TextMultiFilter
     | DateRangeFilter
-    | VotingHistoryFilter
+    | VotingHistoryCountFilter
+    | VotingHistoryDetailFilter
     | AddressFilter
     | CanvassOutcomeFilter
     | CanvassResponseFilter
@@ -231,9 +244,16 @@ class DateRangeFieldDef(BaseModel):
     key: str
 
 
-class VotingHistoryFieldDef(BaseModel):
+class VotingHistoryCountFieldDef(BaseModel):
     kind: Literal["voting-history-count"]
-    key: str  # the STRUCT[] column name, e.g. "voting_history"
+    key: str  # catalog identifier, e.g. "voting_history_count"
+    column: str  # the STRUCT[] column the clause array-scans, e.g. "voting_history"
+
+
+class VotingHistoryDetailFieldDef(BaseModel):
+    kind: Literal["voting-history-detail"]
+    key: str  # catalog identifier, e.g. "voting_history_detail"
+    column: str  # the STRUCT[] column the clause array-scans (shared with count)
 
 
 class AddressFieldDef(BaseModel):
@@ -247,7 +267,8 @@ FieldDef = (
     | TextFieldDef
     | TextMultiFieldDef
     | DateRangeFieldDef
-    | VotingHistoryFieldDef
+    | VotingHistoryCountFieldDef
+    | VotingHistoryDetailFieldDef
     | AddressFieldDef
 )
 
@@ -281,9 +302,12 @@ def build_field_catalog(manifest: Manifest) -> FieldCatalog:
     """
     fields: dict[str, FieldDef] = {}
     key_groups: dict[str, str] = {}
-    # Sections are a display concern; the compiler flattens them away.
+    # Sections are a display concern; the compiler flattens them away. `key` is
+    # the field's catalog identifier (defaults to its column); scalar clauses use
+    # it directly as the SQL column, so for them identifier == column. The
+    # voting-history kinds carry `column` separately (identifier != column).
     for fd in (fd for section in manifest.fields for fd in section):
-        key = fd.column
+        key = fd.identifier
         if fd.filter_kind == "text":
             fields[key] = TextFieldDef(kind="text", key=key)
         elif fd.filter_kind == "enum":
@@ -295,7 +319,9 @@ def build_field_catalog(manifest: Manifest) -> FieldCatalog:
         elif fd.filter_kind == "date-range":
             fields[key] = DateRangeFieldDef(kind="date-range", key=key)
         elif fd.filter_kind == "voting-history-count":
-            fields[key] = VotingHistoryFieldDef(kind="voting-history-count", key=key)
+            fields[key] = VotingHistoryCountFieldDef(kind="voting-history-count", key=key, column=fd.column or key)
+        elif fd.filter_kind == "voting-history-detail":
+            fields[key] = VotingHistoryDetailFieldDef(kind="voting-history-detail", key=key, column=fd.column or key)
         elif fd.filter_kind == "address":
             fields[key] = AddressFieldDef(kind="address", key="address")
         if fd.key_group:

--- a/apps/data/src/dsl/elections.py
+++ b/apps/data/src/dsl/elections.py
@@ -1,0 +1,40 @@
+"""Shared election-identity helpers for the voting-history filters.
+
+An election is identified by (year, type) — no month. Per-record months in the
+raw voter history are unreliable (corrupt date bytes; older records are date-less
+in the source) and bought only brittleness: generals are one-per-year regardless,
+and primaries/specials collapse cleanly to a year+type bucket. Keying by
+(year, type) sidesteps all of it — a corrupt month still lands in the right
+year+type, and dated/undated records of the same election merge automatically.
+
+`election_key_sql` is the single place the key formula lives, so the detail
+filter's compiled predicate and the picker's precomputed options can't drift.
+"""
+
+from __future__ import annotations
+
+# Minimum distinct voters for a (year, type) to be offered as an election. Real
+# elections draw thousands+; corrupt or degenerate keys draw a handful — a raw
+# floor (not a share, which would silently re-cut as the data changes) cleanly
+# separates them. Kept low so it generalizes beyond NYC-scale datasets.
+ELECTION_MIN_VOTERS = 100
+
+_TYPE_LABELS = {
+    "general": "General",
+    "primary": "Primary",
+    "presidential_primary": "Presidential Primary",
+    "special": "Special",
+    "runoff": "Runoff",
+}
+
+
+def election_key_sql(entry: str) -> str:
+    """DuckDB expression mapping a voting_history STRUCT entry (bound as `entry`)
+    to its `<year>-<type>` key, e.g. `2024-general`. Used by the detail filter's
+    compile clause and the picker precompute so the two can't drift."""
+    return f"{entry}.year || '-' || {entry}.type"
+
+
+def election_label(year: int, type_: str) -> str:
+    """Human label for an election, e.g. "2024 General" or "2022 Primary"."""
+    return f"{year} {_TYPE_LABELS.get(type_, type_.replace('_', ' ').title())}"

--- a/apps/data/src/import_job.py
+++ b/apps/data/src/import_job.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 
 from src import postgres
 from src.dags import aggregate, assembly, geocode, matching, osm, tiger
+from src.derived import compute_derived_metadata
 from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres, get_connection
 from src.import_progress import ImportProgress, ProgressNodeHook
 from src.importers.registry import get_importer
@@ -92,15 +93,20 @@ def _run(payload: ImportDatasetVersionPayload) -> dict[str, Any]:
             .build()
         )
         dag_steps = sum(1 for n in dr.graph.get_upstream_nodes(_FINAL_VARS)[0] if n.name not in input_keys)
-        progress.start(importer.PROGRESS_STEPS + dag_steps)
+        # +1 for the post-DAG derived-metadata pass (a full unnest+count over
+        # persons_geocoded), so it doesn't sit "stuck" at 100% while it runs.
+        progress.start(importer.PROGRESS_STEPS + dag_steps + 1)
 
         # Source → persons_validated (importer-specific), then the shared pipeline.
         persons_validated = importer.load(payload.source, schema, conn, progress)
         result = dr.execute(final_vars=_FINAL_VARS, inputs={"persons_validated": persons_validated, **dag_inputs})
 
-        person_count = conn.sql(f"SELECT count(*) FROM {result['persons_geocoded'].fqn}").fetchone()[0]
-        finalize_version(conn, settings, payload.dataset_version_id, importer.manifest(), person_count)
-        return {"row_count": person_count, "schema": schema}
+        geocoded_fqn = result["persons_geocoded"].fqn
+        manifest = importer.manifest()
+        derived = compute_derived_metadata(conn, geocoded_fqn, manifest)
+        progress.advance()
+        finalize_version(conn, settings, payload.dataset_version_id, manifest, derived)
+        return {"row_count": derived["rowCount"], "schema": schema}
     finally:
         conn.close()
 

--- a/apps/data/src/importers/base.py
+++ b/apps/data/src/importers/base.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Protocol
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.alias_generators import to_camel
 
 if TYPE_CHECKING:
@@ -37,6 +37,7 @@ FilterKind = Literal[
     "age-range",  # numeric age range derived from a birthdate column
     "date-range",  # date range
     "voting-history-count",  # count of matching elections in a recency window
+    "voting-history-detail",  # membership in specific named elections (multi-select)
     "address",  # the geocodable composite (canonical; also filters)
 ]
 
@@ -62,9 +63,17 @@ class FieldDef(_CamelModel):
     """One filterable field — the union of what the web editor and the SQL
     compiler each need, as data."""
 
-    # Every field is a top-level `persons_geocoded` column (shredded for Parquet
-    # pruning + Bloom filters). `column` doubles as the filter `key`.
-    column: str
+    # The physical `persons_geocoded` column this filter reads (shredded for
+    # Parquet pruning + Bloom filters). How it's read is the compiler clause's
+    # business — a scalar `age-range` computes age from its `date_of_birth`
+    # column; a `voting-history-*` kind array-scans its `voting_history` STRUCT[].
+    # None for a column-less composite (`address` reads several columns directly).
+    column: str | None = None
+    # Unique field identifier — the filter `key` the editor and compiler match on.
+    # Defaults to `column`; set explicitly only to disambiguate two filters over
+    # one column (the `voting_history` count/detail pair) or to name a column-less
+    # composite (`address`). Use `identifier` for the resolved value.
+    key: str | None = None
     label: str  # editor display label
     filter_kind: FilterKind
     # `enum` / `text-multi` value catalog. None → no fixed catalog (freetext
@@ -78,6 +87,18 @@ class FieldDef(_CamelModel):
     # editor, e.g. "Election districts") rides alongside it. Compiler ignores both.
     key_group: str | None = None
     key_group_label: str | None = None
+
+    @model_validator(mode="after")
+    def _require_identifier(self) -> FieldDef:
+        if self.key is None and self.column is None:
+            raise ValueError("FieldDef requires `column` or `key`")
+        return self
+
+    @property
+    def identifier(self) -> str:
+        ident = self.key or self.column
+        assert ident is not None  # guaranteed by _require_identifier
+        return ident
 
 
 class Manifest(_CamelModel):

--- a/apps/data/src/importers/nys_voter_file/manifest.py
+++ b/apps/data/src/importers/nys_voter_file/manifest.py
@@ -28,7 +28,8 @@ NYS_MANIFEST = Manifest(
         [
             FieldDef(column="first_name", label="First name", filter_kind="text"),
             FieldDef(column="last_name", label="Last name", filter_kind="text"),
-            FieldDef(column="address", label="Address", filter_kind="address"),
+            # Composite: reads several columns directly, so no single `column`.
+            FieldDef(key="address", label="Address", filter_kind="address"),
             # zip5 doubles as the `nyc_zips` boundary key (derivable from the address,
             # so any geocoded dataset can zone by zip).
             FieldDef(
@@ -105,7 +106,23 @@ NYS_MANIFEST = Manifest(
                     _enum("unknown", "Unknown"),
                 ],
             ),
-            FieldDef(column="voting_history", label="Voting History", filter_kind="voting-history-count"),
+            # Two filters over the one `voting_history` STRUCT[] column, so both
+            # carry an explicit `key` to disambiguate. Detail's picker values are
+            # precomputed per version at import (see `compute_derived_metadata`)
+            # and read from `dataset_versions.derived_metadata`, so no static
+            # `values` here.
+            FieldDef(
+                column="voting_history",
+                key="voting_history_count",
+                label="Voting History Count",
+                filter_kind="voting-history-count",
+            ),
+            FieldDef(
+                column="voting_history",
+                key="voting_history_detail",
+                label="Voting History Detail",
+                filter_kind="voting-history-detail",
+            ),
         ],
     ]
 )

--- a/apps/data/src/importers/nys_voter_file/voting_history.py
+++ b/apps/data/src/importers/nys_voter_file/voting_history.py
@@ -50,6 +50,19 @@ def _classify_description(desc: str) -> str | None:
     return None
 
 
+# Plausible election-year window. Guards the date-first paths (`_RE_MODERN` /
+# `_RE_CODE_FIRST`), which take `year = date[:4]` verbatim — a corrupt 8-digit
+# date like `38120810 GE(P)` would otherwise yield year 3812, which also
+# pollutes the count filter's recency window. Static bounds keep the parser
+# deterministic; the trailing-status path is already bounded by `_RE_YEAR_4`.
+_YEAR_MIN = 1900
+_YEAR_MAX = 2100
+
+
+def _plausible_year(year: int) -> bool:
+    return _YEAR_MIN <= year <= _YEAR_MAX
+
+
 def _expand_two_digit_year(y: int) -> int:
     # SBOE-realistic pivot: 0-26 → 2000s, else 1900s.
     return 2000 + y if y <= 26 else 1900 + y
@@ -68,7 +81,7 @@ def parse_entry(entry: str) -> dict | None:
     if m := _RE_MODERN.match(entry):
         date, code, method = m.groups()
         etype = ELECTION_TYPE_LABELS.get(code)
-        if etype is None:
+        if etype is None or not _plausible_year(int(date[:4])):
             return None
         return {
             "year": int(date[:4]),
@@ -80,7 +93,7 @@ def parse_entry(entry: str) -> dict | None:
     if m := _RE_CODE_FIRST.match(entry):
         code, date, method = m.groups()
         etype = ELECTION_TYPE_LABELS.get(code)
-        if etype is None:
+        if etype is None or not _plausible_year(int(date[:4])):
             return None
         return {
             "year": int(date[:4]),

--- a/apps/data/src/tables.py
+++ b/apps/data/src/tables.py
@@ -228,32 +228,35 @@ def finalize_version(
     settings: "Settings",
     dataset_version_id: str,
     manifest: Manifest,
-    row_count: int,
+    derived_metadata: dict,
 ) -> None:
-    """Land a version's `manifest` + `row_count` and mark it `ready`, once its
-    DuckLake tables are built. The single write point for both callers: the
+    """Land a version's `manifest` + `derived_metadata` and mark it `ready`, once
+    its DuckLake tables are built. The single write point for both callers: the
     `import_dataset_version` job (production) and `seed-persons` (dev). The
     importer *derives* the manifest and the DuckDB connection already has the
     Postgres attach, so writing it here — rather than handing it back for the web
     to persist — keeps the version's data and its manifest landed in one place.
-    `active_dataset_version_id` is left untouched: activation is the web's concern
-    ("Make active"), which then invalidates the web's manifest cache.
+    `derived_metadata` is the caller's `compute_derived_metadata` result
+    (`rowCount`, `elections`, …), cached so reads never recompute over the
+    immutable version. `active_dataset_version_id` is left untouched: activation
+    is the web's concern ("Make active"), which invalidates the web's caches.
 
     Postgres implicit-casts json→jsonb on INSERT but not on UPDATE, and DuckDB
     (no native jsonb type) sends the value as varchar — so a bound-param UPDATE
-    into the jsonb `manifest` column fails. The maintainer-blessed workaround is
-    to run the UPDATE natively on Postgres via `postgres_execute` with an explicit
-    `::jsonb` cast (duckdb/duckdb#16195). The manifest is our own serialized model,
-    not user input; single quotes are doubled for the Postgres string literal and
-    the statement is dollar-quoted for DuckDB.
+    into a jsonb column fails. The maintainer-blessed workaround is to run the
+    UPDATE natively on Postgres via `postgres_execute` with an explicit `::jsonb`
+    cast (duckdb/duckdb#16195). The values are our own serialized models, not user
+    input; single quotes are doubled for the Postgres string literal and the
+    statement is dollar-quoted for DuckDB.
     """
     attach_operational_postgres(conn, settings)
     manifest_literal = manifest.model_dump_json(by_alias=True).replace("'", "''")
+    derived_literal = json.dumps(derived_metadata).replace("'", "''")
     conn.execute(
         f"CALL postgres_execute('{OPERATIONAL_PG_ALIAS}', $ft$"
         f"UPDATE public.dataset_versions "
         f"SET manifest = '{manifest_literal}'::jsonb, "
-        f"row_count = {int(row_count)}, status = 'ready' "
+        f"derived_metadata = '{derived_literal}'::jsonb, status = 'ready' "
         f"WHERE dataset_version_id = '{dataset_version_id}'"
         f"$ft$)"
     )

--- a/apps/data/tests/test_compile.py
+++ b/apps/data/tests/test_compile.py
@@ -24,7 +24,8 @@ from src.dsl.criteria import (
     Step,
     TextFilter,
     TextMultiFilter,
-    VotingHistoryFilter,
+    VotingHistoryCountFilter,
+    VotingHistoryDetailFilter,
     build_field_catalog,
 )
 from src.importers.nys_voter_file.manifest import NYS_MANIFEST
@@ -213,9 +214,9 @@ def test_voting_history_at_least_primary() -> None:
     where = criteria_to_where(
         CATALOG,
         _narrow(
-            VotingHistoryFilter(
+            VotingHistoryCountFilter(
                 kind="voting-history-count",
-                key="voting_history",
+                key="voting_history_count",
                 type="primary",
                 window_years=4,
                 comparator="at_least",
@@ -291,9 +292,9 @@ def test_voting_history_exactly_general() -> None:
     where = criteria_to_where(
         CATALOG,
         _narrow(
-            VotingHistoryFilter(
+            VotingHistoryCountFilter(
                 kind="voting-history-count",
-                key="voting_history",
+                key="voting_history_count",
                 type="general",
                 window_years=4,
                 comparator="exactly",
@@ -306,6 +307,66 @@ def test_voting_history_exactly_general() -> None:
     assert "list_filter(voting_history" in where
     assert ") = ?" in where
     assert params == [4, "general", 1]
+
+
+def test_voting_history_detail_any_membership() -> None:
+    """`any` mode matches persons who voted in at least one selected election."""
+    params: list = []
+    where = criteria_to_where(
+        CATALOG,
+        _narrow(
+            VotingHistoryDetailFilter(
+                kind="voting-history-detail",
+                key="voting_history_detail",
+                mode="any",
+                elections=["2024-primary", "2022-general"],
+            )
+        ),
+        None,
+        params,
+    )
+    # Reads the physical voting_history column (not the synthetic catalog key).
+    assert "list_has_any(list_transform(voting_history" in where
+    assert params == ["2024-primary", "2022-general"]
+
+
+def test_voting_history_detail_all_membership() -> None:
+    """`all` mode requires every selected election."""
+    params: list = []
+    where = criteria_to_where(
+        CATALOG,
+        _narrow(
+            VotingHistoryDetailFilter(
+                kind="voting-history-detail",
+                key="voting_history_detail",
+                mode="all",
+                elections=["2024-primary", "2022-general"],
+            )
+        ),
+        None,
+        params,
+    )
+    assert "list_has_all(list_transform(voting_history" in where
+    assert params == ["2024-primary", "2022-general"]
+
+
+def test_voting_history_detail_empty_is_inactive() -> None:
+    params: list = []
+    where = criteria_to_where(
+        CATALOG,
+        _narrow(
+            VotingHistoryDetailFilter(
+                kind="voting-history-detail",
+                key="voting_history_detail",
+                mode="any",
+                elections=[],
+            )
+        ),
+        None,
+        params,
+    )
+    assert where == ""
+    assert params == []
 
 
 # ---------------------------------------------------------------------------

--- a/apps/data/tests/test_voting_history.py
+++ b/apps/data/tests/test_voting_history.py
@@ -145,6 +145,13 @@ def test_parse_entry_unknown_method_code_buckets_to_other():
     assert result["method"] == "other"
 
 
+def test_parse_entry_implausible_year_dropped():
+    """A corrupt 8-digit date yielding an out-of-range year is dropped, not
+    surfaced as a bogus election (e.g. the observed '3812 November General')."""
+    assert parse_entry("38120810 GE(P)") is None  # modern format
+    assert parse_entry("GE 38120810(P)") is None  # code-first format
+
+
 # ---------------------------------------------------------------------------
 # parse_voting_history — full-string parsing
 # ---------------------------------------------------------------------------

--- a/apps/web/src/lib/filters.ts
+++ b/apps/web/src/lib/filters.ts
@@ -42,13 +42,24 @@ export type DateRangeFilter = {
   max: string | null;
 };
 
-export type VotingHistoryFilter = {
+export type VotingHistoryCountFilter = {
   kind: "voting-history-count";
   key: string;
   type: "primary" | "general";
   windowYears: number;
   comparator: "at_least" | "exactly";
   count: number;
+};
+
+// Membership in specific named elections. `mode` picks the set semantics: "any"
+// matches a person who voted in at least one selected election, "all" requires
+// every one. Each value is an election's stable key (e.g. `2024-06-primary`);
+// the option set is precomputed per version (see `queries/elections`).
+export type VotingHistoryDetailFilter = {
+  kind: "voting-history-detail";
+  key: string;
+  mode: "any" | "all";
+  elections: string[];
 };
 
 // Single UI element, multiple underlying columns. Each sub-field is
@@ -111,7 +122,8 @@ export type Filter =
   | TextFilter
   | TextMultiFilter
   | DateRangeFilter
-  | VotingHistoryFilter
+  | VotingHistoryCountFilter
+  | VotingHistoryDetailFilter
   | AddressFilter
   | CanvassOutcomeFilter
   | CanvassResponseFilter
@@ -140,6 +152,7 @@ export type FilterDef =
   | { kind: "text-multi"; key: string; label: string }
   | { kind: "date-range"; key: string; label: string }
   | { kind: "voting-history-count"; key: string; label: string }
+  | { kind: "voting-history-detail"; key: string; label: string }
   | { kind: "address"; key: "address"; label: string }
   | {
       kind: "canvass-outcome";
@@ -202,7 +215,9 @@ export function emptyFilterFor(def: FilterDef): Filter {
   if (def.kind === "canvass-response")
     return { kind: "canvass-response", key: "canvass_response", questionId: null, optionIds: [] };
   if (def.kind === "segment") return { kind: "segment", key: "segment", segmentId: null };
-  // Voting history default: "voted in 1+ recent primaries" (single prime).
+  if (def.kind === "voting-history-detail")
+    return { kind: "voting-history-detail", key: def.key, mode: "any", elections: [] };
+  // Voting history count default: "voted in 1+ recent primaries" (single prime).
   return {
     kind: "voting-history-count",
     key: def.key,
@@ -232,6 +247,7 @@ export function isActiveFilter(f: Filter): boolean {
   if (f.kind === "canvass-response") return f.questionId != null && f.optionIds.length > 0;
   if (f.kind === "segment") return f.segmentId != null;
   if (f.kind === "nested") return f.criteria.steps.length > 0;
+  if (f.kind === "voting-history-detail") return f.elections.length > 0;
   // voting-history-count: active when window and count are non-degenerate.
   return f.windowYears > 0 && f.count >= 0;
 }

--- a/apps/web/src/lib/manifest.ts
+++ b/apps/web/src/lib/manifest.ts
@@ -20,12 +20,17 @@ export type ManifestFilterKind =
   | "age-range"
   | "date-range"
   | "voting-history-count"
+  | "voting-history-detail"
   | "address";
 
 export type ManifestEnumValue = { value: string; label?: string | null };
 
 export type ManifestFieldDef = {
-  column: string;
+  // Physical column this field reads; absent for a column-less composite
+  // (`address`). `key` is the field identifier, defaulting to `column`; set
+  // explicitly to disambiguate two filters over one column (voting_history).
+  column?: string | null;
+  key?: string | null;
   label: string;
   filterKind: ManifestFilterKind;
   values?: ManifestEnumValue[] | null;
@@ -40,24 +45,29 @@ export type Manifest = { fields: ManifestFieldDef[][] };
 // this is near-identity.
 function fieldToFilterDef(fd: ManifestFieldDef): FilterDef {
   const label = fd.label;
+  // Field identifier: explicit `key`, else the column (mirrors the data side's
+  // `FieldDef.identifier`). A field with neither is malformed.
+  const key = fd.key ?? fd.column ?? "";
   switch (fd.filterKind) {
     case "text":
-      return { kind: "text", key: fd.column, label };
+      return { kind: "text", key, label };
     case "enum":
       return {
         kind: "enum",
-        key: fd.column,
+        key,
         label,
         values: (fd.values ?? []).map((v) => ({ value: v.value, label: v.label ?? undefined })),
       };
     case "text-multi":
-      return { kind: "text-multi", key: fd.column, label };
+      return { kind: "text-multi", key, label };
     case "age-range":
-      return { kind: "age-range", key: fd.column, label };
+      return { kind: "age-range", key, label };
     case "date-range":
-      return { kind: "date-range", key: fd.column, label };
+      return { kind: "date-range", key, label };
     case "voting-history-count":
-      return { kind: "voting-history-count", key: fd.column, label };
+      return { kind: "voting-history-count", key, label };
+    case "voting-history-detail":
+      return { kind: "voting-history-detail", key, label };
     case "address":
       return { kind: "address", key: "address", label };
   }

--- a/apps/web/src/lib/queries/elections.ts
+++ b/apps/web/src/lib/queries/elections.ts
@@ -1,0 +1,14 @@
+import { queryOptions } from "@tanstack/react-query";
+import { client } from "~/rpc/client";
+
+// Distinct elections in the org's active dataset — the option set for the
+// voting-history-detail filter's picker. Immutable per active version, so
+// `staleTime: Infinity`; a sibling of `manifestQuery` (the active-version flip
+// removes both keys — see `data.tsx` `makeActive`). Ambient org scoping keys it
+// per org (see `queryKeyHashFn`).
+export const electionsQuery = () =>
+  queryOptions({
+    queryKey: ["elections"] as const,
+    queryFn: () => client.datasets.elections(),
+    staleTime: Number.POSITIVE_INFINITY,
+  });

--- a/apps/web/src/routes/$orgSlug/data.tsx
+++ b/apps/web/src/routes/$orgSlug/data.tsx
@@ -102,12 +102,14 @@ function DataPage() {
 
   const makeActive = useMutation({
     mutationFn: (versionId: string) => client.datasets.makeActive({ versionId }),
-    // A new active version replaces the manifest that gates the editors. Remove
-    // it (not just invalidate) so those editors re-fetch clean — useSuspenseQuery
-    // would otherwise render the stale manifest for a frame. Invalidate the rest —
-    // counts, dataset-scoped lists — so they re-resolve on next read.
+    // A new active version replaces the manifest that gates the editors, and the
+    // election list the voting-history-detail filter picks from. Remove both (not
+    // just invalidate) so those editors re-fetch clean — a hard-cached query
+    // would otherwise render stale for a frame. Invalidate the rest — counts,
+    // dataset-scoped lists — so they re-resolve on next read.
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: ["manifest"] });
+      queryClient.removeQueries({ queryKey: ["elections"] });
       void queryClient.invalidateQueries();
     },
     onError: (e) => toast.error(e.message),

--- a/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
+++ b/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
@@ -54,7 +54,8 @@ import {
   type TextFilter,
   type TextMultiFilter,
   type Verb,
-  type VotingHistoryFilter,
+  type VotingHistoryCountFilter,
+  type VotingHistoryDetailFilter,
   VERB_META,
 } from "~/lib/filters";
 import {
@@ -65,6 +66,7 @@ import {
   segmentSampleQuery,
   segmentsListQuery,
 } from "~/lib/queries/segments";
+import { electionsQuery } from "~/lib/queries/elections";
 import { questionsWithOptionsQuery } from "~/lib/queries/questions";
 import { useFilterCatalog } from "~/lib/manifest";
 import { findCyclicSegmentIds, type SegmentLike } from "~/lib/segment-refs";
@@ -673,7 +675,10 @@ function StepRow({
         <DateRangeFilterEditor filter={filter} onChange={onChange} />
       ) : null}
       {filter.kind === "voting-history-count" && def?.kind === "voting-history-count" ? (
-        <VotingHistoryFilterEditor filter={filter} onChange={onChange} />
+        <VotingHistoryCountEditor filter={filter} onChange={onChange} />
+      ) : null}
+      {filter.kind === "voting-history-detail" && def?.kind === "voting-history-detail" ? (
+        <VotingHistoryDetailEditor filter={filter} onChange={onChange} />
       ) : null}
       {filter.kind === "address" && def?.kind === "address" ? (
         <AddressFilterEditor filter={filter} onChange={onChange} />
@@ -1199,11 +1204,11 @@ function DateRangeFilterEditor({
   );
 }
 
-function VotingHistoryFilterEditor({
+function VotingHistoryCountEditor({
   filter,
   onChange,
 }: {
-  filter: VotingHistoryFilter;
+  filter: VotingHistoryCountFilter;
   onChange: (next: Filter) => void;
 }) {
   const [localCount, setLocalCount] = useState(String(filter.count));
@@ -1283,6 +1288,70 @@ function VotingHistoryFilterEditor({
           className="h-7 w-12 px-2"
         />
         <span className="text-muted-foreground">years</span>
+      </div>
+    </div>
+  );
+}
+
+function VotingHistoryDetailEditor({
+  filter,
+  onChange,
+}: {
+  filter: VotingHistoryDetailFilter;
+  onChange: (next: Filter) => void;
+}) {
+  // Elections are precomputed per active dataset (immutable, cached hard). Gate
+  // on data so first load doesn't flash the empty state; the global spinner
+  // covers the wait.
+  const { data } = useQuery(electionsQuery());
+  const toggle = (value: string) => {
+    const next = filter.elections.includes(value)
+      ? filter.elections.filter((v) => v !== value)
+      : [...filter.elections, value];
+    onChange({ ...filter, elections: next });
+  };
+  const radioClass = "aria-pressed:border-muted-foreground data-[state=on]:border-muted-foreground";
+  if (!data) return null;
+  if (data.elections.length === 0) {
+    return <p className="text-sm text-muted-foreground">No elections in this dataset.</p>;
+  }
+  return (
+    <div className="flex flex-col gap-2 text-sm">
+      <div className="flex items-center gap-1.5">
+        <span className="text-muted-foreground">Voted in</span>
+        <Toggle
+          size="sm"
+          variant="outline"
+          pressed={filter.mode === "any"}
+          onPressedChange={(p) => p && onChange({ ...filter, mode: "any" })}
+          className={radioClass}
+        >
+          Any
+        </Toggle>
+        <Toggle
+          size="sm"
+          variant="outline"
+          pressed={filter.mode === "all"}
+          onPressedChange={(p) => p && onChange({ ...filter, mode: "all" })}
+          className={radioClass}
+        >
+          All
+        </Toggle>
+        <span className="text-muted-foreground">of:</span>
+      </div>
+      <div className="flex max-h-56 flex-col gap-1.5 overflow-y-auto">
+        {data.elections.map((e) => (
+          <Toggle
+            key={e.value}
+            size="sm"
+            variant="outline"
+            pressed={filter.elections.includes(e.value)}
+            onPressedChange={() => toggle(e.value)}
+            className={cn("h-7 w-full shrink-0 justify-start", radioClass)}
+          >
+            {e.label}
+          </Toggle>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/rpc/index.ts
+++ b/apps/web/src/rpc/index.ts
@@ -36,6 +36,7 @@ export const webRouter = {
     archive: datasets.archive,
     unarchive: datasets.unarchive,
     manifest: datasets.manifest,
+    elections: datasets.elections,
   },
   segments: {
     list: segments.list,

--- a/apps/web/src/rpc/web/datasets.ts
+++ b/apps/web/src/rpc/web/datasets.ts
@@ -40,7 +40,7 @@ export const list = pub.input(z.object({}).optional()).handler(async ({ context 
       versionId: datasetVersions.datasetVersionId,
       versionNumber: datasetVersions.versionNumber,
       status: datasetVersions.status,
-      rowCount: datasetVersions.rowCount,
+      derivedMetadata: datasetVersions.derivedMetadata,
       importedAt: datasetVersions.createdAt,
       archivedAt: datasetVersions.archivedAt,
       importStep: datasetVersions.importStep,
@@ -52,8 +52,10 @@ export const list = pub.input(z.object({}).optional()).handler(async ({ context 
     .where(eq(datasetOrganizations.organizationId, context.organizationId))
     .orderBy(asc(datasets.name), desc(datasetVersions.versionNumber));
 
-  return rows.map((r) => ({
+  // `rowCount` now lives in the derived-metadata blob (see DerivedMetadata).
+  return rows.map(({ derivedMetadata, ...r }) => ({
     ...r,
+    rowCount: derivedMetadata?.rowCount ?? null,
     isActive: r.versionId === activeDatasetVersionId,
     isArchived: r.archivedAt != null,
   }));
@@ -289,3 +291,24 @@ export const manifest = pub.input(z.object({}).optional()).handler(async ({ cont
   if (!row) return null;
   return { manifest: row.manifest as Manifest, versionId: row.versionId };
 });
+
+export type Election = { value: string; label: string };
+
+// Distinct elections in the org's active dataset — the voting-history-detail
+// filter's picker options. Read straight from the version's derived-metadata
+// blob (precomputed at import), like the manifest — no data-service round trip,
+// no per-request scan. Follows `organizations.activeDatasetVersionId`.
+export const elections = pub
+  .input(z.object({}).optional())
+  .handler(async ({ context }): Promise<{ elections: Election[] }> => {
+    const rows = await context.db
+      .select({ derivedMetadata: datasetVersions.derivedMetadata })
+      .from(organizations)
+      .innerJoin(
+        datasetVersions,
+        eq(datasetVersions.datasetVersionId, organizations.activeDatasetVersionId),
+      )
+      .where(eq(organizations.organizationId, context.organizationId))
+      .limit(1);
+    return { elections: rows[0]?.derivedMetadata?.elections ?? [] };
+  });

--- a/packages/db/src/schema/datasets.ts
+++ b/packages/db/src/schema/datasets.ts
@@ -30,6 +30,15 @@ export const datasets = pgTable(
 
 export type DatasetVersionStatus = "importing" | "ready" | "failed";
 
+// Properties derived once from a version's data at import time and cached here,
+// so reads never recompute them over the (immutable) version's rows. Written by
+// the data server's `finalize_version` alongside `manifest`. `rowCount` is the
+// person count; `elections` backs the voting-history-detail filter's picker.
+export type DerivedMetadata = {
+  rowCount?: number;
+  elections?: { value: string; label: string }[];
+};
+
 // An immutable, retained version of a dataset. Never deleted, so any pinned
 // reference (a published turf, a canvass event) always resolves. Its data lives
 // in the DuckLake schema `${dataset.slug}_v${versionNumber}`. `manifest` is the
@@ -43,8 +52,10 @@ export const datasetVersions = pgTable(
       .references(() => datasets.datasetId),
     versionNumber: integer().notNull(),
     manifest: jsonb(),
+    // Derived-once-at-import cache (see `DerivedMetadata`); read like `manifest`.
+    // Holds `rowCount` + `elections`.
+    derivedMetadata: jsonb().$type<DerivedMetadata>(),
     sourceUri: text(),
-    rowCount: integer(),
     // Coarse import progress (step / total), shown as a % while `importing`.
     importStep: integer(),
     importTotalSteps: integer(),


### PR DESCRIPTION
This PR adds a new "Voting History Detail" filter that supports filtering for any / all of a given combination of historical year and type election combinations. It sits alongside a "Voting History Count" filter that supports the case of filtering for "K of N" elections. Both are useful and commonly requested. 

To avoid a repeated expensive combination, I added a metadata derivation step to the import process that calculates metadata, like the existing `row_count`, and now a unique list of elections (expressed as year / type combinations to smooth over inconsistencies in the voter file and avoid requiring custom ground truth election lists per region).