### PR TITLE
feat: appended custom fields

### DIFF
--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -7,15 +7,22 @@ import tempfile
 from contextlib import asynccontextmanager, suppress
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Response
+from fastapi import FastAPI, HTTPException, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 from starlette.background import BackgroundTask
 
 import src.import_job  # noqa: F401 — registers the `import_dataset_version` job with the worker
+from src.custom_fields import (
+    append_custom_fields,
+    catalog_for,
+    custom_fields_fqn,
+    load_upload_table,
+    sync_registry,
+)
 from src.dsl.compile import boundary_key_expr_for, cascade_sql, criteria_to_where
-from src.dsl.criteria import Criteria, KeyFilter, build_field_catalog
+from src.dsl.criteria import Criteria, KeyFilter
 from src.dsl.resolve import resolve_criteria
 from src.duckdb import get_connection, refresh_s3_secret_on_shared_connection, s3_secret_expires
 from src.job_runner import JobManager
@@ -221,11 +228,106 @@ async def key_group_geojson(key_group: str, org_slug: str):
     )
 
 
+@app.post("/custom-fields/inspect")
+async def custom_fields_inspect(request: Request):
+    """Parse an append file's shape: raw body in, column names out (or 400
+    with the parse error). Stateless — nothing persists; the full file
+    uploads once, on append. The dialog sends CSVs as a head slice (the
+    header is all that's needed) and reads parquet footers client-side, but
+    this endpoint is format-agnostic: DuckDB is the only CSV dialect sniffer,
+    so the form shape can never diverge from what append will see."""
+    data = await request.body()
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty upload.")
+    with tempfile.NamedTemporaryFile(suffix=".upload") as tmp:
+        tmp.write(data)
+        tmp.flush()
+        conn = get_connection(settings)
+        try:
+            try:
+                columns = await asyncio.to_thread(load_upload_table, conn, tmp.name)
+            except Exception as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+        finally:
+            conn.close()
+    return {"columns": columns}
+
+
+@app.post("/custom-fields/append")
+async def custom_fields_append(
+    request: Request,
+    dataset_id: str = Query(alias="datasetId"),
+    dataset_slug: str = Query(alias="datasetSlug"),
+    field_type: str = Query(alias="fieldType"),
+    upload_id: str = Query(alias="uploadId"),
+    label: str | None = Query(default=None),
+    value: str | None = Query(default=None),
+):
+    """Synchronous append: raw file body + config in query params → parse →
+    registry upsert → lake write → coverage/enum sync → stats out, or 400
+    with the parse error (nothing written). The web edge authenticates,
+    generates `uploadId`, and records provenance after success; lake rows
+    carry the id so every value traces back to its upload."""
+    data = await request.body()
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty upload.")
+
+    def run(source: str) -> dict:
+        conn = get_connection(settings)
+        try:
+            return append_custom_fields(
+                conn,
+                dataset_id=dataset_id,
+                dataset_slug=dataset_slug,
+                upload_id=upload_id,
+                source=source,
+                field_type=field_type,
+                label=label,
+                value=value,
+            )
+        finally:
+            conn.close()
+
+    with tempfile.NamedTemporaryFile(suffix=".upload") as tmp:
+        tmp.write(data)
+        tmp.flush()
+        try:
+            return await asyncio.to_thread(run, tmp.name)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 # Request models accept the camelCase wire shape sent by the TS web tier
 # while exposing snake_case Python attributes. `populate_by_name=True` lets
 # internal callers (tests, ad-hoc construction) use the Python field name.
 class _WireBaseModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
+
+
+class _CustomFieldClearRequest(_WireBaseModel):
+    dataset_slug: str = Field(validation_alias="datasetSlug")
+    field_id: str = Field(validation_alias="fieldId")
+
+
+@app.post("/custom-fields/clear")
+async def custom_fields_clear(req: _CustomFieldClearRequest):
+    """Clear a custom field: delete its values for everyone. The registry row
+    stays (at zero coverage), ready for re-append. Synchronous — one DELETE +
+    a registry sync, no file parsing. Field↔dataset ownership is checked at
+    the web edge (the auth boundary), like every other endpoint's org_slug.
+    History, if ever needed, is DuckLake snapshots — not application state.
+    """
+    conn = get_connection(settings)
+    try:
+        table = custom_fields_fqn(req.dataset_slug)
+        try:
+            conn.execute(f"DELETE FROM {table} WHERE field_id = ?", [req.field_id])
+        except Exception:  # noqa: BLE001 — no values table yet: nothing to clear
+            return {"ok": True}
+        sync_registry(conn, req.dataset_slug, include_values=False)
+    finally:
+        conn.close()
+    return {"ok": True}
 
 
 class _PersonsCountRequest(_WireBaseModel):
@@ -243,7 +345,7 @@ async def persons_count(req: _PersonsCountRequest):
     conn = get_connection(settings, read_only=True)
     version = resolve_version(conn, settings, req.org_slug)
     schema = version.schema
-    catalog = build_field_catalog(version.manifest)
+    catalog = catalog_for(conn, version)
     criteria = resolve_criteria(req.criteria, conn, settings, req.org_slug)
     params: list = []
     where = criteria_to_where(catalog, criteria, req.key_filter, params)
@@ -284,7 +386,7 @@ async def persons_count_cascade(req: _PersonsCountCascadeRequest):
     """
     conn = get_connection(settings, read_only=True)
     version = resolve_version(conn, settings, req.org_slug)
-    catalog = build_field_catalog(version.manifest)
+    catalog = catalog_for(conn, version)
     criteria = resolve_criteria(req.criteria, conn, settings, req.org_slug)
     persons_table = resolve("{persons_geocoded}", version.schema)
     params: list = []
@@ -319,7 +421,7 @@ async def persons_sample(req: _PersonsSampleRequest):
     conn = get_connection(settings, read_only=True)
     version = resolve_version(conn, settings, req.org_slug)
     schema = version.schema
-    catalog = build_field_catalog(version.manifest)
+    catalog = catalog_for(conn, version)
     criteria = resolve_criteria(req.criteria, conn, settings, req.org_slug)
     params: list = []
     where = criteria_to_where(catalog, criteria, req.key_filter, params)
@@ -452,7 +554,7 @@ async def persons_count_by_key(req: _PersonsCountByKeyRequest):
     conn = get_connection(settings, read_only=True)
     version = resolve_version(conn, settings, req.org_slug)
     schema = version.schema
-    catalog = build_field_catalog(version.manifest)
+    catalog = catalog_for(conn, version)
     group_expr = boundary_key_expr_for(catalog, req.key_group)
     criteria = resolve_criteria(req.criteria, conn, settings, req.org_slug)
     params: list = []
@@ -525,7 +627,7 @@ async def segments_export(req: _SegmentExportRequest):
     conn = get_connection(settings, read_only=True)
     version = resolve_version(conn, settings, req.org_slug)
     schema = version.schema
-    catalog = build_field_catalog(version.manifest)
+    catalog = catalog_for(conn, version)
     criteria = resolve_criteria(req.criteria, conn, settings, req.org_slug)
     params: list = []
     where = criteria_to_where(catalog, criteria, None, params)
@@ -574,7 +676,7 @@ async def buildings_list(req: _BuildingsListRequest):
     conn = get_connection(settings, read_only=True)
     version = resolve_version(conn, settings, req.org_slug)
     schema = version.schema
-    catalog = build_field_catalog(version.manifest)
+    catalog = catalog_for(conn, version)
     criteria = resolve_criteria(req.criteria, conn, settings, req.org_slug)
     params: list = []
     where = criteria_to_where(catalog, criteria, req.key_filter, params)
@@ -624,7 +726,7 @@ async def buildings_points(req: _BuildingsPointsRequest):
     conn = get_connection(settings, read_only=True)
     version = resolve_version(conn, settings, req.org_slug)
     schema = version.schema
-    catalog = build_field_catalog(version.manifest)
+    catalog = catalog_for(conn, version)
     criteria = resolve_criteria(req.criteria, conn, settings, req.org_slug)
     params: list = []
     where = criteria_to_where(catalog, criteria, req.key_filter, params)

--- a/apps/data/src/custom_fields.py
+++ b/apps/data/src/custom_fields.py
@@ -1,0 +1,378 @@
+"""Custom-field lake storage (see docs/plans/custom-fields.md).
+
+One long-format table per dataset, beside (not inside) the version schemas —
+`ducklake.main.<slug>_custom_fields (external_id, field_id, value, upload_id)`
+— which is what makes floating-across-versions visible in the layout itself.
+One row per (person, field) that has a value; `value` is a string cast at
+query time. Mutated directly (insert/upsert/delete) — history comes from
+DuckLake snapshots, not a hand-rolled journal.
+
+Used by the synchronous append and clear endpoints in `main.py`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.dsl.criteria import FieldCatalog, build_field_catalog
+from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres
+from src.settings import get_settings
+from src.tables import ResolvedVersion, dataset_version_schema, table_fqn
+
+if TYPE_CHECKING:
+    import duckdb
+
+# Dataset-scoped custom-field tables live in the catalog's default schema.
+_SCHEMA = "main"
+
+# Enum option sets above this are almost certainly free text — fail loudly and
+# suggest the text type instead of silently building a 5,000-toggle picker.
+_ENUM_VALUES_CAP = 100
+
+_FIELD_TYPES = ("number", "date", "text", "enum")
+
+# Display names for error messages — mirrors the UI's FIELD_TYPE_META.
+_TYPE_LABELS = {"number": "Number", "date": "Date", "text": "Text", "enum": "Category"}
+
+
+def custom_fields_fqn(dataset_slug: str) -> str:
+    return table_fqn(_SCHEMA, f"{dataset_slug}_custom_fields")
+
+
+def ensure_custom_fields_table(conn: duckdb.DuckDBPyConnection, dataset_slug: str) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {custom_fields_fqn(dataset_slug)} (
+            external_id VARCHAR, field_id VARCHAR, value VARCHAR, upload_id VARCHAR
+        )
+        """
+    )
+
+
+def custom_fields_table_for(conn: duckdb.DuckDBPyConnection, dataset_slug: str) -> str | None:
+    """FQN of the dataset's values table, or None before any append — custom
+    filters then compile to match-nothing rather than erroring."""
+    fqn = custom_fields_fqn(dataset_slug)
+    try:
+        conn.execute(f"SELECT 1 FROM {fqn} LIMIT 0")
+    except Exception:  # noqa: BLE001 — missing table is the expected miss
+        return None
+    return fqn
+
+
+def sync_registry(conn: duckdb.DuckDBPyConnection, dataset_slug: str, *, include_values: bool = True) -> None:
+    """Mirror per-field coverage (and enum option sets) onto the Postgres
+    registry. Safe as a cache: values only change through the two callers
+    (append ingest, clear) — no third writer to drift against. Simple
+    per-row statements: the postgres ATTACH doesn't reliably support
+    UPDATE...FROM joined against lake tables, and the registry is small."""
+    attach_operational_postgres(conn, get_settings())
+    counts = conn.execute(
+        f"SELECT field_id, count(DISTINCT external_id) FROM {custom_fields_fqn(dataset_slug)} GROUP BY field_id"
+    ).fetchall()
+    conn.execute(
+        f"""
+        UPDATE {OPERATIONAL_PG_ALIAS}.public.custom_fields SET person_count = 0
+        WHERE dataset_id = (SELECT dataset_id FROM {OPERATIONAL_PG_ALIAS}.public.datasets WHERE slug = ?)
+        """,
+        [dataset_slug],
+    )
+    for field_id, n in counts:
+        conn.execute(
+            f"UPDATE {OPERATIONAL_PG_ALIAS}.public.custom_fields SET person_count = ? WHERE custom_field_id = ?::UUID",
+            [n, field_id],
+        )
+    # Enum option sets are owned by APPEND (derived from the data at ingest)
+    # and never touched by clear — a cleared field keeps its last-known
+    # options so open filter cards stay renderable (matching no one) instead
+    # of stranding selections against an empty picker.
+    if not include_values:
+        return
+    enum_fields = conn.execute(
+        f"""
+        SELECT f.custom_field_id::VARCHAR FROM {OPERATIONAL_PG_ALIAS}.public.custom_fields f
+        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d ON d.dataset_id = f.dataset_id
+        WHERE d.slug = ? AND f.field_type = 'enum'
+        """,
+        [dataset_slug],
+    ).fetchall()
+    for (field_id,) in enum_fields:
+        values = [
+            r[0]
+            for r in conn.execute(
+                f"SELECT DISTINCT value FROM {custom_fields_fqn(dataset_slug)} WHERE field_id = ? ORDER BY value",
+                [field_id],
+            ).fetchall()
+        ]
+        conn.execute(
+            f"UPDATE {OPERATIONAL_PG_ALIAS}.public.custom_fields SET values = ? WHERE custom_field_id = ?::UUID",
+            [values, field_id],
+        )
+
+
+def catalog_for(conn: duckdb.DuckDBPyConnection, version: ResolvedVersion) -> FieldCatalog:
+    """The compiler catalog for a resolved version: manifest fields plus the
+    dataset's custom fields (archived included — saved segments referencing an
+    archived field must still compile). One small PG read + one table probe
+    per request."""
+    attach_operational_postgres(conn, get_settings())
+    rows = conn.execute(
+        f"""
+        SELECT f.custom_field_id::VARCHAR, f.field_type
+        FROM {OPERATIONAL_PG_ALIAS}.public.custom_fields f
+        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d ON d.dataset_id = f.dataset_id
+        WHERE d.slug = ?
+        """,
+        [version.dataset_slug],
+    ).fetchall()
+    return build_field_catalog(
+        version.manifest,
+        custom_table=custom_fields_table_for(conn, version.dataset_slug),
+        custom_fields={r[0]: r[1] for r in rows},
+    )
+
+
+def load_upload_table(conn: duckdb.DuckDBPyConnection, path: str) -> list[str]:
+    """Load an uploaded file into the `_upload` temp table and return its
+    column names. Format by magic bytes: parquet ("PAR1") or CSV (header row
+    required, all_varchar so ids keep leading zeros). The single parser for
+    both the inspect and append endpoints — one place for format logic and
+    errors."""
+    with open(path, "rb") as f:
+        magic = f.read(4)
+    if magic == b"PAR1":
+        conn.execute("CREATE OR REPLACE TEMP TABLE _upload AS SELECT * FROM read_parquet(?)", [path])
+    else:
+        conn.execute(
+            "CREATE OR REPLACE TEMP TABLE _upload AS SELECT * FROM read_csv(?, all_varchar = true, header = true)",
+            [path],
+        )
+    cols = [r[0] for r in conn.execute("DESCRIBE _upload").fetchall()]
+    if not cols:
+        raise ValueError("Uploaded file has no columns.")
+    if len(cols) > 2:
+        raise ValueError(f"File has {len(cols)} columns, must have one (IDs only) or two (IDs and values).")
+    return cols
+
+
+def parse_upload(
+    conn: duckdb.DuckDBPyConnection,
+    source: str,
+    field_type: str,
+    label_arg: str | None,
+    value: str | None,
+) -> tuple[str, int, int]:
+    """Load → normalize → validate one upload file. Leaves the normalized
+    rows in the `_rows` temp table for the caller and returns
+    (label, row_count, skipped_count). Pure DuckDB — tests run it against an
+    in-memory connection with fixture CSVs."""
+    if field_type not in _FIELD_TYPES:
+        raise ValueError(f"Unknown field type {field_type!r}.")
+    cols = load_upload_table(conn, source)
+    # Two-column files: the field name IS the value column's header.
+    if len(cols) == 2:
+        label = cols[1].strip()
+        if not label:
+            raise ValueError("The value column needs a header name.")
+    else:
+        label = label_arg.strip() if label_arg else None
+        if not label:
+            raise ValueError("A one-column file needs a field name.")
+    id_col = f'CAST("{cols[0]}" AS VARCHAR)'
+
+    # Normalize to (external_id, label, value); trim, drop empties, dedupe.
+    # Two columns → per-person values; one column → the dialog's constant
+    # ("everyone in this list gets X").
+    if len(cols) >= 2:
+        # One value per person: on in-file duplicates, keep max() —
+        # deterministic, and dup ids in a scalar file are a data smell
+        # rather than a supported feature.
+        conn.execute(
+            f"""
+            CREATE OR REPLACE TEMP TABLE _rows AS
+            SELECT trim({id_col}) AS external_id, ? AS label,
+                max(trim(CAST("{cols[1]}" AS VARCHAR))) AS value
+            FROM _upload
+            WHERE trim({id_col}) <> '' AND trim(CAST("{cols[1]}" AS VARCHAR)) <> ''
+            GROUP BY trim({id_col})
+            """,
+            [label],
+        )
+    else:
+        value = value.strip() if value else None
+        if not value:
+            raise ValueError("A one-column file needs a value, which will applied to everyone in the list.")
+        conn.execute(
+            f"""
+            CREATE OR REPLACE TEMP TABLE _rows AS
+            SELECT DISTINCT trim({id_col}) AS external_id, ? AS label, ? AS value
+            FROM _upload WHERE trim({id_col}) <> ''
+            """,
+            [label, value],
+        )
+    row = conn.execute("SELECT count(*) FROM _rows").fetchone()
+    row_count = row[0] if row else 0
+    if row_count == 0:
+        raise ValueError("No usable rows in the uploaded file.")
+    # Two-column rows with an id but a blank value are ignored entirely
+    # (no write, prior values survive) — counted so the dialog can say so.
+    skipped_count = 0
+    if len(cols) == 2:
+        # Blank CSV cells arrive as NULL (not '') — count both shapes.
+        skipped = conn.execute(
+            f"""SELECT count(*) FROM _upload
+            WHERE trim({id_col}) <> ''
+                AND ("{cols[1]}" IS NULL OR trim(CAST("{cols[1]}" AS VARCHAR)) = '')"""
+        ).fetchone()
+        skipped_count = skipped[0] if skipped else 0
+
+    # Typed values are validated at ingest — fail loudly with an example
+    # rather than storing values that silently never match at query time
+    # (query-side try_cast is the same arbiter: plain or scientific
+    # notation for numbers, ISO YYYY-MM-DD for dates).
+    if field_type in ("number", "date"):
+        cast = "DOUBLE" if field_type == "number" else "DATE"
+        bad = conn.execute(
+            f"SELECT count(*), any_value(value) FROM _rows WHERE try_cast(value AS {cast}) IS NULL"
+        ).fetchone()
+        if bad and bad[0] > 0:
+            kind = "numbers" if field_type == "number" else "dates (expected YYYY-MM-DD)"
+            raise ValueError(f'{bad[0]} of {row_count} values aren\'t {kind} — e.g. "{bad[1]}".')
+
+    if field_type == "enum":
+        distinct = conn.execute("SELECT count(DISTINCT value) FROM _rows").fetchone()[0]
+        if distinct > _ENUM_VALUES_CAP:
+            raise ValueError(
+                f"{distinct} distinct values is too many for a Category field "
+                f"(max {_ENUM_VALUES_CAP}), use the Text type instead."
+            )
+
+    return label, row_count, skipped_count
+
+
+def append_custom_fields(
+    conn: duckdb.DuckDBPyConnection,
+    *,
+    dataset_id: str,
+    dataset_slug: str,
+    upload_id: str,
+    source: str,
+    field_type: str,
+    label: str | None,
+    value: str | None,
+) -> dict[str, Any]:
+    """One synchronous append: parse the file at `source`, upsert the registry,
+    write values into the lake (latest wins), sync coverage/enum options, and
+    return `{fields, rowCount, skippedCount, matchedCount}` for the dialog.
+    Raises ValueError with a user-facing message on any parse/validation
+    failure — nothing is written in that case."""
+    attach_operational_postgres(conn, get_settings())
+    label, row_count, skipped_count = parse_upload(conn, source, field_type, label, value)
+
+    _upsert_registry(conn, dataset_id, field_type)
+    conn.execute(
+        f"""
+        CREATE OR REPLACE TEMP TABLE _rows_ids AS
+        SELECT r.external_id, f.custom_field_id::VARCHAR AS field_id, r.value
+        FROM _rows r
+        JOIN {OPERATIONAL_PG_ALIAS}.public.custom_fields f
+            ON f.label = r.label AND f.dataset_id = ?::UUID
+        """,
+        [dataset_id],
+    )
+    matched_count = _matched_count(conn, dataset_slug)
+
+    ensure_custom_fields_table(conn, dataset_slug)
+    values_table = custom_fields_fqn(dataset_slug)
+    conn.execute("BEGIN TRANSACTION")
+    try:
+        # Latest wins: replace the listed people's values for this field.
+        conn.execute(
+            f"""
+            DELETE FROM {values_table}
+            WHERE field_id IN (SELECT DISTINCT field_id FROM _rows_ids)
+                AND external_id IN (SELECT external_id FROM _rows_ids)
+            """
+        )
+        conn.execute(
+            f"INSERT INTO {values_table} SELECT external_id, field_id, value, ? FROM _rows_ids",
+            [upload_id],
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+    sync_registry(conn, dataset_slug)
+    labels = [r[0] for r in conn.execute("SELECT DISTINCT label FROM _rows ORDER BY label").fetchall()]
+    return {
+        "fields": labels,
+        "rowCount": row_count,
+        "skippedCount": skipped_count,
+        "matchedCount": matched_count,
+    }
+
+
+def _upsert_registry(conn: duckdb.DuckDBPyConnection, dataset_id: str, field_type: str) -> None:
+    """Ensure a registry row per label in `_rows`: insert missing (typed),
+    revive archived, and reject type conflicts — a label can't be a number in
+    one upload and a date in the next."""
+    conflict = conn.execute(
+        f"""
+        SELECT f.label, f.field_type, f.archived_at IS NOT NULL
+        FROM {OPERATIONAL_PG_ALIAS}.public.custom_fields f
+        WHERE f.dataset_id = ?::UUID AND f.field_type <> ?
+            AND f.label IN (SELECT DISTINCT label FROM _rows)
+        LIMIT 1
+        """,
+        [dataset_id, field_type],
+    ).fetchone()
+    if conflict is not None:
+        label, existing_type, archived = conflict
+        kind = f"{'an archived' if archived else 'a'} {_TYPE_LABELS.get(existing_type, existing_type)}"
+        raise ValueError(
+            f'Field "{label}" already exists as {kind} field. Rename that field to use this name for a different type.'
+        )
+    conn.execute(
+        f"""
+        INSERT INTO {OPERATIONAL_PG_ALIAS}.public.custom_fields (custom_field_id, dataset_id, label, field_type)
+        SELECT uuid(), ?::UUID, label, ? FROM (SELECT DISTINCT label FROM _rows)
+        WHERE label NOT IN (
+            SELECT label FROM {OPERATIONAL_PG_ALIAS}.public.custom_fields WHERE dataset_id = ?::UUID
+        )
+        """,
+        [dataset_id, field_type, dataset_id],
+    )
+    conn.execute(
+        f"""
+        UPDATE {OPERATIONAL_PG_ALIAS}.public.custom_fields SET archived_at = NULL
+        WHERE dataset_id = ?::UUID AND archived_at IS NOT NULL
+            AND label IN (SELECT DISTINCT label FROM _rows)
+        """,
+        [dataset_id],
+    )
+
+
+def _matched_count(conn: duckdb.DuckDBPyConnection, dataset_slug: str) -> int | None:
+    """Distinct uploaded ids present in the dataset's latest ready version, or
+    None when the dataset has no ready version yet. Informational — unmatched
+    ids are kept; they may match a later version."""
+    row = conn.execute(
+        f"""
+        SELECT max(v.version_number)
+        FROM {OPERATIONAL_PG_ALIAS}.public.dataset_versions v
+        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d ON d.dataset_id = v.dataset_id
+        WHERE d.slug = ? AND v.status = 'ready'
+        """,
+        [dataset_slug],
+    ).fetchone()
+    if row is None or row[0] is None:
+        return None
+    persons = table_fqn(dataset_version_schema(dataset_slug, row[0]), "persons_geocoded")
+    matched = conn.execute(
+        f"""
+        SELECT count(DISTINCT r.external_id) FROM _rows r
+        WHERE r.external_id IN (SELECT external_id FROM {persons})
+        """
+    ).fetchone()
+    return matched[0] if matched else 0

--- a/apps/data/src/dsl/compile.py
+++ b/apps/data/src/dsl/compile.py
@@ -20,6 +20,7 @@ from .criteria import (
     CanvassOutcomeFilter,
     CanvassResponseFilter,
     Criteria,
+    CustomFieldDef,
     DateRangeFieldDef,
     DateRangeFilter,
     EnumFieldDef,
@@ -29,6 +30,7 @@ from .criteria import (
     Filter,
     KeyFilter,
     NestedFilter,
+    NumberRangeFilter,
     PersonIdSetFilter,
     TextFieldDef,
     TextFilter,
@@ -160,21 +162,35 @@ def _filter_clause(catalog: FieldCatalog, f: Filter, params: list[Any]) -> str:
     if isinstance(f, AllFilter):
         return "1=1"
     if isinstance(f, EnumFilter):
-        return _enum_clause(f, _field(catalog, f.key), params)
+        def_ = _field(catalog, f.key)
+        if isinstance(def_, CustomFieldDef):
+            return _custom_clause(f, def_, catalog, params)
+        return _enum_clause(f, def_, params)
     if isinstance(f, AgeRangeFilter):
         return _age_range_clause(f, _field(catalog, f.key), params)
     if isinstance(f, TextFilter):
-        return _text_clause(f, _field(catalog, f.key), params)
+        def_ = _field(catalog, f.key)
+        if isinstance(def_, CustomFieldDef):
+            return _custom_clause(f, def_, catalog, params)
+        return _text_clause(f, def_, params)
     if isinstance(f, TextMultiFilter):
         return _text_multi_clause(f, _field(catalog, f.key), params)
     if isinstance(f, DateRangeFilter):
-        return _date_range_clause(f, _field(catalog, f.key), params)
+        def_ = _field(catalog, f.key)
+        if isinstance(def_, CustomFieldDef):
+            return _custom_clause(f, def_, catalog, params)
+        return _date_range_clause(f, def_, params)
     if isinstance(f, VotingHistoryCountFilter):
         return _voting_history_count_clause(f, _field(catalog, f.key), params)
     if isinstance(f, VotingHistoryDetailFilter):
         return _voting_history_detail_clause(f, _field(catalog, f.key), params)
     if isinstance(f, AddressFilter):
         return _address_clause(f, _field(catalog, f.key), params)
+    if isinstance(f, NumberRangeFilter):
+        def_ = _field(catalog, f.key)
+        if not isinstance(def_, CustomFieldDef):
+            raise CriteriaError(f"Field {f.key} is not a number field")
+        return _custom_clause(f, def_, catalog, params)
     if isinstance(f, NestedFilter):
         # Empty inner → 1=1 to match the standalone "empty segment matches everyone" semantic.
         inner = _criteria_bool_expr(catalog, f.criteria, params)
@@ -191,6 +207,66 @@ def _filter_clause(catalog: FieldCatalog, f: Filter, params: list[Any]) -> str:
         # Should have been reduced to a PersonIdSetFilter in resolve.py.
         raise CriteriaError(f"{type(f).__name__} reached the compiler unresolved")
     raise CriteriaError(f"Unknown filter kind: {type(f).__name__}")
+
+
+def _custom_clause(
+    f: EnumFilter | TextFilter | DateRangeFilter | NumberRangeFilter,
+    def_: CustomFieldDef,
+    catalog: FieldCatalog,
+    params: list[Any],
+) -> str:
+    """Predicate on a custom field — a semi-join against the dataset's
+    long-format values table, with the value cast per the field's type.
+    Inactive filters return "" exactly like their persons-column cousins."""
+    if isinstance(f, EnumFilter):
+        if def_.kind != "enum":
+            raise CriteriaError(f"Field {f.key} is not an enum field")
+        if not f.values:
+            return ""
+        placeholders = ", ".join("?" for _ in f.values)
+        pred = f"value IN ({placeholders})"
+        pred_params: list[Any] = list(f.values)
+    elif isinstance(f, TextFilter):
+        if def_.kind != "text":
+            raise CriteriaError(f"Field {f.key} is not a text field")
+        if not f.value.strip():
+            return ""
+        pred = "value ILIKE ?"
+        pred_params = [f"%{f.value}%"]
+    elif isinstance(f, DateRangeFilter):
+        if def_.kind != "date":
+            raise CriteriaError(f"Field {f.key} is not a date field")
+        if not f.min and not f.max:
+            return ""
+        parts: list[str] = []
+        pred_params = []
+        if f.min:
+            parts.append("try_cast(value AS DATE) >= ?")
+            pred_params.append(f.min)
+        if f.max:
+            parts.append("try_cast(value AS DATE) <= ?")
+            pred_params.append(f.max)
+        pred = " AND ".join(parts)
+    else:  # NumberRangeFilter
+        if def_.kind != "number":
+            raise CriteriaError(f"Field {f.key} is not a number field")
+        if f.min is None and f.max is None:
+            return ""
+        parts = []
+        pred_params = []
+        if f.min is not None:
+            parts.append("try_cast(value AS DOUBLE) >= ?")
+            pred_params.append(f.min)
+        if f.max is not None:
+            parts.append("try_cast(value AS DOUBLE) <= ?")
+            pred_params.append(f.max)
+        pred = " AND ".join(parts)
+
+    if catalog.custom_table is None:
+        return "1=0"
+    params.append(def_.key)
+    params.extend(pred_params)
+    return f"external_id IN (SELECT external_id FROM {catalog.custom_table} WHERE field_id = ? AND {pred})"
 
 
 def _enum_clause(f: EnumFilter, def_: FieldDef, params: list[Any]) -> str:

--- a/apps/data/src/dsl/criteria.py
+++ b/apps/data/src/dsl/criteria.py
@@ -109,6 +109,16 @@ class AddressFilter(BaseModel):
     zip: str  # noqa: A003
 
 
+class NumberRangeFilter(BaseModel):
+    """Numeric range over a number-type custom field (values cast at query
+    time). Either bound is optional; both unset → inactive."""
+
+    kind: Literal["number-range"]
+    key: str
+    min: float | None = None  # noqa: A003
+    max: float | None = None  # noqa: A003
+
+
 class CanvassOutcomeFilter(BaseModel):
     """Prior canvass dispositions read back from canvass_events. Matches a
     person if any of their per-turf current results has an outcome in
@@ -173,6 +183,7 @@ Filter = Annotated[
     | VotingHistoryCountFilter
     | VotingHistoryDetailFilter
     | AddressFilter
+    | NumberRangeFilter
     | CanvassOutcomeFilter
     | CanvassResponseFilter
     | PersonIdSetFilter
@@ -288,13 +299,32 @@ class FieldCatalog:
     `fields` maps a filter `key` → the compiler's typed `FieldDef`. `key_groups`
     maps a boundary keyGroup → the field key carrying that key on
     persons_geocoded (drives `keyFilter` clauses + per-key aggregation GROUP BYs).
+    `custom_table` is the FQN of the dataset's custom-fields values table
+    (`main.<slug>_custom_fields`), or None before any append — custom-field
+    filters then compile to match-nothing. Custom fields enter `fields`
+    alongside manifest fields as `CustomFieldDef`s keyed by field id, so the
+    same filter kinds work against both; the compiler branches only on where
+    the field lives (persons column vs. values-table semi-join).
     """
 
-    fields: dict[str, FieldDef]
+    fields: dict[str, "FieldDef | CustomFieldDef"]
     key_groups: dict[str, str]
+    custom_table: str | None = None
 
 
-def build_field_catalog(manifest: Manifest) -> FieldCatalog:
+class CustomFieldDef(BaseModel):
+    """A custom (appended) field in the compiler catalog. `kind` is the
+    field's type; `key` is the registry id (`custom_fields.custom_field_id`)."""
+
+    kind: Literal["number", "date", "text", "enum"]
+    key: str
+
+
+def build_field_catalog(
+    manifest: Manifest,
+    custom_table: str | None = None,
+    custom_fields: dict[str, str] | None = None,
+) -> FieldCatalog:
     """Derive the compiler catalog from a dataset version's `Manifest`.
 
     Manifest `filter_kind` values mirror the compiler's `FieldDef` kinds 1:1, so
@@ -326,4 +356,7 @@ def build_field_catalog(manifest: Manifest) -> FieldCatalog:
             fields[key] = AddressFieldDef(kind="address", key="address")
         if fd.key_group:
             key_groups[fd.key_group] = key
-    return FieldCatalog(fields=fields, key_groups=key_groups)
+    merged: dict[str, FieldDef | CustomFieldDef] = dict(fields)
+    for field_id, field_type in (custom_fields or {}).items():
+        merged[field_id] = CustomFieldDef(kind=field_type, key=field_id)  # type: ignore[arg-type]
+    return FieldCatalog(fields=merged, key_groups=key_groups, custom_table=custom_table)

--- a/apps/data/src/publish_turfs.py
+++ b/apps/data/src/publish_turfs.py
@@ -20,8 +20,9 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException
 from pydantic import BaseModel
 
+from src.custom_fields import catalog_for
 from src.dsl.compile import criteria_to_where
-from src.dsl.criteria import Criteria, KeyFilter, build_field_catalog
+from src.dsl.criteria import Criteria, KeyFilter
 from src.dsl.resolve import resolve_criteria
 from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres, get_connection
 from src.settings import get_settings
@@ -92,7 +93,7 @@ async def publish_turfs(req: PublishTurfsRequest) -> dict[str, Any]:
 
     version = resolve_version(conn, settings, req.orgSlug)
     schema = version.schema
-    catalog = build_field_catalog(version.manifest)
+    catalog = catalog_for(conn, version)
     scope = _load_publish_scope(conn, req)
     criteria = resolve_criteria(scope.criteria, conn, settings, req.orgSlug)
     where_params: list = []

--- a/apps/data/tests/test_compile.py
+++ b/apps/data/tests/test_compile.py
@@ -20,6 +20,7 @@ from src.dsl.criteria import (
     EnumFilter,
     KeyFilter,
     NestedFilter,
+    NumberRangeFilter,
     PersonIdSetFilter,
     Step,
     TextFilter,
@@ -472,6 +473,71 @@ def test_mixed_verb_sequence_preserves_order() -> None:
     assert " OR " in where
     assert " AND NOT " in where
     assert params == ["democratic", "republican", "%smith%"]
+
+
+# ---------------------------------------------------------------------------
+# Custom-field filters (values-table semi-join — see docs/plans/custom-fields.md)
+# ---------------------------------------------------------------------------
+
+
+CUSTOM_CATALOG = build_field_catalog(
+    NYS_MANIFEST,
+    custom_table="ducklake.main.nys_custom_fields",
+    custom_fields={"f-num": "number", "f-date": "date", "f-text": "text", "f-enum": "enum"},
+)
+
+
+def test_custom_number_range_semi_join() -> None:
+    params: list = []
+    where = criteria_to_where(
+        CUSTOM_CATALOG,
+        _narrow(NumberRangeFilter(kind="number-range", key="f-num", min=0.5, max=0.9)),
+        None,
+        params,
+    )
+    assert where == (
+        "WHERE external_id IN (SELECT external_id FROM ducklake.main.nys_custom_fields "
+        "WHERE field_id = ? AND try_cast(value AS DOUBLE) >= ? AND try_cast(value AS DOUBLE) <= ?)"
+    )
+    assert params == ["f-num", 0.5, 0.9]
+
+
+def test_custom_date_range_casts_value() -> None:
+    params: list = []
+    where = criteria_to_where(
+        CUSTOM_CATALOG,
+        _narrow(DateRangeFilter(kind="date-range", key="f-date", min="2026-01-01", max=None)),
+        None,
+        params,
+    )
+    assert "try_cast(value AS DATE) >= ?" in where
+    assert params == ["f-date", "2026-01-01"]
+
+
+def test_custom_enum_and_text_clauses() -> None:
+    params: list = []
+    where = criteria_to_where(
+        CUSTOM_CATALOG,
+        _narrow(
+            EnumFilter(kind="enum", key="f-enum", values=["a", "b"]),
+            TextFilter(kind="text", key="f-text", value="smith"),
+        ),
+        None,
+        params,
+    )
+    assert "WHERE field_id = ? AND value IN (?, ?)" in where
+    assert "WHERE field_id = ? AND value ILIKE ?" in where
+    assert params == ["f-enum", "a", "b", "f-text", "%smith%"]
+
+
+def test_custom_field_kind_mismatch_raises() -> None:
+    with pytest.raises(CriteriaError):
+        criteria_to_where(
+            CUSTOM_CATALOG,
+            _narrow(NumberRangeFilter(kind="number-range", key="f-date", min=1.0, max=None)),
+            None,
+            [],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/data/tests/test_custom_field_parse.py
+++ b/apps/data/tests/test_custom_field_parse.py
@@ -1,0 +1,147 @@
+"""Fixture-CSV tests for custom-field upload parsing/validation
+(`parse_upload`) — the contract the Append dialog relies on. Pure in-memory
+DuckDB; each test writes a small CSV and asserts the parse or the error."""
+
+import pytest
+
+import duckdb
+from src.custom_fields import parse_upload
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    yield c
+    c.close()
+
+
+def _csv(tmp_path, text: str) -> str:
+    f = tmp_path / "upload.csv"
+    f.write_text(text)
+    return str(f)
+
+
+def _values(conn) -> dict[str, str]:
+    return dict(conn.execute("SELECT external_id, value FROM _rows").fetchall())
+
+
+def test_two_column_derives_label_from_header(conn, tmp_path):
+    src = _csv(tmp_path, "id,support_score\n1,0.5\n2,0.9\n")
+    label, rows, skipped = parse_upload(conn, src, "number", None, None)
+    assert (label, rows, skipped) == ("support_score", 2, 0)
+    assert _values(conn) == {"1": "0.5", "2": "0.9"}
+
+
+def test_one_column_uses_dialog_label_and_value(conn, tmp_path):
+    src = _csv(tmp_path, "id\n1\n2\n2\n")
+    label, rows, skipped = parse_upload(conn, src, "enum", "employer", "amazon")
+    assert (label, rows, skipped) == ("employer", 2, 0)  # deduped
+    assert _values(conn) == {"1": "amazon", "2": "amazon"}
+
+
+def test_one_column_requires_label(conn, tmp_path):
+    src = _csv(tmp_path, "id\n1\n")
+    with pytest.raises(ValueError, match="needs a field name"):
+        parse_upload(conn, src, "enum", None, "amazon")
+
+
+def test_one_column_requires_value(conn, tmp_path):
+    src = _csv(tmp_path, "id\n1\n")
+    with pytest.raises(ValueError, match="needs a value"):
+        parse_upload(conn, src, "enum", "employer", None)
+
+
+def test_three_columns_rejected(conn, tmp_path):
+    src = _csv(tmp_path, "id,a,b\n1,2,3\n")
+    with pytest.raises(ValueError, match="must have one"):
+        parse_upload(conn, src, "text", None, None)
+
+
+def test_blank_values_skipped_and_counted(conn, tmp_path):
+    # Blank cells arrive as NULL from read_csv; quoted empties as '' — both skip.
+    src = _csv(tmp_path, 'id,score\n1,0.5\n2,\n3,""\n4,1.5\n')
+    label, rows, skipped = parse_upload(conn, src, "number", None, None)
+    assert (rows, skipped) == (2, 2)
+    assert _values(conn) == {"1": "0.5", "4": "1.5"}
+
+
+def test_all_blank_values_is_no_usable_rows(conn, tmp_path):
+    src = _csv(tmp_path, "id,score\n1,\n2,\n")
+    with pytest.raises(ValueError, match="No usable rows"):
+        parse_upload(conn, src, "number", None, None)
+
+
+def test_duplicate_ids_keep_one_value(conn, tmp_path):
+    src = _csv(tmp_path, "id,score\n1,2\n1,9\n")
+    label, rows, skipped = parse_upload(conn, src, "number", None, None)
+    assert rows == 1
+    assert _values(conn) == {"1": "9"}  # max() — deterministic
+
+
+def test_number_validation_fails_with_example(conn, tmp_path):
+    src = _csv(tmp_path, "id,score\n1,0.5\n2,N/A\n3,1;2\n")
+    with pytest.raises(ValueError, match=r"2 of 3 values aren't numbers"):
+        parse_upload(conn, src, "number", None, None)
+
+
+def test_number_accepts_scientific_rejects_commas(conn, tmp_path):
+    ok = _csv(tmp_path, "id,score\n1,1e5\n2,-0.87\n")
+    label, rows, _ = parse_upload(conn, ok, "number", None, None)
+    assert rows == 2
+    bad = tmp_path / "bad.csv"
+    bad.write_text('id,score\n1,"1,234"\n')
+    with pytest.raises(ValueError, match="aren't numbers"):
+        parse_upload(conn, str(bad), "number", None, None)
+
+
+def test_date_validation_iso_only(conn, tmp_path):
+    ok = _csv(tmp_path, "id,canvassed\n1,2026-06-29\n")
+    label, rows, _ = parse_upload(conn, ok, "date", None, None)
+    assert rows == 1
+    bad = tmp_path / "bad.csv"
+    bad.write_text("id,canvassed\n1,06/29/2026\n")
+    with pytest.raises(ValueError, match="aren't dates"):
+        parse_upload(conn, str(bad), "date", None, None)
+
+
+def test_enum_distinct_cap(conn, tmp_path):
+    lines = "id,tag\n" + "\n".join(f"{i},v{i}" for i in range(101))
+    src = _csv(tmp_path, lines + "\n")
+    with pytest.raises(ValueError, match="too many"):
+        parse_upload(conn, src, "enum", None, None)
+
+
+def test_values_are_trimmed(conn, tmp_path):
+    src = _csv(tmp_path, "id,employer\n 1 , amazon \n")
+    parse_upload(conn, src, "enum", None, None)
+    assert _values(conn) == {"1": "amazon"}
+
+
+def test_leading_zero_ids_preserved(conn, tmp_path):
+    src = _csv(tmp_path, "id,employer\n00123,amazon\n")
+    parse_upload(conn, src, "enum", None, None)
+    assert _values(conn) == {"00123": "amazon"}
+
+
+def test_unknown_field_type_rejected(conn, tmp_path):
+    src = _csv(tmp_path, "id\n1\n")
+    with pytest.raises(ValueError, match="Unknown field type"):
+        parse_upload(conn, src, "flag", "x", "y")
+
+
+def test_numeric_value_column_header_allowed(conn, tmp_path):
+    # Only the id column's name signals headerlessness — value columns may
+    # legitimately be named "2024" etc.
+    src = _csv(tmp_path, "id,2024\n1001,0.5\n")
+    label, rows, _ = parse_upload(conn, src, "number", None, None)
+    assert (label, rows) == ("2024", 1)
+
+
+def test_parquet_upload_with_typed_columns(conn, tmp_path):
+    # Parquet columns arrive typed (ints, doubles) — normalized through
+    # VARCHAR so the value pipeline is format-agnostic.
+    src = str(tmp_path / "u.parquet")
+    conn.execute(f"COPY (SELECT * FROM (VALUES (101, 0.5), (102, 0.9)) t(id, score)) TO '{src}' (FORMAT parquet)")
+    label, rows, skipped = parse_upload(conn, src, "number", None, None)
+    assert (label, rows, skipped) == ("score", 2, 0)
+    assert _values(conn) == {"101": "0.5", "102": "0.9"}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "date-fns": "^4.2.1",
     "drizzle-orm": "beta",
+    "hyparquet": "^1.26.2",
     "jotai": "^2.19.1",
     "lucide-react": "^1.7.0",
     "maplibre-gl": "^5.24.0",

--- a/apps/web/src/components/button.tsx
+++ b/apps/web/src/components/button.tsx
@@ -9,7 +9,7 @@ type ButtonClickHandler = NonNullable<ButtonPrimitive.Props["onClick"]>;
 type ButtonClickEvent = Parameters<ButtonClickHandler>[0];
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-normal whitespace-nowrap outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent text-sm font-normal whitespace-nowrap outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/no-active-dataset.tsx
+++ b/apps/web/src/components/no-active-dataset.tsx
@@ -40,7 +40,7 @@ export function NoActiveDataset({
           <DialogClose render={<Button variant="outline" />}>Back to overview</DialogClose>
           {canManage ? (
             <Button
-              render={<Link to="/$orgSlug/data" params={{ orgSlug }} search={{ status: null }} />}
+              render={<Link to="/$orgSlug/data" params={{ orgSlug }} search={{ dataset: null }} />}
             >
               Go to Data
             </Button>

--- a/apps/web/src/lib/filters.ts
+++ b/apps/web/src/lib/filters.ts
@@ -73,6 +73,14 @@ export type AddressFilter = {
   zip: string;
 };
 
+// Numeric range over a number-type custom field. Either bound optional.
+export type NumberRangeFilter = {
+  kind: "number-range";
+  key: string;
+  min: number | null;
+  max: number | null;
+};
+
 // Canvass-outcome filter — reads prior canvass dispositions back out of
 // canvass_events; it is NOT a person-row column. Matches a person if any
 // of their per-turf current results has an outcome in `outcomes`.
@@ -125,6 +133,7 @@ export type Filter =
   | VotingHistoryCountFilter
   | VotingHistoryDetailFilter
   | AddressFilter
+  | NumberRangeFilter
   | CanvassOutcomeFilter
   | CanvassResponseFilter
   | SegmentFilter
@@ -154,6 +163,7 @@ export type FilterDef =
   | { kind: "voting-history-count"; key: string; label: string }
   | { kind: "voting-history-detail"; key: string; label: string }
   | { kind: "address"; key: "address"; label: string }
+  | { kind: "number-range"; key: string; label: string }
   | {
       kind: "canvass-outcome";
       key: "canvass_outcome";
@@ -210,6 +220,8 @@ export function emptyFilterFor(def: FilterDef): Filter {
   if (def.kind === "date-range") return { kind: "date-range", key: def.key, min: null, max: null };
   if (def.kind === "address")
     return { kind: "address", key: "address", line1: "", city: "", state: "", zip: "" };
+  if (def.kind === "number-range")
+    return { kind: "number-range", key: def.key, min: null, max: null };
   if (def.kind === "canvass-outcome")
     return { kind: "canvass-outcome", key: "canvass_outcome", outcomes: [] };
   if (def.kind === "canvass-response")
@@ -243,6 +255,7 @@ export function isActiveFilter(f: Filter): boolean {
       f.state.trim().length > 0 ||
       f.zip.trim().length > 0
     );
+  if (f.kind === "number-range") return f.min != null || f.max != null;
   if (f.kind === "canvass-outcome") return f.outcomes.length > 0;
   if (f.kind === "canvass-response") return f.questionId != null && f.optionIds.length > 0;
   if (f.kind === "segment") return f.segmentId != null;

--- a/apps/web/src/lib/manifest.ts
+++ b/apps/web/src/lib/manifest.ts
@@ -12,6 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { type FilterDef, SYSTEM_BOTTOM_SECTIONS, SYSTEM_TOP_SECTION } from "~/lib/filters";
 import { manifestQuery } from "~/lib/queries/manifest";
+import { customFieldsQuery } from "~/lib/queries/custom-fields";
 
 export type ManifestFilterKind =
   | "text"
@@ -85,14 +86,52 @@ export type FilterCatalog = {
   keyGroups: KeyGroupOption[];
 };
 
-export function buildFilterCatalog(manifest: Manifest | null): FilterCatalog {
+export type CustomFieldOption = {
+  customFieldId: string;
+  label: string;
+  fieldType: "number" | "date" | "text" | "enum";
+  values: string[] | null;
+  isArchived: boolean;
+};
+
+// Custom fields become ordinary defs (enum/text/date-range/number-range)
+// keyed by field id, so the standard editors work against them unchanged.
+function customFieldToFilterDef(f: CustomFieldOption): FilterDef {
+  if (f.fieldType === "enum")
+    return {
+      kind: "enum",
+      key: f.customFieldId,
+      label: f.label,
+      values: (f.values ?? []).map((v) => ({ value: v })),
+    };
+  if (f.fieldType === "date") return { kind: "date-range", key: f.customFieldId, label: f.label };
+  if (f.fieldType === "text") return { kind: "text", key: f.customFieldId, label: f.label };
+  return { kind: "number-range", key: f.customFieldId, label: f.label };
+}
+
+export function buildFilterCatalog(
+  manifest: Manifest | null,
+  customFields: CustomFieldOption[] = [],
+): FilterCatalog {
   const fieldSections = (manifest?.fields ?? [])
     .map((section) => section.map(fieldToFilterDef))
     .filter((s) => s.length > 0);
-  const sections = [SYSTEM_TOP_SECTION, ...fieldSections, ...SYSTEM_BOTTOM_SECTIONS];
+  // Archived custom fields stay resolvable (saved segments reference them by
+  // id) but drop out of the picker; definitionFor sees every def in
+  // `sections`, and the picker renders the same sections, so archived defs
+  // are resolved through `archivedDefs` below instead.
+  const customSection = customFields.filter((f) => !f.isArchived).map(customFieldToFilterDef);
+  const archivedDefs = customFields.filter((f) => f.isArchived).map(customFieldToFilterDef);
+  const sections = [
+    SYSTEM_TOP_SECTION,
+    ...fieldSections,
+    ...(customSection.length > 0 ? [customSection] : []),
+    ...SYSTEM_BOTTOM_SECTIONS,
+  ];
 
   const byKey = new Map<string, FilterDef>();
   for (const section of sections) for (const def of section) byKey.set(def.key, def);
+  for (const def of archivedDefs) byKey.set(def.key, def);
 
   const keyGroups: KeyGroupOption[] = [];
   for (const section of manifest?.fields ?? []) {
@@ -111,6 +150,10 @@ export function buildFilterCatalog(manifest: Manifest | null): FilterCatalog {
 // catalog is system-filters-only.
 export function useFilterCatalog(): FilterCatalog & { isLoading: boolean } {
   const { data, isLoading } = useQuery(manifestQuery());
-  const catalog = useMemo(() => buildFilterCatalog(data?.manifest ?? null), [data]);
+  const { data: customFields } = useQuery(customFieldsQuery());
+  const catalog = useMemo(
+    () => buildFilterCatalog(data?.manifest ?? null, customFields ?? []),
+    [data, customFields],
+  );
   return { ...catalog, isLoading };
 }

--- a/apps/web/src/lib/queries/custom-fields.ts
+++ b/apps/web/src/lib/queries/custom-fields.ts
@@ -1,0 +1,28 @@
+import { queryOptions } from "@tanstack/react-query";
+import { client } from "~/rpc/client";
+
+// The dataset's custom fields (id + label + type + coverage). No datasetId →
+// the org's active dataset (the segment editor's filter catalog); with one →
+// any granted dataset (the Data page rail selection).
+export const customFieldsQuery = (datasetId?: string) =>
+  queryOptions({
+    queryKey: ["custom-fields", datasetId ?? "active"] as const,
+    queryFn: () => client.customFields.list(datasetId ? { datasetId } : undefined),
+  });
+
+// Appends that touched a field — the field dialog's history list.
+export const customFieldHistoryQuery = (customFieldId: string) =>
+  queryOptions({
+    queryKey: ["custom-field-history", customFieldId] as const,
+    queryFn: () => client.customFields.history({ customFieldId }),
+  });
+
+// The dataset's base (manifest) fields, from its latest ready version — the
+// Data page's fields card shows them beneath any custom fields.
+export const baseFieldsQuery = (datasetId: string) =>
+  queryOptions({
+    queryKey: ["base-fields", datasetId] as const,
+    queryFn: () => client.datasets.baseFields({ datasetId }),
+    // Immutable per version; make-active invalidates globally and prefetches.
+    staleTime: Number.POSITIVE_INFINITY,
+  });

--- a/apps/web/src/routes/$orgSlug/data.tsx
+++ b/apps/web/src/routes/$orgSlug/data.tsx
@@ -1,19 +1,9 @@
-import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import {
-  Activity,
-  Archive,
-  ArchiveRestore,
-  Check,
-  ChevronDown,
-  MoreHorizontal,
-  Plus,
-  Upload,
-} from "lucide-react";
-import { useState } from "react";
+import { Columns2, Check, Upload } from "lucide-react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "~/components/button";
-import { Filter } from "~/components/filter";
 import {
   Dialog,
   DialogClose,
@@ -25,23 +15,27 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "~/components/dropdown-menu";
 import { EditorHeader } from "~/components/editor-header";
+import { EditorPage } from "~/components/editor-page";
 import { Input } from "~/components/input";
-import { Page } from "~/components/page";
 import { Pill } from "~/components/pill";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/table";
+import { Rail } from "~/components/rail";
+import { Switch } from "~/components/switch";
 import { formatDate } from "~/lib/format";
 import { AVAILABLE_IMPORTERS, importerLabel } from "~/lib/importers";
 import { hasPermission } from "~/lib/permissions";
+import type { CustomFieldType } from "@turf-tools/db/schema";
+import { Archive, ArchiveRestore, MoreHorizontal } from "lucide-react";
+import {
+  baseFieldsQuery,
+  customFieldHistoryQuery,
+  customFieldsQuery,
+} from "~/lib/queries/custom-fields";
 import { datasetsListQuery } from "~/lib/queries/datasets";
 import { DEFAULT_DISPLAY_TIMEZONE } from "~/lib/timezones";
-import { useDeferredRadioDropdown } from "~/lib/use-deferred-radio-dropdown";
 import { useFadeOnce } from "~/lib/use-fade-once";
-import { useDialogMutation } from "~/lib/use-dialog-mutation";
 import { cn } from "~/lib/utils";
 import { client } from "~/rpc/client";
 
@@ -51,56 +45,233 @@ const STATUS_META: Record<string, { label: string; color: string }> = {
   failed: { label: "Failed", color: "#ff725c" },
 };
 
-// Default (null) hides archived versions.
-const STATUS_OPTIONS = [
-  { value: "archived", label: "Archived" },
-  { value: "all", label: "All statuses" },
-];
+// Display names for base (manifest) field kinds in the fields card.
+const BASE_KIND_LABELS: Record<string, string> = {
+  enum: "Category",
+  text: "Text",
+  "text-multi": "Text",
+  "date-range": "Date",
+  "age-range": "Age",
+  "voting-history-count": "Voting history",
+  "voting-history-detail": "Voting history",
+  address: "Address",
+};
+
+const FIELD_TYPE_META: Record<CustomFieldType, string> = {
+  enum: "Category",
+  number: "Number",
+  date: "Date",
+  text: "Text",
+};
 
 export const Route = createFileRoute("/$orgSlug/data")({
-  validateSearch: (search): { status: string | null } => ({
-    status: typeof search.status === "string" ? search.status : null,
+  validateSearch: (search): { dataset: string | null } => ({
+    dataset: typeof search.dataset === "string" ? search.dataset : null,
   }),
   beforeLoad: ({ context, params }) => {
     if (!hasPermission(context.role, "datasets.manage")) {
       throw redirect({ to: "/$orgSlug/overview", params: { orgSlug: params.orgSlug } });
     }
   },
-  loader: ({ context: { queryClient } }) => queryClient.fetchQuery(datasetsListQuery()),
+  loaderDeps: ({ search }) => ({ dataset: search.dataset }),
+  loader: async ({ context: { queryClient }, deps }) => {
+    // Prefetch the selected dataset's field queries so the cards render
+    // complete on first paint — rail switches re-run this via loaderDeps,
+    // and the previous canvas stays up until the new data is ready.
+    const rows = await queryClient.fetchQuery(datasetsListQuery());
+    const selected =
+      rows.find((r) => r.datasetId === deps.dataset)?.datasetId ?? rows[0]?.datasetId;
+    if (selected) {
+      await Promise.all([
+        queryClient.fetchQuery(customFieldsQuery(selected)),
+        queryClient.fetchQuery(baseFieldsQuery(selected)),
+      ]);
+    }
+  },
   component: DataPage,
 });
 
+type VersionRow = Awaited<ReturnType<typeof client.datasets.list>>[number];
+
 function DataPage() {
   const { session } = Route.useRouteContext();
+  const { orgSlug } = Route.useParams();
   const timezone = session?.user?.displayTimezone ?? DEFAULT_DISPLAY_TIMEZONE;
   const queryClient = useQueryClient();
-  const { status: statusFilter } = Route.useSearch();
+  const { dataset: datasetParam } = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const shouldFade = useFadeOnce("/data");
-  const { data: datasets } = useSuspenseQuery({
+
+  const { data: versionRows } = useSuspenseQuery({
     ...datasetsListQuery(),
-    // Poll while any version is importing so the row advances to Ready on its own.
+    // Poll while any version is importing so rows advance to Ready on their own.
     refetchInterval: (q) => (q.state.data?.some((r) => r.status === "importing") ? 3000 : false),
   });
 
-  const importDialog = useDialogMutation({
-    mutationFn: async (
-      input:
-        | { mode: "new"; name: string; importer: string; sourceUri: string }
-        | { mode: "update"; datasetId: string; sourceUri: string },
-    ): Promise<void> => {
-      if (input.mode === "new") {
-        await client.datasets.create({
-          name: input.name,
-          importer: input.importer,
-          sourceUri: input.sourceUri,
-        });
-      } else {
-        await client.datasets.update({ datasetId: input.datasetId, sourceUri: input.sourceUri });
-      }
-    },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["datasets"] }),
-  });
+  // One entry per dataset; the list endpoint returns flat version rows.
+  const datasetGroups = useMemo(() => {
+    const byId = new Map<
+      string,
+      { datasetId: string; name: string; importer: string; versions: VersionRow[] }
+    >();
+    for (const r of versionRows) {
+      const g = byId.get(r.datasetId) ?? {
+        datasetId: r.datasetId,
+        name: r.name,
+        importer: r.importer,
+        versions: [],
+      };
+      g.versions.push(r);
+      byId.set(r.datasetId, g);
+    }
+    return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }, [versionRows]);
+
+  const selected = datasetGroups.find((d) => d.datasetId === datasetParam) ?? datasetGroups[0];
+  const selectDataset = (datasetId: string) => void navigate({ search: { dataset: datasetId } });
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [updateOpen, setUpdateOpen] = useState(false);
+  const [appendOpen, setAppendOpen] = useState(false);
+
+  return (
+    <div className={cn("flex h-[calc(100vh-3.5rem)]", shouldFade)}>
+      <Rail>
+        {datasetGroups.map((d) => (
+          <Rail.Item
+            key={d.datasetId}
+            label={d.name}
+            active={selected?.datasetId === d.datasetId}
+            onSelect={() => selectDataset(d.datasetId)}
+          />
+        ))}
+        <Rail.New label="Import dataset" onClick={() => setCreateOpen(true)} />
+      </Rail>
+
+      <CreateDatasetDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={(datasetId) => {
+          void queryClient.invalidateQueries({ queryKey: ["datasets"] });
+          selectDataset(datasetId);
+        }}
+      />
+
+      {selected ? (
+        <DatasetEditor
+          key={selected.datasetId}
+          dataset={selected}
+          orgSlug={orgSlug}
+          timezone={timezone}
+          updateOpen={updateOpen}
+          setUpdateOpen={setUpdateOpen}
+          appendOpen={appendOpen}
+          setAppendOpen={setAppendOpen}
+        />
+      ) : (
+        <EditorPage>
+          <EditorHeader title="Data" subtitle="Voter files and other imported datasets" />
+          <p className="text-sm text-muted-foreground">
+            No datasets yet — create one to start importing.
+          </p>
+        </EditorPage>
+      )}
+    </div>
+  );
+}
+
+function DatasetEditor({
+  dataset,
+  orgSlug,
+  timezone,
+  updateOpen,
+  setUpdateOpen,
+  appendOpen,
+  setAppendOpen,
+}: {
+  dataset: { datasetId: string; name: string; importer: string; versions: VersionRow[] };
+  orgSlug: string;
+  timezone: string;
+  updateOpen: boolean;
+  setUpdateOpen: (open: boolean) => void;
+  appendOpen: boolean;
+  setAppendOpen: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  // Loader-prefetched; suspense keeps the card from painting incomplete.
+  const { data: fields } = useSuspenseQuery(customFieldsQuery(dataset.datasetId));
+  const { data: baseFields } = useSuspenseQuery(baseFieldsQuery(dataset.datasetId));
+
+  const importing = dataset.versions.some((v) => v.status === "importing");
+
+  const invalidateFields = () => {
+    // Both keys: this dataset's list (the card) and the active-dataset list
+    // (the segment editor's filter catalog).
+    void queryClient.invalidateQueries({ queryKey: ["custom-fields"] });
+  };
+
+  // Which field the edit dialog targets — held separately from the open flag
+  // so the dialog body doesn't flash a fallback during the close animation.
+  const [fieldTarget, setFieldTarget] = useState<FieldRow | null>(null);
+  const [fieldDialogOpen, setFieldDialogOpen] = useState(false);
+
+  return (
+    <EditorPage>
+      <EditorHeader title={dataset.name} subtitle={importerLabel(dataset.importer)}>
+        <Button variant="outline" onClick={() => setAppendOpen(true)}>
+          <Columns2 className="size-4" />
+          Append
+        </Button>
+        <Button onClick={() => setUpdateOpen(true)} disabled={importing}>
+          <Upload className="size-4" />
+          Update
+        </Button>
+      </EditorHeader>
+
+      <UpdateDialog
+        open={updateOpen}
+        onOpenChange={setUpdateOpen}
+        datasetId={dataset.datasetId}
+        datasetName={dataset.name}
+        onUpdated={() => void queryClient.invalidateQueries({ queryKey: ["datasets"] })}
+      />
+      <AppendDialog
+        open={appendOpen}
+        onOpenChange={setAppendOpen}
+        orgSlug={orgSlug}
+        datasetId={dataset.datasetId}
+        onAppended={invalidateFields}
+      />
+      <FieldDialog
+        open={fieldDialogOpen}
+        onOpenChange={setFieldDialogOpen}
+        field={fieldTarget}
+        timezone={timezone}
+        onDone={invalidateFields}
+      />
+
+      <div className="flex min-h-0 flex-1 gap-4">
+        <VersionsCard versions={dataset.versions} timezone={timezone} />
+        <FieldsCard
+          fields={fields}
+          baseFields={baseFields}
+          onSelect={(f) => {
+            setFieldTarget(f);
+            setFieldDialogOpen(true);
+          }}
+        />
+      </div>
+    </EditorPage>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Versions
+// ---------------------------------------------------------------------------
+
+function VersionsCard({ versions, timezone }: { versions: VersionRow[]; timezone: string }) {
+  const queryClient = useQueryClient();
+  const [showArchived, setShowArchived] = useState(false);
 
   const makeActive = useMutation({
     mutationFn: (versionId: string) => client.datasets.makeActive({ versionId }),
@@ -116,18 +287,6 @@ function DataPage() {
     },
     onError: (e) => toast.error(e.message),
   });
-
-  // Which dataset the Update dialog targets (its name is fixed; only the source
-  // is entered). Held separately from the dialog's open flag so the name stays
-  // put through the close animation.
-  const [updateTarget, setUpdateTarget] = useState<{ datasetId: string; name: string } | null>(
-    null,
-  );
-  const updateDialog = useDialogMutation({
-    mutationFn: (input: { datasetId: string; sourceUri: string }) => client.datasets.update(input),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["datasets"] }),
-  });
-
   const archive = useMutation({
     mutationFn: (versionId: string) => client.datasets.archive({ versionId }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["datasets"] }),
@@ -139,514 +298,110 @@ function DataPage() {
     onError: (e) => toast.error(e.message),
   });
 
-  // A dataset with an in-flight import can't take another until it finishes.
-  // Computed over all datasets (not the filtered view) so the guard is correct.
-  const importingDatasetIds = new Set(
-    datasets.filter((r) => r.status === "importing").map((r) => r.datasetId),
-  );
-
-  // Distinct datasets with a ready, non-archived version and no import in flight
-  // — what the import dialog's "Update existing" mode can target.
-  const updatableById = new Map<string, { datasetId: string; name: string }>();
-  for (const r of datasets) {
-    if (r.status === "ready" && !r.isArchived && !importingDatasetIds.has(r.datasetId)) {
-      updatableById.set(r.datasetId, { datasetId: r.datasetId, name: r.name });
-    }
-  }
-  const updatableDatasets = [...updatableById.values()];
-
-  const rows = datasets.filter((r) => {
-    if (statusFilter === null && r.isArchived) return false;
-    if (statusFilter === "archived" && !r.isArchived) return false;
-    return true;
-  });
-  const statusLabel =
-    statusFilter === null
-      ? "All current"
-      : (STATUS_OPTIONS.find((o) => o.value === statusFilter)?.label ?? null);
+  const visible = versions.filter((v) => showArchived || !v.isArchived);
+  const hasArchived = versions.some((v) => v.isArchived);
 
   return (
-    <Page className={shouldFade}>
-      <EditorHeader title="Data" subtitle="Voter files and other imported datasets">
-        <Filter
-          icon={<Activity className="size-3.5" />}
-          label={statusLabel}
-          value={statusFilter}
-          options={STATUS_OPTIONS}
-          allLabel="All current"
-          onChange={(next) => void navigate({ search: (prev) => ({ ...prev, status: next }) })}
-        />
-        <Button onClick={importDialog.open}>
-          <Plus className="size-4" />
-          Import
-        </Button>
-      </EditorHeader>
-
-      <ImportDialog
-        open={importDialog.isOpen}
-        onOpenChange={importDialog.onOpenChange}
-        pending={importDialog.isPending}
-        error={importDialog.error}
-        clearError={importDialog.reset}
-        datasets={updatableDatasets}
-        onSubmit={(input) => importDialog.mutate(input)}
-      />
-
-      <UpdateDialog
-        open={updateDialog.isOpen}
-        onOpenChange={updateDialog.onOpenChange}
-        datasetName={updateTarget?.name ?? null}
-        pending={updateDialog.isPending}
-        error={updateDialog.error}
-        clearError={updateDialog.reset}
-        onSubmit={(sourceUri) =>
-          updateTarget && updateDialog.mutate({ datasetId: updateTarget.datasetId, sourceUri })
-        }
-      />
-
-      <Table containerClassName="h-[calc(100vh-9rem)] overflow-y-auto" className="table-fixed">
-        <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-background">
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead className="w-56">Type</TableHead>
-            <TableHead className="w-20">Version</TableHead>
-            <TableHead className="w-36">Status</TableHead>
-            <TableHead className="w-32">People</TableHead>
-            <TableHead className="w-28">Imported</TableHead>
-            <TableHead className="w-16">Active</TableHead>
-            <TableHead className="w-11" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {rows.length === 0 ? (
-            <TableRow className="h-10">
-              <TableCell colSpan={8}>
-                <Pill>
-                  <span>
-                    {datasets.length === 0
-                      ? "No datasets — import a voter file to start building segments."
-                      : "No results"}
-                  </span>
-                </Pill>
-              </TableCell>
-            </TableRow>
-          ) : null}
-          {rows.map((r) => {
-            const status = STATUS_META[r.status ?? ""] ?? {
-              label: r.status ?? "—",
-              color: "#9ca3af",
-            };
-            // While importing, always show a percentage (0% before the job has
-            // written any progress) so it never reads as a bare "Importing".
-            const pct =
-              r.status === "importing"
-                ? r.importTotalSteps
-                  ? Math.min(100, Math.round(((r.importStep ?? 0) / r.importTotalSteps) * 100))
-                  : 0
-                : null;
-            const pillLabel = pct != null ? `Importing (${pct}%)` : status.label;
-            return (
-              <TableRow key={r.versionId} className={cn(r.isArchived && "text-muted-foreground")}>
-                <TableCell>
-                  <Pill className="min-w-0">
-                    <span className="truncate">{r.name}</span>
-                  </Pill>
-                </TableCell>
-                <TableCell>
-                  <Pill className="min-w-0">
-                    <span className="truncate">{importerLabel(r.importer)}</span>
-                  </Pill>
-                </TableCell>
-                <TableCell>
-                  <Pill className="tabular-nums">v{r.versionNumber}</Pill>
-                </TableCell>
-                <TableCell>
-                  <span
-                    className="flex h-8 w-full items-center rounded-md border border-transparent bg-clip-padding px-2 text-sm tabular-nums"
-                    style={{ backgroundColor: `${status.color}20`, color: status.color }}
-                  >
-                    <span className="truncate">{pillLabel}</span>
-                  </span>
-                </TableCell>
-                <TableCell>
-                  <Pill variant="number">
-                    {r.rowCount != null ? r.rowCount.toLocaleString() : "—"}
-                  </Pill>
-                </TableCell>
-                <TableCell>
-                  <Pill variant="number">
-                    {r.importedAt ? formatDate(r.importedAt, timezone) : "—"}
-                  </Pill>
-                </TableCell>
-                <TableCell>
-                  <Pill className="justify-center">
-                    {r.isActive ? <Check className="size-4" /> : null}
-                  </Pill>
-                </TableCell>
-                <TableCell>
-                  <DatasetRowMenu
-                    canActivate={!r.isActive && r.status === "ready" && !r.isArchived}
-                    canUpdate={!importingDatasetIds.has(r.datasetId)}
-                    isArchived={r.isArchived}
-                    canArchive={
-                      !r.isActive &&
-                      !r.isArchived &&
-                      (r.status === "ready" || r.status === "failed")
-                    }
-                    onMakeActive={() => makeActive.mutate(r.versionId)}
-                    onUpdate={() => {
-                      setUpdateTarget({ datasetId: r.datasetId, name: r.name });
-                      updateDialog.open();
-                    }}
-                    onArchive={() => archive.mutate(r.versionId)}
-                    onUnarchive={() => unarchive.mutate(r.versionId)}
-                  />
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </Page>
-  );
-}
-
-type ImportSubmit =
-  | { mode: "new"; name: string; importer: string; sourceUri: string }
-  | { mode: "update"; datasetId: string; sourceUri: string };
-
-function ImportDialog({
-  open,
-  onOpenChange,
-  pending,
-  error,
-  clearError,
-  datasets,
-  onSubmit,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  pending: boolean;
-  error: string | null;
-  clearError: () => void;
-  datasets: Array<{ datasetId: string; name: string }>;
-  onSubmit: (input: ImportSubmit) => void;
-}) {
-  const [mode, setMode] = useState<"new" | "update">("new");
-  const [name, setName] = useState("");
-  const [importer, setImporter] = useState<string>(AVAILABLE_IMPORTERS[0].name);
-  const [datasetId, setDatasetId] = useState<string>("");
-  const [source, setSource] = useState("");
-
-  // Editing after a failed submit clears the stale error.
-  const edit = (set: (v: string) => void) => (v: string) => {
-    if (error) clearError();
-    set(v);
-  };
-
-  // Reset synchronously on open (not in a post-paint effect) so reopening never
-  // flashes the previous submission's values.
-  const [wasOpen, setWasOpen] = useState(open);
-  if (open !== wasOpen) {
-    setWasOpen(open);
-    if (open) {
-      setMode("new");
-      setName("");
-      setImporter(AVAILABLE_IMPORTERS[0].name);
-      setDatasetId(datasets[0]?.datasetId ?? "");
-      setSource("");
-    }
-  }
-
-  // "Update existing" is only offered when there's a ready dataset to target.
-  const canUpdate = datasets.length > 0;
-  const valid =
-    source.trim().length > 0 && (mode === "new" ? name.trim().length > 0 : datasetId.length > 0);
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogTitle>Import</DialogTitle>
-        <DialogDescription>
-          Create a new dataset or update an existing one. Type will be fixed after creating a new
-          dataset. Segments and campaigns will carry over on updates.
-        </DialogDescription>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (!valid || pending) return;
-            onSubmit(
-              mode === "new"
-                ? { mode: "new", name: name.trim(), importer, sourceUri: source.trim() }
-                : { mode: "update", datasetId, sourceUri: source.trim() },
-            );
-          }}
-          className="flex flex-col gap-4"
-        >
-          {canUpdate ? (
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium">Create or update</label>
-              <div className="flex flex-wrap gap-1.5">
-                {(["new", "update"] as const).map((m) => {
-                  const selected = mode === m;
-                  return (
-                    <button
-                      type="button"
-                      key={m}
-                      onClick={() => {
-                        if (error) clearError();
-                        setMode(m);
-                      }}
-                      disabled={pending}
-                      className={cn(
-                        "rounded-md border border-border px-2.5 py-1 text-sm disabled:cursor-not-allowed active:translate-y-px",
-                        selected ? "bg-foreground/10" : "bg-background hover:bg-muted",
-                      )}
-                    >
-                      {m === "new" ? "New dataset" : "Update existing"}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          ) : null}
-
-          {mode === "new" ? (
-            <>
-              <div className="flex flex-col gap-1.5">
-                <label className="text-sm font-medium">Name</label>
-                <Input
-                  value={name}
-                  onChange={(e) => edit(setName)(e.target.value)}
-                  placeholder="Name of dataset..."
-                  disabled={pending}
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <label className="text-sm font-medium">Type</label>
-                <div className="flex flex-wrap gap-1.5">
-                  {AVAILABLE_IMPORTERS.map((imp) => {
-                    const selected = importer === imp.name;
-                    return (
-                      <button
-                        type="button"
-                        key={imp.name}
-                        onClick={() => setImporter(imp.name)}
-                        disabled={pending}
-                        className={cn(
-                          "rounded-md border border-border px-2.5 py-1 text-sm disabled:cursor-not-allowed active:translate-y-px",
-                          selected ? "bg-foreground/10" : "bg-background hover:bg-muted",
-                        )}
-                      >
-                        {imp.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium">Dataset</label>
-              <DatasetSelect
-                value={datasetId}
-                datasets={datasets}
-                onChange={(id) => {
-                  if (error) clearError();
-                  setDatasetId(id);
-                }}
-                disabled={pending}
+    <div className="flex min-h-0 flex-1 flex-col rounded-md border border-border bg-card">
+      <div
+        className={cn(
+          "grid grid-cols-[3.75rem_repeat(3,minmax(0,1fr))_3.25rem_2.25rem] items-center gap-2",
+          "px-3.5 pt-3 pb-1 text-sm text-muted-foreground",
+        )}
+      >
+        <span>Version</span>
+        <span>Status</span>
+        <span>People</span>
+        <span>Imported</span>
+        <span>Active</span>
+        <span />
+      </div>
+      <div className="flex flex-1 flex-col gap-0 overflow-y-auto p-2 pt-1">
+        {visible.map((v) => {
+          const status = STATUS_META[v.status ?? ""] ?? {
+            label: v.status ?? "—",
+            color: "#9ca3af",
+          };
+          // While importing, always show a percentage (0% before the job has
+          // written any progress) so it never reads as a bare "Importing".
+          const pct =
+            v.status === "importing"
+              ? v.importTotalSteps
+                ? Math.min(100, Math.round(((v.importStep ?? 0) / v.importTotalSteps) * 100))
+                : 0
+              : null;
+          return (
+            <div
+              key={v.versionId}
+              className={cn(
+                "grid grid-cols-[3.75rem_repeat(3,minmax(0,1fr))_3.25rem_2.25rem] items-center gap-2 rounded-md p-1.5 text-sm",
+                v.isArchived && "text-muted-foreground",
+              )}
+            >
+              <Pill className="tabular-nums">v{v.versionNumber}</Pill>
+              <span
+                className="flex h-8 w-full items-center rounded-md border border-transparent bg-clip-padding px-2 text-sm tabular-nums"
+                style={{ backgroundColor: `${status.color}20`, color: status.color }}
+              >
+                <span className="truncate">
+                  {pct != null ? `Importing (${pct}%)` : status.label}
+                </span>
+              </span>
+              <Pill variant="number">{v.rowCount != null ? v.rowCount.toLocaleString() : "—"}</Pill>
+              <Pill variant="number">
+                {v.importedAt ? formatDate(v.importedAt, timezone) : "—"}
+              </Pill>
+              <Pill className="justify-center">
+                {v.isActive ? <Check className="size-4" /> : null}
+              </Pill>
+              <VersionRowMenu
+                canActivate={!v.isActive && v.status === "ready" && !v.isArchived}
+                isArchived={v.isArchived}
+                canArchive={
+                  !v.isActive && !v.isArchived && (v.status === "ready" || v.status === "failed")
+                }
+                onMakeActive={() => makeActive.mutate(v.versionId)}
+                onArchive={() => archive.mutate(v.versionId)}
+                onUnarchive={() => unarchive.mutate(v.versionId)}
               />
             </div>
-          )}
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium">Source</label>
-            <Input
-              value={source}
-              onChange={(e) => edit(setSource)(e.target.value)}
-              placeholder="e.g. https://example.com/voters.parquet"
-              disabled={pending}
-            />
-            <span className="text-sm text-muted-foreground italic">URL of the raw file</span>
-          </div>
-          {error ? (
-            <p
-              className={cn(
-                "rounded-md border border-destructive/40 bg-destructive/10",
-                "px-3 py-2 text-sm text-destructive",
-              )}
-            >
-              {error}
-            </p>
-          ) : null}
-          <div className="mt-2 flex justify-end gap-2">
-            <DialogClose render={<Button variant="outline" type="button" />}>Cancel</DialogClose>
-            <Button type="submit" disabled={!valid} loading={pending}>
-              Import
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+          );
+        })}
+      </div>
+      {hasArchived ? (
+        <div className="flex items-center justify-between border-t border-border px-3 py-2.5">
+          <span className="text-sm text-muted-foreground">Show archived versions</span>
+          <Switch checked={showArchived} onCheckedChange={setShowArchived} />
+        </div>
+      ) : null}
+    </div>
   );
 }
 
-function DatasetSelect({
-  value,
-  datasets,
-  onChange,
-  disabled,
-}: {
-  value: string;
-  datasets: Array<{ datasetId: string; name: string }>;
-  onChange: (id: string) => void;
-  disabled?: boolean;
-}) {
-  const dd = useDeferredRadioDropdown({ onCommit: (v) => onChange(v) });
-  const selected = datasets.find((d) => d.datasetId === value);
-  return (
-    <DropdownMenu {...dd.menu}>
-      <DropdownMenuTrigger
-        disabled={disabled}
-        render={<Button variant="outline" type="button" className="w-full justify-between" />}
-      >
-        <span className="truncate">{selected?.name ?? "Select a dataset"}</span>
-        <ChevronDown className="size-3.5 text-muted-foreground" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-72">
-        <DropdownMenuRadioGroup {...dd.radio} value={value}>
-          {datasets.map((d) => (
-            <DropdownMenuRadioItem key={d.datasetId} value={d.datasetId}>
-              <span className="truncate">{d.name}</span>
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-function UpdateDialog({
-  open,
-  onOpenChange,
-  datasetName,
-  pending,
-  error,
-  clearError,
-  onSubmit,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  datasetName: string | null;
-  pending: boolean;
-  error: string | null;
-  clearError: () => void;
-  onSubmit: (sourceUri: string) => void;
-}) {
-  const [source, setSource] = useState("");
-
-  const [wasOpen, setWasOpen] = useState(open);
-  if (open !== wasOpen) {
-    setWasOpen(open);
-    if (open) setSource("");
-  }
-
-  const valid = source.trim().length > 0;
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogTitle>Update dataset</DialogTitle>
-        <DialogDescription>
-          Imports a new version of{" "}
-          <span className="font-medium text-foreground">{datasetName ?? "this dataset"}</span>. Your
-          segments and campaigns carry over; the new version stays inactive until you make it
-          active.
-        </DialogDescription>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (!valid || pending) return;
-            onSubmit(source.trim());
-          }}
-          className="flex flex-col gap-4"
-        >
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium">Source</label>
-            <Input
-              value={source}
-              onChange={(e) => {
-                if (error) clearError();
-                setSource(e.target.value);
-              }}
-              placeholder="e.g. https://example.com/voters.parquet"
-              disabled={pending}
-            />
-            <span className="text-sm text-muted-foreground italic">URL of the raw file</span>
-          </div>
-          {error ? (
-            <p
-              className={cn(
-                "rounded-md border border-destructive/40 bg-destructive/10",
-                "px-3 py-2 text-sm text-destructive",
-              )}
-            >
-              {error}
-            </p>
-          ) : null}
-          <div className="mt-2 flex justify-end gap-2">
-            <DialogClose render={<Button variant="outline" type="button" />}>Cancel</DialogClose>
-            <Button type="submit" disabled={!valid} loading={pending}>
-              Import version
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function DatasetRowMenu({
+function VersionRowMenu({
   canActivate,
-  canUpdate,
   isArchived,
   canArchive,
   onMakeActive,
-  onUpdate,
   onArchive,
   onUnarchive,
 }: {
   canActivate: boolean;
-  canUpdate: boolean;
   isArchived: boolean;
   canArchive: boolean;
   onMakeActive: () => void;
-  onUpdate: () => void;
   onArchive: () => void;
   onUnarchive: () => void;
 }) {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn("w-full bg-muted hover:bg-foreground/8", "aria-expanded:bg-foreground/8")}
-          />
-        }
-      >
+      <DropdownMenuTrigger render={<Button variant="outline" size="icon" className="h-8 w-full" />}>
         <MoreHorizontal />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-44">
         <DropdownMenuItem disabled={!canActivate} onClick={onMakeActive}>
           <Check />
           Make active
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={!canUpdate} onClick={onUpdate}>
-          <Upload />
-          Update
         </DropdownMenuItem>
         {isArchived ? (
           <DropdownMenuItem onClick={onUnarchive}>
@@ -661,5 +416,801 @@ function DatasetRowMenu({
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Custom fields
+// ---------------------------------------------------------------------------
+
+type FieldRow = {
+  customFieldId: string;
+  label: string;
+  fieldType: CustomFieldType;
+  values: string[] | null;
+  personCount: number;
+  isArchived: boolean;
+};
+
+// Every custom field with its coverage, bars scaled to the largest. Click a
+// row to rename/archive/clear; archived fields hide behind the footer toggle.
+function FieldsCard({
+  fields,
+  baseFields,
+  onSelect,
+}: {
+  fields: FieldRow[];
+  baseFields: Array<{ label: string; kind: string }>;
+  onSelect: (f: FieldRow) => void;
+}) {
+  const [showArchived, setShowArchived] = useState(false);
+  const visible = fields.filter((f) => showArchived || !f.isArchived);
+  const sorted = [...visible].sort(
+    (a, b) =>
+      Number(a.isArchived) - Number(b.isArchived) ||
+      b.personCount - a.personCount ||
+      a.label.localeCompare(b.label),
+  );
+  const max = visible.reduce((m, f) => Math.max(m, f.personCount), 0);
+  const hasArchived = fields.some((f) => f.isArchived);
+
+  return (
+    <div className="flex min-h-0 w-80 shrink-0 flex-col rounded-md border border-border bg-card">
+      <div className="flex flex-1 flex-col overflow-y-auto">
+        {sorted.length > 0 ? (
+          <div className="px-3.5 pt-3 pb-1 text-sm text-muted-foreground">Custom fields</div>
+        ) : null}
+        <div className={cn("flex flex-col gap-0 p-2 pt-1", sorted.length === 0 && "hidden")}>
+          {sorted.map((f) => (
+            <button
+              type="button"
+              key={f.customFieldId}
+              onClick={() => onSelect(f)}
+              onMouseDown={(e) => e.preventDefault()}
+              className={cn(
+                // min-h matches the versions rows (p-1.5 + h-8 pills = 44px).
+                "flex min-h-11 flex-col justify-center gap-1 rounded-md p-1.5 text-left hover:bg-muted",
+                f.isArchived && "text-muted-foreground",
+              )}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="min-w-0 truncate text-sm">{f.label}</span>
+                <span className="shrink-0 text-sm text-muted-foreground tabular-nums">
+                  {FIELD_TYPE_META[f.fieldType]} ·{" "}
+                  {f.isArchived
+                    ? `${f.personCount.toLocaleString()} (Archived)`
+                    : f.personCount.toLocaleString()}
+                </span>
+              </div>
+              <div className="h-1.5 rounded-full bg-foreground/10">
+                <div
+                  className="h-full rounded-full bg-foreground/40"
+                  // Zero coverage → truly empty track; the 2% floor only applies
+                  // to nonzero counts so small fields stay visible.
+                  style={{
+                    width: `${
+                      !f.isArchived && f.personCount > 0 && max > 0
+                        ? Math.max(2, (f.personCount / max) * 100)
+                        : 0
+                    }%`,
+                  }}
+                />
+              </div>
+            </button>
+          ))}
+        </div>
+        <div className="px-3.5 pt-3 pb-2 text-sm text-muted-foreground">Base fields</div>
+        <div className="flex flex-col gap-1 p-2 pt-1">
+          {baseFields.map((f) => (
+            <div
+              key={f.label}
+              className="flex items-center justify-between gap-2 rounded-md px-1.5"
+            >
+              <span className="min-w-0 truncate text-sm">{f.label}</span>
+              <span className="shrink-0 text-sm text-muted-foreground">
+                {BASE_KIND_LABELS[f.kind] ?? ""}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {hasArchived ? (
+        <div className="flex items-center justify-between border-t border-border px-3 py-2.5">
+          <span className="text-sm text-muted-foreground">Show archived custom fields</span>
+          <Switch checked={showArchived} onCheckedChange={setShowArchived} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// Rename / archive / clear a custom field, with its append history. Rename is
+// safe by construction (criteria and lake values are id-keyed); archive is
+// display-only and re-appending the label revives it; clear deletes values
+// for everyone (the field stays, at zero coverage).
+function FieldDialog({
+  open,
+  onOpenChange,
+  field,
+  timezone,
+  onDone,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  field: FieldRow | null;
+  timezone: string;
+  onDone: () => void;
+}) {
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setLabel(field?.label ?? "");
+      setError(null);
+    }
+  }
+
+  const { data: history } = useQuery({
+    ...customFieldHistoryQuery(field?.customFieldId ?? ""),
+    enabled: open && field != null,
+  });
+
+  const done = () => {
+    onDone();
+    onOpenChange(false);
+  };
+  const rename = useMutation({
+    mutationFn: (next: string) =>
+      client.customFields.rename({ customFieldId: field!.customFieldId, label: next }),
+    onSuccess: done,
+    onError: (e) => setError(e.message),
+  });
+  const setArchived = useMutation({
+    mutationFn: (archived: boolean) =>
+      archived
+        ? client.customFields.archive({ customFieldId: field!.customFieldId })
+        : client.customFields.unarchive({ customFieldId: field!.customFieldId }),
+    onSuccess: done,
+    onError: (e) => setError(e.message),
+  });
+  const clear = useMutation({
+    mutationFn: () => client.customFields.clear({ customFieldId: field!.customFieldId }),
+    onSuccess: done,
+    onError: (e) => setError(e.message),
+  });
+
+  const pending = rename.isPending || setArchived.isPending || clear.isPending;
+  const changed = field != null && label.trim() !== field.label;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>Edit field</DialogTitle>
+        <DialogDescription>
+          Rename the field, clear its values from everyone, or archive to hide it until you need it
+          again.
+        </DialogDescription>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!changed || pending || !label.trim()) return;
+            rename.mutate(label.trim());
+          }}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Name</label>
+            <Input
+              value={label}
+              onChange={(e) => {
+                setError(null);
+                setLabel(e.target.value);
+              }}
+              disabled={pending}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Type</label>
+            {/* Static — retyping a field would invalidate already-typed
+                values; the honest path is clear + re-append. */}
+            <span className="w-fit rounded-md border border-border bg-foreground/10 px-2.5 py-1 text-sm">
+              {field ? FIELD_TYPE_META[field.fieldType] : ""}
+            </span>
+          </div>
+
+          {history && history.length > 0 ? (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Uploads</label>
+              <div className="grid grid-cols-[minmax(0,1fr)_6rem_4.5rem] gap-x-2 text-sm text-muted-foreground">
+                <span>Filename</span>
+                <span>Date</span>
+                <span className="text-right">Count</span>
+              </div>
+              <div className="flex max-h-32 flex-col gap-1 overflow-y-auto">
+                {history.map((h) => (
+                  <div
+                    key={h.customFieldUploadId}
+                    className="grid grid-cols-[minmax(0,1fr)_6rem_4.5rem] gap-x-2 text-sm"
+                  >
+                    <span className="min-w-0 truncate">{h.filename ?? "upload"}</span>
+                    <span className="tabular-nums">{formatDate(h.createdAt, timezone)}</span>
+                    <span className="text-right tabular-nums">
+                      {h.rowCount?.toLocaleString() ?? "—"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {error ? <DialogError error={error} /> : null}
+          <div className="mt-2 flex items-center justify-between gap-2">
+            <div className="flex gap-2">
+              {field?.isArchived ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="disabled:opacity-100"
+                  disabled={pending}
+                  onClick={() => setArchived.mutate(false)}
+                >
+                  <ArchiveRestore className="size-4" />
+                  Unarchive
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  className="disabled:opacity-100"
+                  disabled={pending}
+                  onClick={() => setArchived.mutate(true)}
+                >
+                  <Archive className="size-4" />
+                  Archive
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="destructive"
+                className="disabled:opacity-100"
+                disabled={pending || field == null || field.personCount === 0}
+                onClick={() => clear.mutate()}
+              >
+                Clear
+              </Button>
+            </div>
+            <div className="flex gap-2">
+              <DialogClose render={<Button variant="outline" type="button" />}>Cancel</DialogClose>
+              <Button type="submit" disabled={!changed || !label.trim()} loading={pending}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dialogs: create / update / append
+// ---------------------------------------------------------------------------
+
+function CreateDatasetDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (datasetId: string) => void;
+}) {
+  const [name, setName] = useState("");
+  const [importer, setImporter] = useState<string>(AVAILABLE_IMPORTERS[0].name);
+  const [source, setSource] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setName("");
+      setImporter(AVAILABLE_IMPORTERS[0].name);
+      setSource("");
+      setError(null);
+    }
+  }
+
+  const create = useMutation({
+    mutationFn: () =>
+      client.datasets.create({ name: name.trim(), importer, sourceUri: source.trim() }),
+    onSuccess: (res) => {
+      onCreated(res.datasetId);
+      onOpenChange(false);
+    },
+    onError: (e) => setError(e.message),
+  });
+
+  const pending = create.isPending;
+  const valid = name.trim().length > 0 && source.trim().length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>Import dataset</DialogTitle>
+        <DialogDescription>
+          Import a source file as a new dataset. Type is fixed after creation; use updates
+          afterwards to get newer versions.
+        </DialogDescription>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!valid || pending) return;
+            create.mutate();
+          }}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Name</label>
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => {
+                setError(null);
+                setName(e.target.value);
+              }}
+              placeholder="Name of dataset..."
+              disabled={pending}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Type</label>
+            <div className="flex flex-wrap gap-1.5">
+              {AVAILABLE_IMPORTERS.map((imp) => {
+                const sel = importer === imp.name;
+                return (
+                  <button
+                    type="button"
+                    key={imp.name}
+                    onClick={() => setImporter(imp.name)}
+                    disabled={pending}
+                    className={cn(
+                      "rounded-md border border-border px-2.5 py-1 text-sm disabled:cursor-not-allowed active:translate-y-px",
+                      sel ? "bg-foreground/10" : "bg-background hover:bg-muted",
+                    )}
+                  >
+                    {imp.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Source</label>
+            <Input
+              value={source}
+              onChange={(e) => {
+                setError(null);
+                setSource(e.target.value);
+              }}
+              placeholder="e.g. https://example.com/voters.parquet"
+              disabled={pending}
+            />
+            <span className="text-sm text-muted-foreground italic">URL of the raw file</span>
+          </div>
+          {error ? <DialogError error={error} /> : null}
+          <div className="mt-2 flex justify-end gap-2">
+            <DialogClose render={<Button variant="outline" type="button" />}>Cancel</DialogClose>
+            <Button type="submit" disabled={!valid} loading={pending}>
+              Import
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function UpdateDialog({
+  open,
+  onOpenChange,
+  datasetId,
+  datasetName,
+  onUpdated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  datasetId: string;
+  datasetName: string;
+  onUpdated: () => void;
+}) {
+  const [source, setSource] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setSource("");
+      setError(null);
+    }
+  }
+
+  const update = useMutation({
+    mutationFn: () => client.datasets.update({ datasetId, sourceUri: source.trim() }),
+    onSuccess: () => {
+      onUpdated();
+      onOpenChange(false);
+    },
+    onError: (e) => setError(e.message),
+  });
+
+  const pending = update.isPending;
+  const valid = source.trim().length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>Update dataset</DialogTitle>
+        <DialogDescription>
+          Imports a new version of{" "}
+          <span className="font-medium text-foreground">{datasetName}</span>. Segments and campaigns
+          carry over; the new version stays inactive until you make it active.
+        </DialogDescription>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!valid || pending) return;
+            update.mutate();
+          }}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Source</label>
+            <Input
+              autoFocus
+              value={source}
+              onChange={(e) => {
+                setError(null);
+                setSource(e.target.value);
+              }}
+              placeholder="e.g. https://example.com/voters.parquet"
+              disabled={pending}
+            />
+            <span className="text-sm text-muted-foreground italic">URL of the raw file</span>
+          </div>
+          {error ? <DialogError error={error} /> : null}
+          <div className="mt-2 flex justify-end gap-2">
+            <DialogClose render={<Button variant="outline" type="button" />}>Cancel</DialogClose>
+            <Button type="submit" disabled={!valid} loading={pending}>
+              Import version
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// Pick-time inspection reads only what it must: parquet schemas come from the
+// file's footer, parsed client-side (exact — no sniffing); CSVs send a head
+// slice to the server so DuckDB stays the one dialect sniffer and the form
+// shape can never diverge from what append will see. The full file crosses
+// the wire once, on append.
+const CSV_INSPECT_BYTES = 64 * 1024;
+
+async function inspectFile(orgSlug: string, file: File): Promise<string[]> {
+  const magic = await file.slice(0, 4).arrayBuffer();
+  if (new TextDecoder().decode(magic) === "PAR1") {
+    const { parquetMetadataAsync, parquetSchema } = await import("hyparquet");
+    const metadata = await parquetMetadataAsync({
+      byteLength: file.size,
+      slice: (start: number, end?: number) => file.slice(start, end).arrayBuffer(),
+    });
+    const columns = parquetSchema(metadata).children.map((c) => c.element.name);
+    if (columns.length === 0) throw new Error("Uploaded file has no columns.");
+    if (columns.length > 2)
+      throw new Error(
+        `File has ${columns.length} columns, must have one (IDs only) or two (IDs and values).`,
+      );
+    return columns;
+  }
+  let body: Blob = file;
+  if (file.size > CSV_INSPECT_BYTES) {
+    // Trim the slice to the last complete line so DuckDB never sees a
+    // mid-row truncation.
+    const head = await file.slice(0, CSV_INSPECT_BYTES).text();
+    const cut = head.lastIndexOf("\n");
+    body = new Blob([cut > 0 ? head.slice(0, cut) : head]);
+  }
+  const res = await fetch(`/api/web/${orgSlug}/custom-field-inspect`, { method: "POST", body });
+  if (!res.ok) throw new Error(await res.text());
+  const { columns } = (await res.json()) as { columns: string[] };
+  return columns;
+}
+
+type AppendStats = {
+  fields: string[];
+  rowCount: number;
+  skippedCount: number;
+  matchedCount: number | null;
+};
+
+// Append a file of (id, value) rows as a custom field. Ingest is synchronous —
+// the submit request parses, writes, and returns match stats (or the parse
+// error) directly; there is no job or polling.
+function AppendDialog({
+  open,
+  onOpenChange,
+  orgSlug,
+  datasetId,
+  onAppended,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgSlug: string;
+  datasetId: string;
+  onAppended: () => void;
+}) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  // From pick-time inspection (parquet footer client-side, CSV head via the
+  // server) — the file drives which inputs render.
+  const [fileInfo, setFileInfo] = useState<{
+    columns: number;
+    valueHeader: string | null;
+  } | null>(null);
+  // Gates submit while pick-time inspection is in flight; deliberately no
+  // loading UI — inspection is near-instant (parquet footer / 64KB CSV
+  // head), and every indicator tried here (label swap, button spinner)
+  // read as flicker in the common fast case.
+  const [inspecting, setInspecting] = useState(false);
+  const [fieldType, setFieldType] = useState<CustomFieldType>("enum");
+  const [label, setLabel] = useState("");
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<AppendStats | null>(null);
+
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setFile(null);
+      setFileInfo(null);
+      setFieldType("enum");
+      setLabel("");
+      setValue("");
+      setError(null);
+      setStats(null);
+    }
+  }
+
+  const resetFeedback = () => setError(null);
+
+  const submit = useMutation({
+    mutationFn: async () => {
+      if (!file || !fileInfo) return;
+      const params = new URLSearchParams({ datasetId, fieldType, filename: file.name });
+      if (fileInfo.columns === 1) {
+        params.set("label", label.trim());
+        params.set("value", value.trim());
+      }
+      const res = await fetch(`/api/web/${orgSlug}/custom-field-append?${params.toString()}`, {
+        method: "POST",
+        body: file,
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return (await res.json()) as AppendStats;
+    },
+    onSuccess: (res) => {
+      if (!res) return;
+      setStats(res);
+      onAppended();
+    },
+    onError: (e) => setError(e.message),
+  });
+
+  const pending = submit.isPending;
+  const valid =
+    !inspecting &&
+    file != null &&
+    fileInfo != null &&
+    (fileInfo.columns === 2 || (label.trim().length > 0 && value.trim().length > 0));
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (pending && !next ? null : onOpenChange(next))}>
+      <DialogContent>
+        <DialogTitle>Append</DialogTitle>
+        <DialogDescription>
+          Add a column to this dataset from a file. Format should be one column (IDs) or two columns
+          (IDs and values) and a header is required. Appended columns will apply to all dataset
+          versions with matching IDs.
+        </DialogDescription>
+        {stats ? (
+          <div className="flex flex-col gap-4">
+            <DialogSuccess>
+              Appended column "<span className="font-medium">{stats.fields.join(", ")}</span>" with{" "}
+              <span className="font-medium">{stats.rowCount.toLocaleString()}</span> rows
+              {stats.matchedCount != null ? (
+                <>
+                  {" "}
+                  and <span className="font-medium">
+                    {stats.matchedCount.toLocaleString()}
+                  </span>{" "}
+                  matched people
+                </>
+              ) : null}
+              .
+              {stats.skippedCount ? (
+                <>
+                  {" "}
+                  <span className="font-medium">{stats.skippedCount.toLocaleString()}</span> rows
+                  without values were ignored.
+                </>
+              ) : null}
+            </DialogSuccess>
+            <div className="flex justify-end">
+              <Button type="button" onClick={() => onOpenChange(false)}>
+                Done
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!valid || pending) return;
+              setError(null);
+              submit.mutate();
+            }}
+            className="flex flex-col gap-4"
+          >
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">File</label>
+              <input
+                ref={fileRef}
+                type="file"
+                accept=".csv,.tsv,.txt,.parquet"
+                className="hidden"
+                onChange={(e) => {
+                  resetFeedback();
+                  const next = e.target.files?.[0] ?? null;
+                  setFile(next);
+                  setFileInfo(null);
+                  if (!next) return;
+                  setInspecting(true);
+                  inspectFile(orgSlug, next)
+                    .then((columns) =>
+                      setFileInfo({
+                        columns: columns.length,
+                        valueHeader: columns[1]?.trim() ?? null,
+                      }),
+                    )
+                    .catch((err: Error) => {
+                      setError(err.message);
+                      setFile(null);
+                    })
+                    .finally(() => setInspecting(false));
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                className="justify-start disabled:opacity-100"
+                disabled={pending}
+                onClick={() => fileRef.current?.click()}
+              >
+                <span className="truncate">{file ? file.name : "Choose a file..."}</span>
+              </Button>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Type</label>
+              <div className="flex flex-wrap gap-1.5">
+                {(Object.keys(FIELD_TYPE_META) as CustomFieldType[]).map((t) => {
+                  const sel = fieldType === t;
+                  return (
+                    <button
+                      type="button"
+                      key={t}
+                      onClick={() => {
+                        resetFeedback();
+                        setFieldType(t);
+                      }}
+                      disabled={pending}
+                      className={cn(
+                        "rounded-md border border-border px-2.5 py-1 text-sm disabled:cursor-not-allowed active:translate-y-px",
+                        sel ? "bg-foreground/10" : "bg-background hover:bg-muted",
+                      )}
+                    >
+                      {FIELD_TYPE_META[t]}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {fileInfo?.columns === 2 ? (
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">Field name</label>
+                <Input value={fileInfo.valueHeader ?? ""} disabled readOnly />
+                <span className="text-sm text-muted-foreground italic">
+                  Fixed from the file's value column, you can rename later
+                </span>
+              </div>
+            ) : null}
+            {fileInfo?.columns === 1 ? (
+              <>
+                <div className="flex flex-col gap-1.5">
+                  <label className="text-sm font-medium">Field name</label>
+                  <Input
+                    value={label}
+                    onChange={(e) => {
+                      resetFeedback();
+                      setLabel(e.target.value);
+                    }}
+                    placeholder="Required"
+                    disabled={pending}
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <label className="text-sm font-medium">Value</label>
+                  <Input
+                    value={value}
+                    onChange={(e) => {
+                      resetFeedback();
+                      setValue(e.target.value);
+                    }}
+                    placeholder="Required"
+                    disabled={pending}
+                  />
+                  <span className="text-sm text-muted-foreground italic">
+                    Everyone in the list gets this value
+                  </span>
+                </div>
+              </>
+            ) : null}
+            {error ? <DialogError error={error} /> : null}
+            <div className="mt-2 flex justify-end gap-2">
+              <DialogClose render={<Button variant="outline" type="button" disabled={pending} />}>
+                Cancel
+              </DialogClose>
+              <Button type="submit" disabled={!valid} loading={pending}>
+                Append
+              </Button>
+            </div>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DialogError({ error }: { error: string }) {
+  return (
+    <p
+      className={cn(
+        "rounded-md border border-destructive/40 bg-destructive/10",
+        "px-3 py-2 text-sm text-destructive",
+      )}
+    >
+      {error}
+    </p>
+  );
+}
+
+// Green mirror of DialogError, using the app's status green (STATUS_META).
+function DialogSuccess({ children }: { children: ReactNode }) {
+  return (
+    <p
+      className="rounded-md border px-3 py-2 text-sm"
+      style={{ backgroundColor: "#3ca95120", borderColor: "#3ca95140", color: "#3ca951" }}
+    >
+      {children}
+    </p>
   );
 }

--- a/apps/web/src/routes/$orgSlug/data.tsx
+++ b/apps/web/src/routes/$orgSlug/data.tsx
@@ -1104,7 +1104,9 @@ function AppendDialog({
                 disabled={pending}
                 onClick={() => fileRef.current?.click()}
               >
-                <span className="truncate">{file ? file.name : "Choose a file..."}</span>
+                <span className="truncate">
+                  {file ? file.name : "Choose a file (CSV or Parquet)..."}
+                </span>
               </Button>
             </div>
 

--- a/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
+++ b/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
@@ -51,6 +51,7 @@ import {
   type Criteria,
   type SegmentFilter,
   type Step,
+  type NumberRangeFilter,
   type TextFilter,
   type TextMultiFilter,
   type Verb,
@@ -683,6 +684,9 @@ function StepRow({
       {filter.kind === "address" && def?.kind === "address" ? (
         <AddressFilterEditor filter={filter} onChange={onChange} />
       ) : null}
+      {filter.kind === "number-range" && def?.kind === "number-range" ? (
+        <NumberRangeFilterEditor filter={filter} onChange={onChange} />
+      ) : null}
       {filter.kind === "canvass-outcome" && def?.kind === "canvass-outcome" ? (
         <CanvassOutcomeEditor filter={filter} def={def} onChange={onChange} />
       ) : null}
@@ -805,9 +809,19 @@ function EnumFilterEditor({
       : [...filter.values, value];
     onChange({ ...filter, values: next });
   };
+  // Render selected values even when the option set no longer carries them
+  // (custom-field re-derives and manifest drift across versions both retire
+  // values) — a stale selection stays visible and untogglable-away instead of
+  // silently constraining the query. Once untoggled, it disappears for good.
+  const options: Array<{ value: string; label?: string }> = [
+    ...def.values,
+    ...filter.values
+      .filter((v) => !def.values.some((o) => o.value === v))
+      .map((v) => ({ value: v })),
+  ];
   return (
     <div className="flex flex-wrap gap-1.5">
-      {def.values.map((v) => (
+      {options.map((v) => (
         <Toggle
           key={v.value}
           size="sm"
@@ -1289,6 +1303,59 @@ function VotingHistoryCountEditor({
         />
         <span className="text-muted-foreground">years</span>
       </div>
+    </div>
+  );
+}
+
+function NumberRangeFilterEditor({
+  filter,
+  onChange,
+}: {
+  filter: NumberRangeFilter;
+  onChange: (next: Filter) => void;
+}) {
+  // Same commit-on-blur/Enter pattern as text. Plain Inputs (not NumberInput,
+  // which is digit-only) — scores are often decimals.
+  const [localMin, setLocalMin] = useState(filter.min == null ? "" : String(filter.min));
+  const [localMax, setLocalMax] = useState(filter.max == null ? "" : String(filter.max));
+  useEffect(() => setLocalMin(filter.min == null ? "" : String(filter.min)), [filter.min]);
+  useEffect(() => setLocalMax(filter.max == null ? "" : String(filter.max)), [filter.max]);
+  const parse = (v: string) => {
+    if (v.trim() === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  };
+  const commit = () => {
+    const min = parse(localMin);
+    const max = parse(localMax);
+    if (min !== filter.min || max !== filter.max) onChange({ ...filter, min, max });
+  };
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit();
+    }
+  };
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="text-muted-foreground">Between</span>
+      <Input
+        value={localMin}
+        onChange={(e) => setLocalMin(e.target.value)}
+        onBlur={commit}
+        onKeyDown={onKeyDown}
+        className="h-7 w-20 px-2"
+        placeholder="min"
+      />
+      <span className="text-muted-foreground">and</span>
+      <Input
+        value={localMax}
+        onChange={(e) => setLocalMax(e.target.value)}
+        onBlur={commit}
+        onKeyDown={onKeyDown}
+        className="h-7 w-20 px-2"
+        placeholder="max"
+      />
     </div>
   );
 }

--- a/apps/web/src/routes/api/web.$orgSlug.custom-field-append.ts
+++ b/apps/web/src/routes/api/web.$orgSlug.custom-field-append.ts
@@ -1,0 +1,120 @@
+// Custom-field append: browser file → synchronous ingest on the data service
+// → provenance row → stats back to the dialog. Raw body (not multipart) with
+// the config in query params, so the file streams through without a
+// form-parsing layer; the data service is internal and the browser only ever
+// talks to this edge. The upload id is minted here and passed down so lake
+// rows carry it; the provenance row is inserted only after ingest succeeds —
+// failed appends write nothing anywhere.
+
+import { createFileRoute } from "@tanstack/react-router";
+import { and, db, eq } from "@turf-tools/db";
+import {
+  type CustomFieldType,
+  customFieldUploads,
+  datasetOrganizations,
+  datasets,
+} from "@turf-tools/db/schema";
+import { hasPermission } from "~/lib/permissions";
+import { dataFetch } from "~/lib/server/data-proxy";
+import { buildWebContext } from "~/rpc/context";
+
+const FIELD_TYPES: CustomFieldType[] = ["number", "date", "text", "enum"];
+
+// Worst realistic append is a full-population two-column CSV (~100–150MB for
+// 5M rows); typical lists are well under 15MB. Cap well above the worst case.
+const MAX_BODY_BYTES = 250 * 1024 * 1024;
+
+type AppendStats = {
+  fields: string[];
+  rowCount: number;
+  skippedCount: number;
+  matchedCount: number | null;
+};
+
+export const Route = createFileRoute("/api/web/$orgSlug/custom-field-append")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const url = new URL(request.url);
+        const orgSlug = url.pathname.match(/^\/api\/web\/([^/]+)\/custom-field-append$/)?.[1];
+        if (!orgSlug) return new Response("Not Found", { status: 404 });
+
+        let context: Awaited<ReturnType<typeof buildWebContext>>;
+        try {
+          context = await buildWebContext(db, request.headers, orgSlug);
+        } catch {
+          return new Response("Unauthorized", { status: 401 });
+        }
+        if (!hasPermission(context.role, "datasets.manage")) {
+          return new Response("Forbidden", { status: 403 });
+        }
+
+        const datasetId = url.searchParams.get("datasetId");
+        const fieldType = url.searchParams.get("fieldType") as CustomFieldType | null;
+        // Sent only for one-column files (name + constant value).
+        const label = url.searchParams.get("label")?.trim() || null;
+        const value = url.searchParams.get("value")?.trim() || null;
+        const filename = url.searchParams.get("filename") || null;
+        if (!datasetId || !fieldType || !FIELD_TYPES.includes(fieldType)) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const [grant] = await db
+          .select({ slug: datasets.slug })
+          .from(datasetOrganizations)
+          .innerJoin(datasets, eq(datasets.datasetId, datasetOrganizations.datasetId))
+          .where(
+            and(
+              eq(datasetOrganizations.datasetId, datasetId),
+              eq(datasetOrganizations.organizationId, context.organizationId),
+            ),
+          );
+        if (!grant) return new Response("Not Found", { status: 404 });
+
+        const body = await request.arrayBuffer();
+        if (body.byteLength === 0) return new Response("Empty upload.", { status: 400 });
+        if (body.byteLength > MAX_BODY_BYTES) {
+          return new Response("File is too large to append.", { status: 413 });
+        }
+
+        const customFieldUploadId = crypto.randomUUID();
+        const params = new URLSearchParams({
+          datasetId,
+          datasetSlug: grant.slug,
+          fieldType,
+          uploadId: customFieldUploadId,
+        });
+        if (label) params.set("label", label);
+        if (value) params.set("value", value);
+        const upstream = await dataFetch(`/custom-fields/append?${params.toString()}`, {
+          method: "POST",
+          body,
+        });
+        const text = await upstream.text();
+        if (!upstream.ok) {
+          // FastAPI wraps errors as {detail} — unwrap for the dialog.
+          try {
+            const parsed = JSON.parse(text) as { detail?: string };
+            return new Response(parsed.detail ?? text, { status: upstream.status });
+          } catch {
+            return new Response(text, { status: upstream.status });
+          }
+        }
+        const stats = JSON.parse(text) as AppendStats;
+
+        await db.insert(customFieldUploads).values({
+          customFieldUploadId,
+          datasetId,
+          filename,
+          fields: stats.fields,
+          rowCount: stats.rowCount,
+          skippedCount: stats.skippedCount,
+          matchedCount: stats.matchedCount,
+          createdBy: context.user.id,
+        });
+
+        return Response.json(stats);
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/api/web.$orgSlug.custom-field-inspect.ts
+++ b/apps/web/src/routes/api/web.$orgSlug.custom-field-inspect.ts
@@ -1,0 +1,49 @@
+// Inspect a custom-field upload: raw body → data service parses it and
+// returns the column names or the parse error. Fully stateless — nothing is
+// persisted. The dialog sends only a head slice of CSVs (the header is all
+// inspect needs; DuckDB stays the one dialect sniffer) and reads parquet
+// footers client-side, so the full file crosses the wire once, on append.
+
+import { createFileRoute } from "@tanstack/react-router";
+import { db } from "@turf-tools/db";
+import { hasPermission } from "~/lib/permissions";
+import { dataFetch } from "~/lib/server/data-proxy";
+import { buildWebContext } from "~/rpc/context";
+
+export const Route = createFileRoute("/api/web/$orgSlug/custom-field-inspect")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const url = new URL(request.url);
+        const orgSlug = url.pathname.match(/^\/api\/web\/([^/]+)\/custom-field-inspect$/)?.[1];
+        if (!orgSlug) return new Response("Not Found", { status: 404 });
+        let context: Awaited<ReturnType<typeof buildWebContext>>;
+        try {
+          context = await buildWebContext(db, request.headers, orgSlug);
+        } catch {
+          return new Response("Unauthorized", { status: 401 });
+        }
+        if (!hasPermission(context.role, "datasets.manage")) {
+          return new Response("Forbidden", { status: 403 });
+        }
+        const body = await request.arrayBuffer();
+        if (body.byteLength === 0) return new Response("Empty upload.", { status: 400 });
+        const upstream = await dataFetch("/custom-fields/inspect", { method: "POST", body });
+        const text = await upstream.text();
+        if (!upstream.ok) {
+          // FastAPI wraps errors as {detail} — unwrap for the dialog.
+          try {
+            const parsed = JSON.parse(text) as { detail?: string };
+            return new Response(parsed.detail ?? text, { status: upstream.status });
+          } catch {
+            return new Response(text, { status: upstream.status });
+          }
+        }
+        return new Response(text, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/rpc/index.ts
+++ b/apps/web/src/rpc/index.ts
@@ -6,6 +6,7 @@ import * as persons from "./web/persons";
 import * as scripts from "./web/scripts";
 import * as segments from "./web/segments";
 import * as questions from "./web/questions";
+import * as customFields from "./web/custom-fields";
 import * as turfDrafts from "./web/turf-drafts";
 import * as webTurfs from "./web/turfs";
 import * as webUsers from "./web/users";
@@ -37,6 +38,7 @@ export const webRouter = {
     archive: datasets.archive,
     unarchive: datasets.unarchive,
     manifest: datasets.manifest,
+    baseFields: datasets.baseFields,
     elections: datasets.elections,
   },
   segments: {
@@ -114,6 +116,14 @@ export const webRouter = {
     removeResponseOption: questions.removeResponseOption,
     reorderResponseOptions: questions.reorderResponseOptions,
     updateResponseOptionText: questions.updateResponseOptionText,
+  },
+  customFields: {
+    list: customFields.list,
+    rename: customFields.rename,
+    archive: customFields.archive,
+    unarchive: customFields.unarchive,
+    clear: customFields.clear,
+    history: customFields.history,
   },
   users: {
     list: webUsers.list,

--- a/apps/web/src/rpc/web/custom-fields.ts
+++ b/apps/web/src/rpc/web/custom-fields.ts
@@ -1,0 +1,162 @@
+import { ORPCError } from "@orpc/server";
+import { and, arrayContains, asc, desc, eq } from "@turf-tools/db";
+import {
+  customFields,
+  customFieldUploads,
+  datasetOrganizations,
+  datasets,
+} from "@turf-tools/db/schema";
+import { z } from "zod";
+import { dataPostJson } from "~/lib/server/data-proxy";
+import { webPub as pub } from "../context";
+import { activeDatasetId } from "./active-dataset";
+
+// Custom fields (see docs/plans/custom-fields.md) — user-appended, typed,
+// dataset-scoped columns that float across versions. Values live in the lake;
+// this module serves the Postgres registry. `datasetId` targets any granted
+// dataset (the Data page rail); omitted → the org's active dataset (the
+// segment editor's filter catalog).
+export const list = pub
+  .input(z.object({ datasetId: z.string().uuid().optional() }).optional())
+  .handler(async ({ context, input }) => {
+    const datasetId = input?.datasetId
+      ? await guardDataset(context.db, context.organizationId, input.datasetId)
+      : await activeDatasetId(context.db, context.organizationId);
+    if (!datasetId) return [];
+    const rows = await context.db
+      .select({
+        customFieldId: customFields.customFieldId,
+        label: customFields.label,
+        fieldType: customFields.fieldType,
+        values: customFields.values,
+        personCount: customFields.personCount,
+        archivedAt: customFields.archivedAt,
+      })
+      .from(customFields)
+      .where(eq(customFields.datasetId, datasetId))
+      .orderBy(asc(customFields.label));
+    return rows.map(({ archivedAt, ...f }) => ({ ...f, isArchived: archivedAt != null }));
+  });
+
+// Rename is a one-row UPDATE with no fallout: criteria and lake values are
+// customFieldId-keyed — labels only exist at display edges.
+export const rename = pub
+  .input(z.object({ customFieldId: z.string().uuid(), label: z.string().min(1) }))
+  .handler(async ({ context, input }) => {
+    const field = await guardField(context.db, context.organizationId, input.customFieldId);
+    const label = input.label.trim();
+    if (!label) throw new ORPCError("BAD_REQUEST", { message: "Field name can't be empty." });
+    const [clash] = await context.db
+      .select({ customFieldId: customFields.customFieldId })
+      .from(customFields)
+      .where(and(eq(customFields.datasetId, field.datasetId), eq(customFields.label, label)));
+    if (clash && clash.customFieldId !== input.customFieldId)
+      throw new ORPCError("CONFLICT", { message: "A field with this name already exists." });
+    await context.db
+      .update(customFields)
+      .set({ label })
+      .where(eq(customFields.customFieldId, input.customFieldId));
+    return { ok: true as const };
+  });
+
+// Soft-hide a field from the card / picker — display only, values untouched.
+// Re-appending the label revives it.
+export const archive = pub
+  .input(z.object({ customFieldId: z.string().uuid() }))
+  .handler(async ({ context, input }) => {
+    await guardField(context.db, context.organizationId, input.customFieldId);
+    await context.db
+      .update(customFields)
+      .set({ archivedAt: new Date() })
+      .where(eq(customFields.customFieldId, input.customFieldId));
+    return { ok: true as const };
+  });
+
+export const unarchive = pub
+  .input(z.object({ customFieldId: z.string().uuid() }))
+  .handler(async ({ context, input }) => {
+    await guardField(context.db, context.organizationId, input.customFieldId);
+    await context.db
+      .update(customFields)
+      .set({ archivedAt: null })
+      .where(eq(customFields.customFieldId, input.customFieldId));
+    return { ok: true as const };
+  });
+
+// Clear a field — delete its values for everyone (registry row stays at zero
+// coverage, ready for re-append). Synchronous on the data side.
+export const clear = pub
+  .input(z.object({ customFieldId: z.string().uuid() }))
+  .handler(async ({ context, input }) => {
+    const field = await guardField(context.db, context.organizationId, input.customFieldId);
+    const [ds] = await context.db
+      .select({ slug: datasets.slug })
+      .from(datasets)
+      .where(eq(datasets.datasetId, field.datasetId));
+    if (!ds) throw new ORPCError("NOT_FOUND", { message: "Dataset not found." });
+    await dataPostJson("/custom-fields/clear", {
+      datasetSlug: ds.slug,
+      fieldId: input.customFieldId,
+    });
+    return { ok: true as const };
+  });
+
+// Appends that touched a field (by label) — the field dialog's history list.
+// Rows only exist for successful appends; failures never persist.
+export const history = pub
+  .input(z.object({ customFieldId: z.string().uuid() }))
+  .handler(async ({ context, input }) => {
+    const field = await guardField(context.db, context.organizationId, input.customFieldId);
+    return context.db
+      .select({
+        customFieldUploadId: customFieldUploads.customFieldUploadId,
+        filename: customFieldUploads.filename,
+        rowCount: customFieldUploads.rowCount,
+        matchedCount: customFieldUploads.matchedCount,
+        createdAt: customFieldUploads.createdAt,
+      })
+      .from(customFieldUploads)
+      .where(
+        and(
+          eq(customFieldUploads.datasetId, field.datasetId),
+          arrayContains(customFieldUploads.fields, [field.label]),
+        ),
+      )
+      .orderBy(desc(customFieldUploads.createdAt));
+  });
+
+type Db = Parameters<typeof activeDatasetId>[0];
+
+// Guards scope to datasets the org is granted — tenant isolation.
+async function guardDataset(db: Db, organizationId: string, datasetId: string): Promise<string> {
+  const [grant] = await db
+    .select({ datasetId: datasetOrganizations.datasetId })
+    .from(datasetOrganizations)
+    .where(
+      and(
+        eq(datasetOrganizations.datasetId, datasetId),
+        eq(datasetOrganizations.organizationId, organizationId),
+      ),
+    );
+  if (!grant) throw new ORPCError("NOT_FOUND", { message: "Dataset not found." });
+  return datasetId;
+}
+
+async function guardField(db: Db, organizationId: string, customFieldId: string) {
+  const [row] = await db
+    .select({
+      customFieldId: customFields.customFieldId,
+      datasetId: customFields.datasetId,
+      label: customFields.label,
+    })
+    .from(customFields)
+    .innerJoin(datasetOrganizations, eq(datasetOrganizations.datasetId, customFields.datasetId))
+    .where(
+      and(
+        eq(customFields.customFieldId, customFieldId),
+        eq(datasetOrganizations.organizationId, organizationId),
+      ),
+    );
+  if (!row) throw new ORPCError("NOT_FOUND", { message: "Field not found." });
+  return row;
+}

--- a/apps/web/src/rpc/web/datasets.ts
+++ b/apps/web/src/rpc/web/datasets.ts
@@ -292,6 +292,44 @@ export const manifest = pub.input(z.object({}).optional()).handler(async ({ cont
   return { manifest: row.manifest as Manifest, versionId: row.versionId };
 });
 
+// Flattened field list from a dataset's latest ready version's manifest —
+// the Data page's "base fields" display (name + kind; coverage is meaningless
+// since every person has them). Dataset-targeted (the rail can select a
+// non-active dataset), unlike `manifest` above which follows the org's
+// active version.
+export const baseFields = pub
+  .input(z.object({ datasetId: z.string().uuid() }))
+  .handler(async ({ context, input }): Promise<Array<{ label: string; kind: string }>> => {
+    // Prefer the org's active version when it belongs to this dataset (the
+    // fields users actually filter on); otherwise the latest ready version.
+    const [org] = await context.db
+      .select({ activeDatasetVersionId: organizations.activeDatasetVersionId })
+      .from(organizations)
+      .where(eq(organizations.organizationId, context.organizationId));
+    const rows = await context.db
+      .select({
+        manifest: datasetVersions.manifest,
+        versionId: datasetVersions.datasetVersionId,
+      })
+      .from(datasetVersions)
+      .innerJoin(
+        datasetOrganizations,
+        eq(datasetOrganizations.datasetId, datasetVersions.datasetId),
+      )
+      .where(
+        and(
+          eq(datasetVersions.datasetId, input.datasetId),
+          eq(datasetOrganizations.organizationId, context.organizationId),
+          eq(datasetVersions.status, "ready"),
+        ),
+      )
+      .orderBy(desc(datasetVersions.versionNumber));
+    const row = rows.find((r) => r.versionId === org?.activeDatasetVersionId) ?? rows[0];
+    const manifest = (row?.manifest ?? null) as Manifest | null;
+    if (!manifest) return [];
+    return manifest.fields.flat().map((fd) => ({ label: fd.label, kind: fd.filterKind }));
+  });
+
 export type Election = { value: string; label: string };
 
 // Distinct elections in the org's active dataset — the voting-history-detail

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,7 +6,7 @@ import * as schema from "./schema";
 
 // Re-export drizzle query helpers so consumers share the same drizzle-orm instance
 // as this package's schema (avoids type mismatches across pnpm peer-dep variants).
-export { and, asc, desc, eq, gt, inArray, isNull, ne, sql } from "drizzle-orm";
+export { and, arrayContains, asc, desc, eq, gt, inArray, isNull, ne, sql } from "drizzle-orm";
 
 export * from "./ids";
 

--- a/packages/db/src/schema/custom-fields.ts
+++ b/packages/db/src/schema/custom-fields.ts
@@ -1,0 +1,56 @@
+import { integer, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { users } from "./auth/users";
+import { datasets } from "./datasets";
+
+// Custom-field types — scalar values, latest-upload-wins per person. Each
+// maps 1:1 onto an existing filter kind (number-range / date-range / text /
+// enum). Membership lists are a one-column upload with a constant value
+// (e.g. Employer → amazon), not a dedicated type.
+export type CustomFieldType = "number" | "date" | "text" | "enum";
+
+// A custom field — a user-appended, dataset-scoped, typed column that floats
+// across dataset versions (see docs/plans/custom-fields.md). One row per
+// field; values live in the lake's long-format `<slug>_custom_fields` table.
+// Criteria reference `customFieldId` (never the label), so rename is a
+// one-row UPDATE with no lake or saved-segment fallout.
+export const customFields = pgTable(
+  "custom_fields",
+  {
+    customFieldId: uuid().defaultRandom().primaryKey(),
+    datasetId: uuid()
+      .notNull()
+      .references(() => datasets.datasetId),
+    label: text().notNull(),
+    fieldType: text().$type<CustomFieldType>().notNull(),
+    // Enum option set, derived from distinct values at ingest.
+    values: text().array(),
+    // Cached coverage (people with a value), synced by the only two value
+    // writers (append ingest, clear); can't drift otherwise.
+    personCount: integer().notNull().default(0),
+    createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+    // Soft-hide from the card / picker — display only, values untouched.
+    // Re-appending the label revives (ingest nulls this).
+    archivedAt: timestamp({ withTimezone: true }),
+  },
+  (t) => [uniqueIndex("custom_fields_dataset_label").on(t.datasetId, t.label)],
+);
+
+// Provenance for one append — inserted after the synchronous ingest succeeds
+// (failed appends write nothing). No standing UI table; the field dialog's
+// history reads it, and lake values carry `upload_id` so every value traces
+// back here.
+export const customFieldUploads = pgTable("custom_field_uploads", {
+  customFieldUploadId: uuid().defaultRandom().primaryKey(),
+  datasetId: uuid()
+    .notNull()
+    .references(() => datasets.datasetId),
+  filename: text(),
+  fields: text().array(),
+  rowCount: integer(),
+  // Rows with an id but no value — ignored entirely (prior values survive);
+  // surfaced in the Append dialog so sparse files don't silently shrink.
+  skippedCount: integer(),
+  matchedCount: integer(),
+  createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
+  createdBy: uuid().references(() => users.id),
+});

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -16,4 +16,5 @@ export * from "./turf-drafts";
 export * from "./zone-groups";
 export * from "./zones";
 export * from "./canvass-events";
+export * from "./custom-fields";
 export * from "./jobs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       drizzle-orm:
         specifier: beta
         version: 1.0.0-beta.22(@electric-sql/pglite@0.4.5)(postgres@3.4.9)(zod@4.4.3)
+      hyparquet:
+        specifier: ^1.26.2
+        version: 1.26.2
       jotai:
         specifier: ^2.19.1
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.0)
@@ -5043,6 +5046,9 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  hyparquet@1.26.2:
+    resolution: {integrity: sha512-6qjyK7R2tZ4vnYP1J8NpcCeDPK1UIYk3xh5XgtQUnUM1iwkYbvI6Mz3xtmpMd6AfCCeoUoJVbEq29k5GReZRWA==}
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
@@ -12312,6 +12318,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  hyparquet@1.26.2: {}
 
   hyphenate-style-name@1.1.0: {}
 


### PR DESCRIPTION
This PR supports a commonly requested feature: appending a dataset (like a voter file) with additional user-provided columns that aren't available through a native stream of data that we can directly consume. Examples might be, support scores from previous campaigns, early voting data from a state file during election week, data about voter's membership in various organizations, or (until we have the right integrations) phone and text banking results, all of which might be critical for defining Segments (in concert with the fields we already have, like Age and Voting History).

Some similar products support this kind of use case through unstructured tags, which is where I started, but tags have a variety of problems and are difficult to maintain. The alternative we landed on stays closer to the underlying data model. The user submits a file with IDs, or IDs and values, and selects a type matched to one of the types we already support for Segment filters (like Text, Number, Date, or Enum / Category). The result is, effectively, adding a column to the data, which can then be filtered in the Segment Editor just like any other existing fields. It's stored in the ducklake in a table alongside the main data table (as opposed to additional columns on the versioned table itself, because appends apply to all versions). It's stored long-form because the more common use case is appending an extra field on a small subset of people, as opposed to a field on all people, but this could be easily revisited without changing the overall UX or data model at all.

As part of this, I expanded the Data tab to let you browse Datasets as a list and see details on them. Those details include the versions you've uploaded (essentially the existing table of datasets), but also the base fields, and any custom fields.