### PR TITLE
chore: schema rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ dist-ssr
 .claude/worktrees/
 docs/plans
 
+# One-time migration scripts, run by hand against live deployments
+deploy/migrate-off-public.sql
+
 # Per-user Claude Code state (personal settings + runtime locks).
 # Shared `.claude/settings.json` and similar can still be committed.
 .claude/settings.local.json

--- a/apps/data/.env.example
+++ b/apps/data/.env.example
@@ -9,7 +9,7 @@
 # DuckLake metadata catalog. Dev defaults to a Postgres catalog on the dev
 # Postgres (concurrency-safe, so import jobs don't fight the serving connection
 # over a single-writer local file) with local Parquet storage — no config
-# needed. Both catalogs share the dev DB via distinct schemas (`ducklake`,
-# `ducklake_geo`), auto-created on connect. Set these only to point elsewhere:
+# needed. Both catalogs share the dev DB via distinct schemas (`catalog`,
+# `catalog_geo`), auto-created on connect. Set these only to point elsewhere:
 # DUCKLAKE_METADATA_POSTGRES_URL=
 # DUCKLAKE_GEO_METADATA_POSTGRES_URL=

--- a/apps/data/src/cli.py
+++ b/apps/data/src/cli.py
@@ -238,26 +238,26 @@ def _ensure_seed_dataset(conn: duckdb.DuckDBPyConnection, schema: str) -> str:
     pg = OPERATIONAL_PG_ALIAS
     conn.execute(
         f"CALL postgres_execute('{pg}', $ft$"
-        f"INSERT INTO public.datasets (slug, name, importer) "
+        f"INSERT INTO app.datasets (slug, name, importer) "
         f"VALUES ('{slug}', 'NY State Voter File', 'nys_voter_file') "
         f"ON CONFLICT (slug) DO NOTHING$ft$)"
     )
-    dataset_id = conn.execute(f"SELECT dataset_id FROM {pg}.public.datasets WHERE slug = ?", [slug]).fetchone()[0]
+    dataset_id = conn.execute(f"SELECT dataset_id FROM {pg}.app.datasets WHERE slug = ?", [slug]).fetchone()[0]
     conn.execute(
         f"CALL postgres_execute('{pg}', $ft$"
-        f"INSERT INTO public.dataset_versions (dataset_id, version_number, status) "
+        f"INSERT INTO app.dataset_versions (dataset_id, version_number, status) "
         f"SELECT '{dataset_id}', {int(version_number)}, 'importing' "
-        f"WHERE NOT EXISTS (SELECT 1 FROM public.dataset_versions "
+        f"WHERE NOT EXISTS (SELECT 1 FROM app.dataset_versions "
         f"WHERE dataset_id = '{dataset_id}' AND version_number = {int(version_number)})$ft$)"
     )
     version_id = conn.execute(
-        f"SELECT dataset_version_id FROM {pg}.public.dataset_versions WHERE dataset_id = ? AND version_number = ?",
+        f"SELECT dataset_version_id FROM {pg}.app.dataset_versions WHERE dataset_id = ? AND version_number = ?",
         [dataset_id, int(version_number)],
     ).fetchone()[0]
     conn.execute(
         f"CALL postgres_execute('{pg}', $ft$"
-        f"INSERT INTO public.dataset_organizations (dataset_id, organization_id) "
-        f"SELECT '{dataset_id}', organization_id FROM public.organizations "
+        f"INSERT INTO app.dataset_organizations (dataset_id, organization_id) "
+        f"SELECT '{dataset_id}', organization_id FROM app.organizations "
         f"ON CONFLICT (dataset_id, organization_id) DO NOTHING$ft$)"
     )
     return str(version_id)
@@ -268,7 +268,7 @@ def _activate_for_all_orgs(conn: duckdb.DuckDBPyConnection, version_id: str) -> 
     theirs via "Make active"; the seed just wires it up so the UI has data."""
     conn.execute(
         f"CALL postgres_execute('{OPERATIONAL_PG_ALIAS}', $ft$"
-        f"UPDATE public.organizations SET active_dataset_version_id = '{version_id}'$ft$)"
+        f"UPDATE app.organizations SET active_dataset_version_id = '{version_id}'$ft$)"
     )
 
 

--- a/apps/data/src/custom_fields.py
+++ b/apps/data/src/custom_fields.py
@@ -72,14 +72,14 @@ def sync_registry(conn: duckdb.DuckDBPyConnection, dataset_slug: str, *, include
     ).fetchall()
     conn.execute(
         f"""
-        UPDATE {OPERATIONAL_PG_ALIAS}.public.custom_fields SET person_count = 0
-        WHERE dataset_id = (SELECT dataset_id FROM {OPERATIONAL_PG_ALIAS}.public.datasets WHERE slug = ?)
+        UPDATE {OPERATIONAL_PG_ALIAS}.app.custom_fields SET person_count = 0
+        WHERE dataset_id = (SELECT dataset_id FROM {OPERATIONAL_PG_ALIAS}.app.datasets WHERE slug = ?)
         """,
         [dataset_slug],
     )
     for field_id, n in counts:
         conn.execute(
-            f"UPDATE {OPERATIONAL_PG_ALIAS}.public.custom_fields SET person_count = ? WHERE custom_field_id = ?::UUID",
+            f"UPDATE {OPERATIONAL_PG_ALIAS}.app.custom_fields SET person_count = ? WHERE custom_field_id = ?::UUID",
             [n, field_id],
         )
     # Enum option sets are owned by APPEND (derived from the data at ingest)
@@ -90,8 +90,8 @@ def sync_registry(conn: duckdb.DuckDBPyConnection, dataset_slug: str, *, include
         return
     enum_fields = conn.execute(
         f"""
-        SELECT f.custom_field_id::VARCHAR FROM {OPERATIONAL_PG_ALIAS}.public.custom_fields f
-        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d ON d.dataset_id = f.dataset_id
+        SELECT f.custom_field_id::VARCHAR FROM {OPERATIONAL_PG_ALIAS}.app.custom_fields f
+        JOIN {OPERATIONAL_PG_ALIAS}.app.datasets d ON d.dataset_id = f.dataset_id
         WHERE d.slug = ? AND f.field_type = 'enum'
         """,
         [dataset_slug],
@@ -105,7 +105,7 @@ def sync_registry(conn: duckdb.DuckDBPyConnection, dataset_slug: str, *, include
             ).fetchall()
         ]
         conn.execute(
-            f"UPDATE {OPERATIONAL_PG_ALIAS}.public.custom_fields SET values = ? WHERE custom_field_id = ?::UUID",
+            f"UPDATE {OPERATIONAL_PG_ALIAS}.app.custom_fields SET values = ? WHERE custom_field_id = ?::UUID",
             [values, field_id],
         )
 
@@ -119,8 +119,8 @@ def catalog_for(conn: duckdb.DuckDBPyConnection, version: ResolvedVersion) -> Fi
     rows = conn.execute(
         f"""
         SELECT f.custom_field_id::VARCHAR, f.field_type
-        FROM {OPERATIONAL_PG_ALIAS}.public.custom_fields f
-        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d ON d.dataset_id = f.dataset_id
+        FROM {OPERATIONAL_PG_ALIAS}.app.custom_fields f
+        JOIN {OPERATIONAL_PG_ALIAS}.app.datasets d ON d.dataset_id = f.dataset_id
         WHERE d.slug = ?
         """,
         [version.dataset_slug],
@@ -275,7 +275,7 @@ def append_custom_fields(
         CREATE OR REPLACE TEMP TABLE _rows_ids AS
         SELECT r.external_id, f.custom_field_id::VARCHAR AS field_id, r.value
         FROM _rows r
-        JOIN {OPERATIONAL_PG_ALIAS}.public.custom_fields f
+        JOIN {OPERATIONAL_PG_ALIAS}.app.custom_fields f
             ON f.label = r.label AND f.dataset_id = ?::UUID
         """,
         [dataset_id],
@@ -324,7 +324,7 @@ def _upsert_registry(conn: duckdb.DuckDBPyConnection, dataset_id: str, field_typ
     conflict = conn.execute(
         f"""
         SELECT f.label, f.field_type, f.archived_at IS NOT NULL
-        FROM {OPERATIONAL_PG_ALIAS}.public.custom_fields f
+        FROM {OPERATIONAL_PG_ALIAS}.app.custom_fields f
         WHERE f.dataset_id = ?::UUID AND f.field_type <> ?
             AND f.label IN (SELECT DISTINCT label FROM _rows)
         LIMIT 1
@@ -339,17 +339,17 @@ def _upsert_registry(conn: duckdb.DuckDBPyConnection, dataset_id: str, field_typ
         )
     conn.execute(
         f"""
-        INSERT INTO {OPERATIONAL_PG_ALIAS}.public.custom_fields (custom_field_id, dataset_id, label, field_type)
+        INSERT INTO {OPERATIONAL_PG_ALIAS}.app.custom_fields (custom_field_id, dataset_id, label, field_type)
         SELECT uuid(), ?::UUID, label, ? FROM (SELECT DISTINCT label FROM _rows)
         WHERE label NOT IN (
-            SELECT label FROM {OPERATIONAL_PG_ALIAS}.public.custom_fields WHERE dataset_id = ?::UUID
+            SELECT label FROM {OPERATIONAL_PG_ALIAS}.app.custom_fields WHERE dataset_id = ?::UUID
         )
         """,
         [dataset_id, field_type, dataset_id],
     )
     conn.execute(
         f"""
-        UPDATE {OPERATIONAL_PG_ALIAS}.public.custom_fields SET archived_at = NULL
+        UPDATE {OPERATIONAL_PG_ALIAS}.app.custom_fields SET archived_at = NULL
         WHERE dataset_id = ?::UUID AND archived_at IS NOT NULL
             AND label IN (SELECT DISTINCT label FROM _rows)
         """,
@@ -364,8 +364,8 @@ def _matched_count(conn: duckdb.DuckDBPyConnection, dataset_slug: str) -> int | 
     row = conn.execute(
         f"""
         SELECT max(v.version_number)
-        FROM {OPERATIONAL_PG_ALIAS}.public.dataset_versions v
-        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d ON d.dataset_id = v.dataset_id
+        FROM {OPERATIONAL_PG_ALIAS}.app.dataset_versions v
+        JOIN {OPERATIONAL_PG_ALIAS}.app.datasets d ON d.dataset_id = v.dataset_id
         WHERE d.slug = ? AND v.status = 'ready'
         """,
         [dataset_slug],

--- a/apps/data/src/dsl/resolve.py
+++ b/apps/data/src/dsl/resolve.py
@@ -129,10 +129,10 @@ def _canvass_outcome_person_ids(
             SELECT
                 e.person_id,
                 json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome') AS outcome
-            FROM {OPERATIONAL_PG_ALIAS}.public.canvass_events e
-            JOIN {OPERATIONAL_PG_ALIAS}.public.turfs t ON t.turf_id = e.turf_id
-            JOIN {OPERATIONAL_PG_ALIAS}.public.campaigns c ON c.campaign_id = t.campaign_id
-            JOIN {OPERATIONAL_PG_ALIAS}.public.organizations o
+            FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
+            JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
+            JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
+            JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
                 ON o.organization_id = c.organization_id
             WHERE e.kind = 'result'
                 AND e.person_id IS NOT NULL
@@ -170,10 +170,10 @@ def _canvass_response_person_ids(
             SELECT
                 e.person_id,
                 CAST(json_extract(CAST(e.payload AS VARCHAR), ?) AS VARCHAR[]) AS selected
-            FROM {OPERATIONAL_PG_ALIAS}.public.canvass_events e
-            JOIN {OPERATIONAL_PG_ALIAS}.public.turfs t ON t.turf_id = e.turf_id
-            JOIN {OPERATIONAL_PG_ALIAS}.public.campaigns c ON c.campaign_id = t.campaign_id
-            JOIN {OPERATIONAL_PG_ALIAS}.public.organizations o
+            FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
+            JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
+            JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
+            JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
                 ON o.organization_id = c.organization_id
             WHERE e.kind = 'result'
                 AND e.person_id IS NOT NULL
@@ -193,8 +193,8 @@ def _load_segments_for_org(conn: duckdb.DuckDBPyConnection, org_slug: str) -> di
     rows = conn.execute(
         f"""
         SELECT s.segment_id::VARCHAR, s.name, s.criteria::VARCHAR
-        FROM {OPERATIONAL_PG_ALIAS}.public.segments s
-        JOIN {OPERATIONAL_PG_ALIAS}.public.organizations o
+        FROM {OPERATIONAL_PG_ALIAS}.app.segments s
+        JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
             ON o.organization_id = s.organization_id
         WHERE o.slug = ?
         """,

--- a/apps/data/src/duckdb.py
+++ b/apps/data/src/duckdb.py
@@ -115,7 +115,7 @@ def _attach_ducklake(
     alias: str,
     *,
     pg_url: str | None,
-    meta_schema: str | None,
+    meta_schema: str,
     local_catalog: str,
     local_data_dir: str,
     bucket: str,
@@ -125,11 +125,14 @@ def _attach_ducklake(
     """Attach one DuckLake catalog. Catalog backend (Postgres vs local DuckDB
     file) and storage (S3 vs local dir) are independent axes:
 
-    - **prod:** Postgres catalog + S3 storage (bucket set).
+    - **prod:** Postgres catalog (a DB per catalog) + S3 storage (bucket set).
     - **dev:** Postgres catalog (concurrency-safe, unlike a single-writer local
-      file) + local storage. Two catalogs share one dev Postgres DB via distinct
-      `META_SCHEMA`s; DuckLake requires the schema to pre-exist, so we ensure it.
+      file) + local storage. Two catalogs share the one dev Postgres DB.
     - **file fallback:** local DuckDB-file catalog + local dir (no Postgres).
+
+    Postgres catalogs always use `META_SCHEMA` (`catalog`/`catalog_geo`) — the
+    same schema names in every environment; only the database differs. DuckLake
+    requires the schema to pre-exist, so we ensure it.
     """
     data_path = _s3_path(bucket, prefix) if bucket else local_data_dir
     if not bucket:
@@ -141,12 +144,10 @@ def _attach_ducklake(
 
     conn.install_extension("postgres")
     conn.load_extension("postgres")
-    schema_opt = ""
-    if meta_schema:
-        conn.execute(f"ATTACH '{pg_url}' AS _meta_{alias} (TYPE postgres)")
-        conn.execute(f"CREATE SCHEMA IF NOT EXISTS _meta_{alias}.{meta_schema}")
-        conn.execute(f"DETACH _meta_{alias}")
-        schema_opt = f", META_SCHEMA '{meta_schema}'"
+    conn.execute(f"ATTACH '{pg_url}' AS _meta_{alias} (TYPE postgres)")
+    conn.execute(f"CREATE SCHEMA IF NOT EXISTS _meta_{alias}.{meta_schema}")
+    conn.execute(f"DETACH _meta_{alias}")
+    schema_opt = f", META_SCHEMA '{meta_schema}'"
     conn.execute(f"ATTACH 'ducklake:postgres:{pg_url}' AS {alias} (DATA_PATH '{data_path}'{schema_opt}{read_only_opt})")
 
 
@@ -213,7 +214,7 @@ def refresh_s3_secret_on_shared_connection(settings: Settings) -> None:
 
 # Alias under which the operational Postgres database is mounted into
 # DuckDB by `attach_operational_postgres`. Cross-database SQL refers to
-# tables as `operational_pg.public.<table>`.
+# tables as `operational_pg.app.<table>`.
 OPERATIONAL_PG_ALIAS = "operational_pg"
 
 

--- a/apps/data/src/import_job.py
+++ b/apps/data/src/import_job.py
@@ -48,7 +48,8 @@ async def import_dataset_version(payload: ImportDatasetVersionPayload, ctx: JobC
         # reason (pure Postgres, so it works even when the DuckLake attach is what
         # failed). Then re-raise so the job framework records it on the job row.
         await postgres.execute(
-            "UPDATE dataset_versions SET status = 'failed', error = left($2, 1000) WHERE dataset_version_id = $1::uuid",
+            "UPDATE app.dataset_versions SET status = 'failed', error = left($2, 1000) "
+            "WHERE dataset_version_id = $1::uuid",
             payload.dataset_version_id,
             str(exc),
         )
@@ -194,8 +195,8 @@ def _resolve_version(
     row = conn.execute(
         f"""
         SELECT d.slug, v.version_number, d.importer
-        FROM {OPERATIONAL_PG_ALIAS}.public.dataset_versions v
-        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d ON d.dataset_id = v.dataset_id
+        FROM {OPERATIONAL_PG_ALIAS}.app.dataset_versions v
+        JOIN {OPERATIONAL_PG_ALIAS}.app.datasets d ON d.dataset_id = v.dataset_id
         WHERE v.dataset_version_id = ?
         """,
         [dataset_version_id],

--- a/apps/data/src/import_progress.py
+++ b/apps/data/src/import_progress.py
@@ -43,7 +43,7 @@ class ImportProgress:
     def _write(self) -> None:
         self._conn.execute(
             f"CALL postgres_execute('{OPERATIONAL_PG_ALIAS}', $ft$"
-            f"UPDATE public.dataset_versions "
+            f"UPDATE app.dataset_versions "
             f"SET import_step = {int(self._step)}, import_total_steps = {int(self._total)} "
             f"WHERE dataset_version_id = '{self._dvid}'$ft$)"
         )
@@ -62,7 +62,7 @@ class JobLog:
         payload = json.dumps({"level": level, "message": message}).replace("'", "''")
         self._conn.execute(
             f"CALL postgres_execute('{OPERATIONAL_PG_ALIAS}', $jobmsg$"
-            f"INSERT INTO public.job_messages (job_id, payload) "
+            f"INSERT INTO app.job_messages (job_id, payload) "
             f"VALUES ('{self._job_id}', '{payload}'::json)$jobmsg$)"
         )
 

--- a/apps/data/src/job_runner.py
+++ b/apps/data/src/job_runner.py
@@ -270,14 +270,14 @@ class PostgresJobStore:
             """
             WITH locked AS (
                 SELECT j.job_id, j.task, j.payload, j.concurrency_key
-                FROM jobs j
+                FROM app.jobs j
                 WHERE j.status = $1
                   AND j.task = ANY($2::text[])
                   AND (
                     j.concurrency_key IS NULL
                     OR NOT EXISTS (
                         SELECT 1
-                        FROM jobs active
+                        FROM app.jobs active
                         WHERE active.status = $3
                           AND active.concurrency_key = j.concurrency_key
                     )
@@ -300,7 +300,7 @@ class PostgresJobStore:
                 WHERE concurrency_rank = 1
                 LIMIT $5
             )
-            UPDATE jobs
+            UPDATE app.jobs
             SET status = $6, locked_by_worker_id = $7
             WHERE job_id IN (SELECT job_id FROM eligible)
             RETURNING job_id, task, payload, concurrency_key
@@ -329,7 +329,7 @@ class PostgresJobStore:
 
         await execute(
             """
-            UPDATE jobs
+            UPDATE app.jobs
             SET status = $1, result = $2::jsonb, failure_reason = NULL, locked_by_worker_id = NULL
             WHERE job_id = $3
             """,
@@ -343,7 +343,7 @@ class PostgresJobStore:
 
         await execute(
             """
-            UPDATE jobs
+            UPDATE app.jobs
             SET status = $1, failure_reason = $2, locked_by_worker_id = NULL
             WHERE job_id = $3
             """,
@@ -357,7 +357,7 @@ class PostgresJobStore:
 
         await execute(
             """
-            INSERT INTO job_messages (job_id, payload)
+            INSERT INTO app.job_messages (job_id, payload)
             VALUES ($1, $2::json)
             """,
             job_id,

--- a/apps/data/src/publish_turfs.py
+++ b/apps/data/src/publish_turfs.py
@@ -185,7 +185,7 @@ def _check_no_ambiguous_assignments(
         SELECT
             row_number() OVER (ORDER BY d.sort_order, d.turf_draft_id) - 1 AS idx,
             ST_GeomFromGeoJSON(d.geometry::VARCHAR) AS geom
-        FROM {OPERATIONAL_PG_ALIAS}.public.turf_drafts d
+        FROM {OPERATIONAL_PG_ALIAS}.app.turf_drafts d
         WHERE d.campaign_id = ?::UUID AND d.zone_id IS NOT DISTINCT FROM ?::UUID
     ),
     matched_buildings AS (
@@ -244,15 +244,15 @@ def _load_publish_scope(conn: duckdb.DuckDBPyConnection, req: PublishTurfsReques
             z.zone_id::VARCHAR AS zone_id,
             z.keys::VARCHAR AS keys_json,
             (
-                SELECT count(*)::INT FROM {OPERATIONAL_PG_ALIAS}.public.turf_drafts d
+                SELECT count(*)::INT FROM {OPERATIONAL_PG_ALIAS}.app.turf_drafts d
                 WHERE d.campaign_id = c.campaign_id
                   AND d.zone_id IS NOT DISTINCT FROM ?::UUID
             ) AS draft_count
-        FROM {OPERATIONAL_PG_ALIAS}.public.campaigns c
-        JOIN {OPERATIONAL_PG_ALIAS}.public.segments s ON s.segment_id = c.segment_id
-        LEFT JOIN {OPERATIONAL_PG_ALIAS}.public.zone_groups zg
+        FROM {OPERATIONAL_PG_ALIAS}.app.campaigns c
+        JOIN {OPERATIONAL_PG_ALIAS}.app.segments s ON s.segment_id = c.segment_id
+        LEFT JOIN {OPERATIONAL_PG_ALIAS}.app.zone_groups zg
             ON zg.zone_group_id = c.zone_group_id
-        LEFT JOIN {OPERATIONAL_PG_ALIAS}.public.zones z
+        LEFT JOIN {OPERATIONAL_PG_ALIAS}.app.zones z
             ON z.zone_id = ?::UUID
             AND z.zone_group_id = c.zone_group_id
         WHERE c.campaign_id = ?::UUID
@@ -365,7 +365,7 @@ def _build_publish_temp_table_sql(schema: str, where_sql: str, present_optional:
             d.sort_order,
             d.geometry::VARCHAR AS geometry_json,
             ST_GeomFromGeoJSON(d.geometry::VARCHAR) AS geom
-        FROM {OPERATIONAL_PG_ALIAS}.public.turf_drafts d
+        FROM {OPERATIONAL_PG_ALIAS}.app.turf_drafts d
         WHERE d.campaign_id = ?::UUID
           AND d.zone_id IS NOT DISTINCT FROM ?::UUID
     ),
@@ -495,7 +495,7 @@ def _build_publish_temp_table_sql(schema: str, where_sql: str, present_optional:
 
 def _insert_turfs_sql() -> str:
     return f"""
-    INSERT INTO {OPERATIONAL_PG_ALIAS}.public.turfs (
+    INSERT INTO {OPERATIONAL_PG_ALIAS}.app.turfs (
         turf_id, campaign_id, segment_id, zone_id, zone_group_id,
         script_id, name, turf_code, geometry, door_count, person_count,
         created_by, dataset_version_id
@@ -510,7 +510,7 @@ def _insert_turfs_sql() -> str:
 
 def _insert_turf_data_sql() -> str:
     return f"""
-    INSERT INTO {OPERATIONAL_PG_ALIAS}.public.turf_data (turf_id, data)
+    INSERT INTO {OPERATIONAL_PG_ALIAS}.app.turf_data (turf_id, data)
     SELECT turf_id, json(data) FROM published_turf_rows;
     """
 

--- a/apps/data/src/settings.py
+++ b/apps/data/src/settings.py
@@ -20,12 +20,6 @@ def _default_ducklake_metadata_url() -> str | None:
     return _default_database_url()
 
 
-def _dev_meta_schema(name: str) -> str | None:
-    """Dev shares one Postgres DB across catalogs via distinct schemas; prod uses
-    a DB per catalog (default schema), so no META_SCHEMA there."""
-    return None if os.environ.get("NODE_ENV") == "production" else name
-
-
 class StorageConfig(BaseSettings):
     """S3-compatible object storage for the deployment.
 
@@ -53,10 +47,10 @@ class Settings(BaseSettings):
         default_factory=_default_ducklake_metadata_url,
         description="PostgreSQL connection URL for the DuckLake metadata catalog. If not set, uses local DuckDB file.",
     )
-    # Postgres schema holding this catalog's metadata tables. Lets several
-    # catalogs share one Postgres DB (dev points both at the dev Postgres). Unset
-    # in prod, where each catalog has its own DB and uses the default schema.
-    ducklake_meta_schema: str | None = Field(default_factory=lambda: _dev_meta_schema("ducklake"))
+    # Postgres schema holding this catalog's metadata tables. Same names in
+    # every environment: dev shares one Postgres DB across catalogs via these
+    # schemas; prod gives each catalog its own DB but keeps the schema name.
+    ducklake_meta_schema: str = "catalog"
 
     ducklake_geo_metadata_postgres_url: str | None = Field(
         default_factory=_default_ducklake_metadata_url,
@@ -64,7 +58,7 @@ class Settings(BaseSettings):
             "PostgreSQL connection URL for the geo DuckLake metadata catalog. If not set, uses local DuckDB file."
         ),
     )
-    ducklake_geo_meta_schema: str | None = Field(default_factory=lambda: _dev_meta_schema("ducklake_geo"))
+    ducklake_geo_meta_schema: str = "catalog_geo"
 
     database_url: str = Field(
         default_factory=_default_database_url,

--- a/apps/data/src/tables.py
+++ b/apps/data/src/tables.py
@@ -159,10 +159,10 @@ def resolve_version(
     row = conn.execute(
         f"""
         SELECT d.slug, v.version_number, v.dataset_version_id, v.manifest
-        FROM {OPERATIONAL_PG_ALIAS}.public.organizations o
-        JOIN {OPERATIONAL_PG_ALIAS}.public.dataset_versions v
+        FROM {OPERATIONAL_PG_ALIAS}.app.organizations o
+        JOIN {OPERATIONAL_PG_ALIAS}.app.dataset_versions v
             ON v.dataset_version_id = o.active_dataset_version_id
-        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d
+        JOIN {OPERATIONAL_PG_ALIAS}.app.datasets d
             ON d.dataset_id = v.dataset_id
         WHERE o.slug = ?
         """,
@@ -191,7 +191,7 @@ def load_manifest(
     row = conn.execute(
         f"""
         SELECT manifest
-        FROM {OPERATIONAL_PG_ALIAS}.public.dataset_versions
+        FROM {OPERATIONAL_PG_ALIAS}.app.dataset_versions
         WHERE dataset_version_id = ?
         """,
         [dataset_version_id],
@@ -214,8 +214,8 @@ def version_id_for_schema(
     row = conn.execute(
         f"""
         SELECT v.dataset_version_id
-        FROM {OPERATIONAL_PG_ALIAS}.public.dataset_versions v
-        JOIN {OPERATIONAL_PG_ALIAS}.public.datasets d ON d.dataset_id = v.dataset_id
+        FROM {OPERATIONAL_PG_ALIAS}.app.dataset_versions v
+        JOIN {OPERATIONAL_PG_ALIAS}.app.datasets d ON d.dataset_id = v.dataset_id
         WHERE d.slug || '_v' || v.version_number = ?
         """,
         [schema],
@@ -254,7 +254,7 @@ def finalize_version(
     derived_literal = json.dumps(derived_metadata).replace("'", "''")
     conn.execute(
         f"CALL postgres_execute('{OPERATIONAL_PG_ALIAS}', $ft$"
-        f"UPDATE public.dataset_versions "
+        f"UPDATE app.dataset_versions "
         f"SET manifest = '{manifest_literal}'::jsonb, "
         f"derived_metadata = '{derived_literal}'::jsonb, status = 'ready' "
         f"WHERE dataset_version_id = '{dataset_version_id}'"

--- a/apps/web/src/rpc/web/progress.ts
+++ b/apps/web/src/rpc/web/progress.ts
@@ -34,9 +34,9 @@ export const forOrg = pub
         SELECT DISTINCT ON (e.turf_id, e.person_id)
           e.turf_id,
           e.payload->>'outcome' AS outcome
-        FROM canvass_events e
-        JOIN turfs t ON t.turf_id = e.turf_id
-        JOIN campaigns c ON c.campaign_id = t.campaign_id
+        FROM app.canvass_events e
+        JOIN app.turfs t ON t.turf_id = e.turf_id
+        JOIN app.campaigns c ON c.campaign_id = t.campaign_id
         WHERE e.kind = 'result'
           AND e.person_id IS NOT NULL
           AND c.organization_id = ${context.organizationId}

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -51,8 +51,8 @@ services:
       <<: *quickwit-env
       QUICKWIT_URL: http://quickwit:7280
       DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/turf_tools
-      DUCKLAKE_METADATA_POSTGRES_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/turf_tools_ducklake_catalog
-      DUCKLAKE_GEO_METADATA_POSTGRES_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/turf_tools_ducklake_geo_catalog
+      DUCKLAKE_METADATA_POSTGRES_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/turf_tools_ducklake
+      DUCKLAKE_GEO_METADATA_POSTGRES_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/turf_tools_ducklake_geo
       # Layout inside the deployment's single bucket — not a per-deployment
       # choice, so it lives here rather than in the env file. Quickwit's prefix
       # is in QW_DEFAULT_INDEX_ROOT_URI above.

--- a/deploy/postgres-init.sql
+++ b/deploy/postgres-init.sql
@@ -1,5 +1,5 @@
 -- Runs once, on first initialisation of an empty data directory.
 -- POSTGRES_DB creates turf_tools; the rest are created here.
-CREATE DATABASE turf_tools_ducklake_catalog;
-CREATE DATABASE turf_tools_ducklake_geo_catalog;
+CREATE DATABASE turf_tools_ducklake;
+CREATE DATABASE turf_tools_ducklake_geo;
 CREATE DATABASE quickwit;

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -16,9 +16,9 @@ export default defineConfig({
   casing: "snake_case",
   dialect: "postgresql",
   dbCredentials: { url },
-  // Manage only the app's `public` schema. In dev, DuckLake's metadata catalog
-  // shares this Postgres in the `ducklake`/`ducklake_geo` schemas — without this
-  // filter, `drizzle-kit push` would see those tables as foreign and offer to
-  // drop them, corrupting the lake.
-  schemaFilter: ["public"],
+  // Manage only the app's `operational` schema. In dev, DuckLake's metadata
+  // catalogs share this Postgres in the `catalog`/`catalog_geo` schemas —
+  // without this filter, `drizzle-kit push` would see those tables as foreign
+  // and offer to drop them, corrupting the lake.
+  schemaFilter: ["app"],
 });

--- a/packages/db/src/schema/app.ts
+++ b/packages/db/src/schema/app.ts
@@ -1,0 +1,6 @@
+import { pgSchema } from "drizzle-orm/pg-core";
+
+// All application tables live in the `app` schema, never `public` — the
+// operational store's namespace, alongside the DuckLake catalogs'
+// `catalog`/`catalog_geo` schemas.
+export const app = pgSchema("app");

--- a/packages/db/src/schema/auth/accounts.ts
+++ b/packages/db/src/schema/auth/accounts.ts
@@ -1,10 +1,11 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "../app";
 import { users } from "./users";
 
 // Better Auth account row. `accountId` here is BA's provider-account-id
 // field — distinct from the row PK, which is `id`.
 
-export const accounts = pgTable("accounts", {
+export const accounts = app.table("accounts", {
   id: uuid().defaultRandom().primaryKey(),
   userId: uuid()
     .notNull()

--- a/packages/db/src/schema/auth/sessions.ts
+++ b/packages/db/src/schema/auth/sessions.ts
@@ -1,10 +1,11 @@
-import { pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { app } from "../app";
 import { users } from "./users";
 
 // Better Auth session row. Cookie holds the opaque `token`; server looks up
 // the session per request.
 
-export const sessions = pgTable(
+export const sessions = app.table(
   "sessions",
   {
     id: uuid().defaultRandom().primaryKey(),

--- a/packages/db/src/schema/auth/users.ts
+++ b/packages/db/src/schema/auth/users.ts
@@ -1,10 +1,11 @@
-import { boolean, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { boolean, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { app } from "../app";
 
 // Better Auth managed. The PK property must be `id` because BA's drizzle
 // introspection hard-codes that name — all four tables in `schema/auth/`
 // follow this constraint. Elsewhere in the schema we use `<table>Id`.
 
-export const users = pgTable(
+export const users = app.table(
   "users",
   {
     id: uuid().defaultRandom().primaryKey(),

--- a/packages/db/src/schema/auth/verifications.ts
+++ b/packages/db/src/schema/auth/verifications.ts
@@ -1,9 +1,10 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "../app";
 
 // Better Auth verification row. Magic-link tokens land here and get consumed
 // on click.
 
-export const verifications = pgTable("verifications", {
+export const verifications = app.table("verifications", {
   id: uuid().defaultRandom().primaryKey(),
   identifier: text().notNull(),
   value: text().notNull(),

--- a/packages/db/src/schema/campaigns.ts
+++ b/packages/db/src/schema/campaigns.ts
@@ -1,4 +1,5 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { datasets } from "./datasets";
 import { organizations } from "./organizations";
 import { scripts } from "./scripts";
@@ -11,7 +12,7 @@ import { zoneGroups } from "./zone-groups";
 // the campaign's zones. The three FKs are nullable because a campaign can
 // be saved as a draft before all the pieces are picked; an "active"
 // campaign should have all three set (enforced at the app level).
-export const campaigns = pgTable("campaigns", {
+export const campaigns = app.table("campaigns", {
   campaignId: uuid().defaultRandom().primaryKey(),
   organizationId: uuid()
     .notNull()

--- a/packages/db/src/schema/canvass-events.ts
+++ b/packages/db/src/schema/canvass-events.ts
@@ -1,13 +1,13 @@
 import {
   bigserial,
   jsonb,
-  pgTable,
   primaryKey,
   text,
   timestamp,
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { turfs } from "./turfs";
 
 // Append-only event log for canvass results. Two kinds:
@@ -29,7 +29,7 @@ import { turfs } from "./turfs";
 // sequence. canvasserId is the universal canvasser identity (no FK — it
 // references the future central identity system); null until that ships.
 
-export const canvassEvents = pgTable(
+export const canvassEvents = app.table(
   "canvass_events",
   {
     sequence: bigserial({ mode: "number" }).notNull(),

--- a/packages/db/src/schema/custom-fields.ts
+++ b/packages/db/src/schema/custom-fields.ts
@@ -1,4 +1,5 @@
-import { integer, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { integer, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { users } from "./auth/users";
 import { datasets } from "./datasets";
 
@@ -13,7 +14,7 @@ export type CustomFieldType = "number" | "date" | "text" | "enum";
 // long-format `<slug>_custom_fields` table.
 // Criteria reference `customFieldId` (never the label), so rename is a
 // one-row UPDATE with no lake or saved-segment fallout.
-export const customFields = pgTable(
+export const customFields = app.table(
   "custom_fields",
   {
     customFieldId: uuid().defaultRandom().primaryKey(),
@@ -38,7 +39,7 @@ export const customFields = pgTable(
 // Provenance for one append — inserted after the synchronous ingest succeeds
 // (failed appends write nothing). Audit-only: nothing renders it today, but
 // lake values carry `upload_id` so every value traces back here.
-export const customFieldUploads = pgTable("custom_field_uploads", {
+export const customFieldUploads = app.table("custom_field_uploads", {
   customFieldUploadId: uuid().defaultRandom().primaryKey(),
   datasetId: uuid()
     .notNull()

--- a/packages/db/src/schema/dataset-organizations.ts
+++ b/packages/db/src/schema/dataset-organizations.ts
@@ -1,4 +1,5 @@
-import { pgTable, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { datasets } from "./datasets";
 import { organizations } from "./organizations";
 
@@ -7,7 +8,7 @@ import { organizations } from "./organizations";
 // (`organizations.activeDatasetVersionId`), so shared orgs activate independently.
 // Lives in its own file (like `memberships`) so `datasets` needn't import
 // `organizations`, keeping the two entity modules free of an import cycle.
-export const datasetOrganizations = pgTable(
+export const datasetOrganizations = app.table(
   "dataset_organizations",
   {
     datasetOrganizationId: uuid().defaultRandom().primaryKey(),

--- a/packages/db/src/schema/datasets.ts
+++ b/packages/db/src/schema/datasets.ts
@@ -1,4 +1,5 @@
-import { integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { integer, jsonb, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { users } from "./auth/users";
 
 // A dataset is a deployment-level source of canvassable persons (a state voter
@@ -7,7 +8,7 @@ import { users } from "./auth/users";
 // deployment (upload once, update once → all referencing orgs move together).
 // Data lives once per version, each version in its own DuckLake schema
 // (`ducklake.<slug>_v<versionNumber>`).
-export const datasets = pgTable(
+export const datasets = app.table(
   "datasets",
   {
     datasetId: uuid().defaultRandom().primaryKey(),
@@ -43,7 +44,7 @@ export type DerivedMetadata = {
 // reference (a published turf, a canvass event) always resolves. Its data lives
 // in the DuckLake schema `${dataset.slug}_v${versionNumber}`. `manifest` is the
 // field catalog (what's filterable/zonable — the serialized importer Manifest).
-export const datasetVersions = pgTable(
+export const datasetVersions = app.table(
   "dataset_versions",
   {
     datasetVersionId: uuid().defaultRandom().primaryKey(),

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,3 +1,4 @@
+export * from "./app";
 export * from "./organizations";
 export * from "./auth/users";
 export * from "./auth/sessions";

--- a/packages/db/src/schema/jobs.ts
+++ b/packages/db/src/schema/jobs.ts
@@ -1,13 +1,5 @@
-import {
-  bigserial,
-  json,
-  jsonb,
-  pgTable,
-  primaryKey,
-  text,
-  timestamp,
-  uuid,
-} from "drizzle-orm/pg-core";
+import { bigserial, json, jsonb, primaryKey, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 
 export const JOB_STATUSES = [
   "unstarted",
@@ -19,11 +11,11 @@ export const JOB_STATUSES = [
 
 export type JobStatus = (typeof JOB_STATUSES)[number];
 
-export const jobStatus = pgTable("job_status", {
+export const jobStatus = app.table("job_status", {
   status: text().primaryKey().$type<JobStatus>(),
 });
 
-export const jobs = pgTable("jobs", {
+export const jobs = app.table("jobs", {
   jobId: uuid().defaultRandom().primaryKey(),
   createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
   status: text()
@@ -39,7 +31,7 @@ export const jobs = pgTable("jobs", {
   lockedByWorkerId: text(),
 });
 
-export const jobMessages = pgTable(
+export const jobMessages = app.table(
   "job_messages",
   {
     jobId: uuid()

--- a/packages/db/src/schema/memberships.ts
+++ b/packages/db/src/schema/memberships.ts
@@ -1,11 +1,12 @@
-import { pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { organizations } from "./organizations";
 import { users } from "./auth/users";
 
 // One row per (user, org) pair. `role` is a free-form text value enforced in
 // application code.
 
-export const memberships = pgTable(
+export const memberships = app.table(
   "memberships",
   {
     membershipId: uuid().defaultRandom().primaryKey(),

--- a/packages/db/src/schema/organizations.ts
+++ b/packages/db/src/schema/organizations.ts
@@ -1,8 +1,9 @@
 import { sql } from "drizzle-orm";
-import { check, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { check, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { datasetVersions } from "./datasets";
 
-export const organizations = pgTable(
+export const organizations = app.table(
   "organizations",
   {
     organizationId: uuid().defaultRandom().primaryKey(),

--- a/packages/db/src/schema/questions.ts
+++ b/packages/db/src/schema/questions.ts
@@ -1,11 +1,12 @@
-import { integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { integer, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { organizations } from "./organizations";
 import { users } from "./auth/users";
 
 // A question is a named question with text and a response type.
 // Standalone and org-level; referenced by script steps and reusable
 // across scripts.
-export const questions = pgTable("questions", {
+export const questions = app.table("questions", {
   questionId: uuid().defaultRandom().primaryKey(),
   organizationId: uuid()
     .notNull()
@@ -21,7 +22,7 @@ export const questions = pgTable("questions", {
 });
 
 // One selectable answer for a question. Order is per-question.
-export const responseOptions = pgTable("response_options", {
+export const responseOptions = app.table("response_options", {
   responseOptionId: uuid().defaultRandom().primaryKey(),
   questionId: uuid()
     .notNull()

--- a/packages/db/src/schema/scripts.ts
+++ b/packages/db/src/schema/scripts.ts
@@ -1,4 +1,5 @@
-import { integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { integer, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { organizations } from "./organizations";
 import { questions } from "./questions";
 import { users } from "./auth/users";
@@ -6,7 +7,7 @@ import { users } from "./auth/users";
 // A script is an ordered sequence of steps presented to canvassers at the
 // door. Standalone and reusable across campaigns; each campaign references
 // one script.
-export const scripts = pgTable("scripts", {
+export const scripts = app.table("scripts", {
   scriptId: uuid().defaultRandom().primaryKey(),
   organizationId: uuid()
     .notNull()
@@ -21,7 +22,7 @@ export const scripts = pgTable("scripts", {
 // A step is either stepType='question' (referencing a reusable
 // question) or stepType='text' (carrying its copy inline). Type/payload
 // consistency is enforced at the RPC layer.
-export const scriptSteps = pgTable("script_steps", {
+export const scriptSteps = app.table("script_steps", {
   scriptStepId: uuid().defaultRandom().primaryKey(),
   scriptId: uuid()
     .notNull()

--- a/packages/db/src/schema/segments.ts
+++ b/packages/db/src/schema/segments.ts
@@ -1,4 +1,5 @@
-import { integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { integer, jsonb, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { datasets } from "./datasets";
 import { organizations } from "./organizations";
 import { users } from "./auth/users";
@@ -6,7 +7,7 @@ import { users } from "./auth/users";
 // A segment is a targeting set defined by criteria over a dataset's persons —
 // e.g., "Swing Voters", "Base Voters", "Bushwick North". Standalone and
 // reusable across campaigns.
-export const segments = pgTable("segments", {
+export const segments = app.table("segments", {
   segmentId: uuid().defaultRandom().primaryKey(),
   organizationId: uuid()
     .notNull()

--- a/packages/db/src/schema/turf-data.ts
+++ b/packages/db/src/schema/turf-data.ts
@@ -1,4 +1,5 @@
-import { jsonb, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+import { jsonb, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { type GeoJsonPolygon, turfs } from "./turfs";
 
 // Per-turf payload — the buildings → doors → persons hierarchy a
@@ -10,7 +11,7 @@ import { type GeoJsonPolygon, turfs } from "./turfs";
 //
 // Cascade on turf delete — if the parent row is gone, the blob is
 // orphaned data.
-export const turfData = pgTable("turf_data", {
+export const turfData = app.table("turf_data", {
   turfId: uuid()
     .primaryKey()
     .references(() => turfs.turfId, { onDelete: "cascade" }),

--- a/packages/db/src/schema/turf-drafts.ts
+++ b/packages/db/src/schema/turf-drafts.ts
@@ -1,4 +1,5 @@
-import { index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { index, integer, jsonb, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { campaigns } from "./campaigns";
 import type { GeoJsonPolygon } from "./turfs";
 
@@ -21,7 +22,7 @@ import type { GeoJsonPolygon } from "./turfs";
 //
 // `zoneId` is nullable so the cutter can produce drafts on campaigns
 // without a zone group (scope = whole segment).
-export const turfDrafts = pgTable(
+export const turfDrafts = app.table(
   "turf_drafts",
   {
     turfDraftId: uuid().primaryKey(),

--- a/packages/db/src/schema/turfs.ts
+++ b/packages/db/src/schema/turfs.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
-import { integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { integer, jsonb, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { campaigns } from "./campaigns";
 import { datasetVersions } from "./datasets";
 import { scripts } from "./scripts";
@@ -26,7 +27,7 @@ import { users } from "./auth/users";
 // reusing them).
 export type TurfStatus = "active" | "archived";
 
-export const turfs = pgTable(
+export const turfs = app.table(
   "turfs",
   {
     turfId: uuid().defaultRandom().primaryKey(),

--- a/packages/db/src/schema/walks.ts
+++ b/packages/db/src/schema/walks.ts
@@ -1,4 +1,5 @@
-import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { index, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { sql } from "drizzle-orm";
 import { turfs } from "./turfs";
 
@@ -17,7 +18,7 @@ import { turfs } from "./turfs";
 // Attribution is the client-claimed identity, same as `canvass_events` —
 // stored verbatim, no FK.
 
-export const walks = pgTable(
+export const walks = app.table(
   "walks",
   {
     walkId: uuid().defaultRandom().primaryKey(),

--- a/packages/db/src/schema/zone-groups.ts
+++ b/packages/db/src/schema/zone-groups.ts
@@ -1,4 +1,5 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { datasets } from "./datasets";
 import { organizations } from "./organizations";
 import { users } from "./auth/users";
@@ -11,7 +12,7 @@ import { users } from "./auth/users";
 // Most orgs will only ever have one zone group. The abstraction exists for
 // the rare case where an org needs more than one zoning (different key
 // types, or alternative partitions for different campaigns).
-export const zoneGroups = pgTable("zone_groups", {
+export const zoneGroups = app.table("zone_groups", {
   zoneGroupId: uuid().defaultRandom().primaryKey(),
   organizationId: uuid()
     .notNull()

--- a/packages/db/src/schema/zones.ts
+++ b/packages/db/src/schema/zones.ts
@@ -1,4 +1,5 @@
-import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { jsonb, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { app } from "./app";
 import { users } from "./auth/users";
 import { zoneGroups } from "./zone-groups";
 
@@ -7,7 +8,7 @@ import { zoneGroups } from "./zone-groups";
 // `zone_groups.keyGroup` — every zone in a group shares the same unit type.
 // Polygons and counts are derived server-side from `keys`; this table only
 // stores the selection.
-export const zones = pgTable("zones", {
+export const zones = app.table("zones", {
   zoneId: uuid().defaultRandom().primaryKey(),
   zoneGroupId: uuid()
     .notNull()

--- a/scripts/prod-reset.ts
+++ b/scripts/prod-reset.ts
@@ -3,7 +3,7 @@ import { createLogger, run } from "./_logging";
 const log = createLogger("reset");
 
 const DATA_ENV = "/etc/turf-tools-data.env";
-const DBS = ["turf_tools", "turf_tools_ducklake_catalog", "turf_tools_ducklake_geo_catalog"];
+const DBS = ["turf_tools", "turf_tools_ducklake", "turf_tools_ducklake_geo"];
 
 log.task("stopping services");
 run(log, "sudo systemctl stop turf-tools-web turf-tools-data");


### PR DESCRIPTION
Purely mechanical refactor to stop using `public` as the schema and instead use `turf_tools.app` for the operational database and `turf_tools_ducklake.catalog` and `turf_tools_ducklake_geo.catalog_geo` for ducklake.