### PR TITLE
feat: better import error handling

### DIFF
--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -13,7 +13,6 @@ from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 from starlette.background import BackgroundTask
 
-import src.import_job  # noqa: F401 — registers the `import_dataset_version` job with the worker
 from src.custom_fields import (
     append_custom_fields,
     catalog_for,
@@ -32,6 +31,7 @@ from src.duckdb import (
     refresh_s3_secret_on_shared_connection,
     s3_secret_expires,
 )
+from src.import_job import fail_interrupted_versions, import_dataset_version
 from src.job_runner import JobManager
 from src.publish_turfs import PublishTurfsRequest, publish_turfs
 from src.quickwit import build_person_query, persons_index_id
@@ -127,7 +127,10 @@ async def lifespan(app: FastAPI):
 
     await get_pool()
 
-    job_manager_task = asyncio.create_task(JobManager().run_forever(), name="job-manager")
+    job_manager_task = asyncio.create_task(
+        JobManager(jobs=(import_dataset_version,), sweeps=(fail_interrupted_versions,)).run_forever(),
+        name="job-manager",
+    )
     job_manager_task.add_done_callback(_log_background_task_failure)
 
     # Only the AWS credential chain expires; static keys need no timer.

--- a/apps/data/src/import_job.py
+++ b/apps/data/src/import_job.py
@@ -23,10 +23,10 @@ from src.derived import compute_derived_metadata
 from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres, get_connection
 from src.import_progress import ImportProgress, JobLog, ProgressNodeHook
 from src.importers.registry import get_importer
-from src.job_runner import JobContext, job
+from src.job_runner import IN_PROGRESS, INTERRUPTED_REASON, UNSTARTED, JobContext, job
 from src.quickwit import ensure_index, persons_index_id
 from src.settings import get_settings
-from src.tables import dataset_version_schema, ensure_schema, finalize_version
+from src.tables import dataset_version_schema, drop_schema, ensure_schema, finalize_version
 
 if TYPE_CHECKING:
     import duckdb
@@ -41,6 +41,41 @@ class ImportDatasetVersionPayload(BaseModel):
     organization_id: str
 
 
+async def _mark_version_failed(dataset_version_id: str, error: str) -> None:
+    """Surface a failure in the UI. Pure Postgres, so it works even when the
+    DuckLake attach is what failed. Guarded on `importing` so a late write can't
+    clobber a version that already finished."""
+    await postgres.execute(
+        "UPDATE app.dataset_versions SET status = 'failed', error = left($2, 1000) "
+        "WHERE dataset_version_id = $1::uuid AND status = 'importing'",
+        dataset_version_id,
+        error,
+    )
+
+
+async def fail_interrupted_versions() -> None:
+    """Maintenance sweep: fail versions stuck `importing` with no live import
+    job. When a worker dies mid-import the reaper fails the job row, but only
+    this moves the version off `importing` — and a version that looks in-flight
+    blocks further imports on its dataset. Guarding on "no live job" is what
+    makes every re-run safe: a retried import has a fresh job and is skipped."""
+    await postgres.execute(
+        """
+        UPDATE app.dataset_versions
+        SET status = 'failed', error = $1
+        WHERE status = 'importing'
+          AND NOT EXISTS (
+              SELECT 1 FROM app.jobs
+              WHERE task = 'import_dataset_version'
+                AND payload->>'dataset_version_id' = dataset_versions.dataset_version_id::text
+                AND status = ANY($2::text[])
+          )
+        """,
+        INTERRUPTED_REASON,
+        [UNSTARTED, IN_PROGRESS],
+    )
+
+
 @job(task="import_dataset_version")
 async def import_dataset_version(payload: ImportDatasetVersionPayload, ctx: JobContext) -> dict[str, Any]:
     await ctx.message("Import started", dataset_version_id=payload.dataset_version_id)
@@ -49,15 +84,9 @@ async def import_dataset_version(payload: ImportDatasetVersionPayload, ctx: JobC
         # so the worker keeps serving other jobs / the s3-secret refresh.
         result = await asyncio.to_thread(_run, payload, str(ctx.job_id))
     except Exception as exc:
-        # Surface the failure in the UI — mark the version `failed` and stash the
-        # reason (pure Postgres, so it works even when the DuckLake attach is what
-        # failed). Then re-raise so the job framework records it on the job row.
-        await postgres.execute(
-            "UPDATE app.dataset_versions SET status = 'failed', error = left($2, 1000) "
-            "WHERE dataset_version_id = $1::uuid",
-            payload.dataset_version_id,
-            str(exc),
-        )
+        # Mark the version failed, then re-raise so the job framework records it
+        # on the job row too.
+        await _mark_version_failed(payload.dataset_version_id, str(exc))
         raise
     await ctx.message("Import complete", **result)
     return result
@@ -81,6 +110,10 @@ def _run(payload: ImportDatasetVersionPayload, job_id: str) -> dict[str, Any]:
         slug, version_number, importer_name = _resolve_version(conn, settings, payload.dataset_version_id)
         log = JobLog(conn, job_id)
         schema = dataset_version_schema(slug, version_number)
+        # A retried import reuses its version number, so the schema may still hold
+        # whatever the failed attempt wrote. Nothing reads a version that isn't
+        # `ready`, so starting empty is always safe.
+        drop_schema(conn, schema)
         ensure_schema(conn, schema)
 
         importer = get_importer(importer_name)()

--- a/apps/data/src/importers/base.py
+++ b/apps/data/src/importers/base.py
@@ -16,6 +16,7 @@ field is free manifest data; adding a kind is the expensive cross-language chang
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Protocol
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.alias_generators import to_camel
@@ -128,6 +129,34 @@ class Progress(Protocol):
     plus the DAG's node count."""
 
     def advance(self, n: int = 1) -> None: ...
+
+
+def redact_source(source: str) -> str:
+    """A source safe to put in an error message: scheme, host, and path only.
+
+    Presigned URLs carry their signature in the query string and some URIs embed
+    `user:secret@`, so the raw string is a credential. The host and path are what
+    identify the file (and catch a typo), and neither is secret.
+    """
+    parts = urlsplit(source)
+    if not parts.scheme:
+        return source  # local path — nothing to strip
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, parts.path, "", ""))
+
+
+class SourceUnreadableError(RuntimeError):
+    """The import source couldn't be read.
+
+    Raised by `load` instead of letting the driver's error through: this message
+    lands verbatim in `dataset_versions.error` and is what the admin reads in the
+    UI, so it says what to check. DuckDB's own text for a missing remote file
+    ("HTTP 0 Internal Server Error") is both noise and misleading — raise `from`
+    the original so the chain still reaches the job log. Build the message with
+    `redact_source`; never interpolate a raw source.
+    """
 
 
 class Importer(Protocol):

--- a/apps/data/src/importers/nys_voter_file/importer.py
+++ b/apps/data/src/importers/nys_voter_file/importer.py
@@ -14,6 +14,8 @@ import json
 import os
 from typing import TYPE_CHECKING
 
+import duckdb
+from src.importers.base import SourceUnreadableError, redact_source
 from src.importers.nys_voter_file.decode import decode_txt_to_table
 from src.importers.nys_voter_file.manifest import NYS_MANIFEST
 from src.importers.nys_voter_file.transform import nys_sboe_transformation_query
@@ -22,7 +24,6 @@ from src.models import Person, TableRef
 from src.tables import PERSON_CATALOG, ensure_schema, table_fqn
 
 if TYPE_CHECKING:
-    import duckdb
     from src.importers.base import Manifest, Progress
 
 _EXPECTED_COLUMNS = set(Person.model_fields.keys())
@@ -75,7 +76,7 @@ class NysVoterFileImporter:
         # `read_csv` blocks forever. Fail fast instead. (`://` = object-storage key.)
         source = os.path.expanduser(source)
         if "://" not in source and not os.path.exists(source):
-            raise FileNotFoundError(f"Import source not found: {source!r}")
+            raise SourceUnreadableError(f"Import source not found: {redact_source(source)!r}")
         ensure_schema(conn, schema)
         raw_fqn = table_fqn(schema, "persons_raw")
         transformed_fqn = table_fqn(schema, "persons_transformed")
@@ -83,11 +84,18 @@ class NysVoterFileImporter:
 
         # 1. Source → persons_raw. Raw `.txt` gets the fixed-width decode; an
         #    already-tabular parquet/CSV loads directly.
-        if source.lower().endswith(".txt"):
-            decode_txt_to_table(source, raw_fqn, conn)
-        else:
-            conn.execute(f"DROP TABLE IF EXISTS {raw_fqn}")
-            conn.read_parquet(source).create(raw_fqn)
+        #    A remote source can't be checked up front the way a local path can,
+        #    so this is where a bad URL surfaces.
+        try:
+            if source.lower().endswith(".txt"):
+                decode_txt_to_table(source, raw_fqn, conn)
+            else:
+                conn.execute(f"DROP TABLE IF EXISTS {raw_fqn}")
+                conn.read_parquet(source).create(raw_fqn)
+        except (duckdb.Error, OSError) as exc:
+            raise SourceUnreadableError(
+                f"Could not read the import source {redact_source(source)!r}. Check that it exists and is reachable."
+            ) from exc
         progress.advance()
 
         # 2. Transform to the canonical Person schema (raw NYS codes → canonical

--- a/apps/data/src/job_runner.py
+++ b/apps/data/src/job_runner.py
@@ -7,19 +7,36 @@ import inspect
 import json
 import traceback
 import uuid
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol, get_type_hints, overload
 
 from pydantic import BaseModel, ValidationError
 
 type JobFunc = Callable[..., Any]
+# A periodic maintenance pass, run by every worker on each maintenance tick,
+# after reaping. Must be idempotent: it re-runs forever, which is what makes it
+# the reliable cleanup path for interrupted jobs — a pass that fails is simply
+# retried on the next tick.
+type Sweep = Callable[[], Awaitable[None]]
 PayloadModel = type[BaseModel]
 
 UNSTARTED = "unstarted"
 IN_PROGRESS = "in_progress"
 COMPLETED = "completed"
 PERMANENTLY_FAILED = "permanently_failed"
+
+# How often a worker stamps `heartbeat_at` on the jobs it holds, and how long a
+# job may go unstamped before another poll reaps it. The heartbeat runs on the
+# event loop while handlers do their blocking work in threads, so a long step is
+# still a live heartbeat — staleness means the process is gone, not slow. Six
+# missed beats keeps a briefly-stalled loop from reaping its own live work.
+HEARTBEAT_INTERVAL_SECONDS = 15.0
+LEASE_SECONDS = 90.0
+
+INTERRUPTED_REASON = (
+    "Interrupted: the worker stopped without reporting a result (restart, deploy, or out-of-memory kill)."
+)
 
 
 @dataclass(frozen=True)
@@ -30,6 +47,15 @@ class ClaimedJob:
     task: str
     payload: Mapping[str, Any]
     concurrency_key: str | None
+
+
+@dataclass(frozen=True)
+class ReapedJob:
+    """A job failed by the reaper after its lease expired."""
+
+    job_id: uuid.UUID
+    task: str
+    payload: Mapping[str, Any]
 
 
 class JobStore(Protocol):
@@ -47,38 +73,21 @@ class JobStore(Protocol):
 
     async def fail_job(self, *, job_id: uuid.UUID, failure_reason: str) -> None: ...
 
+    async def heartbeat(self, *, worker_id: str, job_ids: Iterable[uuid.UUID]) -> None: ...
+
+    async def reap_expired_jobs(self, *, lease_seconds: float) -> list[ReapedJob]: ...
+
     async def write_message(self, *, job_id: uuid.UUID, payload: Mapping[str, Any]) -> None: ...
 
 
 @dataclass(frozen=True)
 class RegisteredJob:
-    """A decorated job function and the model used to validate its payload."""
+    """A job function and the model used to validate its payload. Built by the
+    `job` decorator and handed to `JobManager(jobs=...)`."""
 
     task: str
     func: JobFunc
     payload_model: PayloadModel
-
-
-class JobRegistry:
-    """Registry populated by the `job` decorator."""
-
-    def __init__(self) -> None:
-        self._jobs: dict[str, RegisteredJob] = {}
-
-    def register(self, registered_job: RegisteredJob) -> None:
-        self._jobs[registered_job.task] = registered_job
-
-    def get(self, task: str) -> RegisteredJob | None:
-        return self._jobs.get(task)
-
-    def tasks(self) -> list[str]:
-        return sorted(self._jobs)
-
-    def clear(self) -> None:
-        self._jobs.clear()
-
-
-DEFAULT_REGISTRY = JobRegistry()
 
 
 class JobContext:
@@ -105,35 +114,36 @@ class JobContext:
 
 
 @overload
-def job[TJobFunc: JobFunc](func: TJobFunc, /) -> TJobFunc: ...
+def job(func: JobFunc, /) -> RegisteredJob: ...
 
 
 @overload
-def job[TJobFunc: JobFunc](
+def job(
     func: None = None,
     /,
     *,
     task: str | None = None,
     payload_model: PayloadModel | None = None,
-    registry: JobRegistry = DEFAULT_REGISTRY,
-) -> Callable[[TJobFunc], TJobFunc]: ...
+) -> Callable[[JobFunc], RegisteredJob]: ...
 
 
-def job[TJobFunc: JobFunc](
-    func: TJobFunc | None = None,
+def job(
+    func: JobFunc | None = None,
     /,
     *,
     task: str | None = None,
     payload_model: PayloadModel | None = None,
-    registry: JobRegistry = DEFAULT_REGISTRY,
-) -> TJobFunc | Callable[[TJobFunc], TJobFunc]:
-    """Register a function as a runnable job."""
+) -> RegisteredJob | Callable[[JobFunc], RegisteredJob]:
+    """Package a function as a runnable job. Nothing registers globally — a job
+    runs only if the returned `RegisteredJob` is handed to `JobManager(jobs=...)`,
+    so the wiring in `main.py` is the complete list of what the worker runs."""
 
-    def decorator(inner: TJobFunc) -> TJobFunc:
-        registered_task = task or inner.__name__
-        registered_model = payload_model or _infer_payload_model(inner)
-        registry.register(RegisteredJob(task=registered_task, func=inner, payload_model=registered_model))
-        return inner
+    def decorator(inner: JobFunc) -> RegisteredJob:
+        return RegisteredJob(
+            task=task or inner.__name__,
+            func=inner,
+            payload_model=payload_model or _infer_payload_model(inner),
+        )
 
     if func is None:
         return decorator
@@ -147,23 +157,30 @@ class JobManager:
     def __init__(
         self,
         *,
-        registry: JobRegistry = DEFAULT_REGISTRY,
+        jobs: Iterable[RegisteredJob] = (),
         store: JobStore | None = None,
         worker_id: str | None = None,
         max_concurrent_jobs: int = 1,
         poll_interval_seconds: float = 1.0,
+        heartbeat_interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS,
+        lease_seconds: float = LEASE_SECONDS,
+        sweeps: Iterable[Sweep] = (),
     ) -> None:
         if max_concurrent_jobs < 1:
             raise ValueError("max_concurrent_jobs must be at least 1")
 
-        self.registry = registry
+        self._jobs = {registered_job.task: registered_job for registered_job in jobs}
         self.store = store or PostgresJobStore()
         self.worker_id = worker_id or f"data-job-runner-{uuid.uuid4()}"
         self.max_concurrent_jobs = max_concurrent_jobs
         self.poll_interval_seconds = poll_interval_seconds
+        self.heartbeat_interval_seconds = heartbeat_interval_seconds
+        self.lease_seconds = lease_seconds
+        self.sweeps = tuple(sweeps)
+        self._in_flight: set[uuid.UUID] = set()
 
     async def run_once(self) -> int:
-        tasks = self.registry.tasks()
+        tasks = sorted(self._jobs)
         if not tasks:
             return 0
 
@@ -186,24 +203,75 @@ class JobManager:
         logging the first of each consecutive run so a persistent outage doesn't
         flood the log at the poll interval.
         """
-        consecutive_failures = 0
+        # Separate task: `run_once` awaits its handlers, so the poll loop is
+        # blocked for the whole of a long import and can't beat or reap from here.
+        maintenance = asyncio.create_task(self.maintain_forever(), name="job-maintenance")
+        try:
+            consecutive_failures = 0
+            while True:
+                try:
+                    handled = await self.run_once()
+                    consecutive_failures = 0
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001 — any failure is retryable
+                    if consecutive_failures == 0:
+                        print(f"WARNING: job poll failed, retrying: {exc}", flush=True)
+                    consecutive_failures += 1
+                    await asyncio.sleep(min(self.poll_interval_seconds * consecutive_failures, 30.0))
+                    continue
+                if handled == 0:
+                    await asyncio.sleep(self.poll_interval_seconds)
+        finally:
+            maintenance.cancel()
+
+    async def maintain_forever(self) -> None:
+        """Stamp this worker's live jobs, fail everyone's expired ones, and run
+        the sweeps.
+
+        Every worker reaps, not just the one that owned the job — the owner of an
+        expired lease is by definition not around to do it.
+        """
         while True:
+            await asyncio.sleep(self.heartbeat_interval_seconds)
             try:
-                handled = await self.run_once()
-                consecutive_failures = 0
+                await self.maintain_once()
             except asyncio.CancelledError:
                 raise
-            except Exception as exc:  # noqa: BLE001 — any failure is retryable
-                if consecutive_failures == 0:
-                    print(f"WARNING: job poll failed, retrying: {exc}", flush=True)
-                consecutive_failures += 1
-                await asyncio.sleep(min(self.poll_interval_seconds * consecutive_failures, 30.0))
-                continue
-            if handled == 0:
-                await asyncio.sleep(self.poll_interval_seconds)
+            except Exception as exc:  # noqa: BLE001 — a bad tick must not end the loop
+                print(f"WARNING: job maintenance failed, retrying: {exc}", flush=True)
+
+    async def maintain_once(self) -> list[ReapedJob]:
+        if self._in_flight:
+            # Beat before reaping: on recovery from a shared Postgres outage this
+            # refreshes the worker's own lease before the reap query can see it
+            # as expired. Reordering these reintroduces self-reaping.
+            await self.store.heartbeat(worker_id=self.worker_id, job_ids=tuple(self._in_flight))
+
+        reaped_jobs = await self.store.reap_expired_jobs(lease_seconds=self.lease_seconds)
+        for reaped_job in reaped_jobs:
+            print(f"WARNING: reaped interrupted job {reaped_job.job_id} ({reaped_job.task})", flush=True)
+
+        # After reaping, so a just-reaped job's leftovers are cleaned this tick.
+        # A failed pass just waits for the next tick, but must not block the rest.
+        for sweep in self.sweeps:
+            try:
+                await sweep()
+            except Exception as exc:  # noqa: BLE001 — retried next tick
+                print(f"WARNING: maintenance sweep failed, will retry: {exc}", flush=True)
+
+        return reaped_jobs
 
     async def _run_claimed_job(self, claimed_job: ClaimedJob) -> None:
-        registered_job = self.registry.get(claimed_job.task)
+        # Held for the duration so the maintenance loop keeps its lease alive.
+        self._in_flight.add(claimed_job.job_id)
+        try:
+            await self._execute_claimed_job(claimed_job)
+        finally:
+            self._in_flight.discard(claimed_job.job_id)
+
+    async def _execute_claimed_job(self, claimed_job: ClaimedJob) -> None:
+        registered_job = self._jobs.get(claimed_job.task)
         if registered_job is None:
             await self.store.fail_job(
                 job_id=claimed_job.job_id,
@@ -301,7 +369,7 @@ class PostgresJobStore:
                 LIMIT $5
             )
             UPDATE app.jobs
-            SET status = $6, locked_by_worker_id = $7
+            SET status = $6, locked_by_worker_id = $7, heartbeat_at = now()
             WHERE job_id IN (SELECT job_id FROM eligible)
             RETURNING job_id, task, payload, concurrency_key
             """,
@@ -351,6 +419,57 @@ class PostgresJobStore:
             failure_reason,
             job_id,
         )
+
+    async def heartbeat(self, *, worker_id: str, job_ids: Iterable[uuid.UUID]) -> None:
+        from src.postgres import execute
+
+        ids = list(job_ids)
+        if not ids:
+            return
+
+        # Scoped to this worker so a job already reaped and re-claimed elsewhere
+        # can't have its lease revived by the process that lost it.
+        await execute(
+            """
+            UPDATE app.jobs
+            SET heartbeat_at = now()
+            WHERE job_id = ANY($1::uuid[])
+              AND status = $2
+              AND locked_by_worker_id = $3
+            """,
+            ids,
+            IN_PROGRESS,
+            worker_id,
+        )
+
+    async def reap_expired_jobs(self, *, lease_seconds: float) -> list[ReapedJob]:
+        from src.postgres import fetch
+
+        # `created_at` covers rows claimed before heartbeats existed, and any
+        # claimed by a worker too old to stamp them — both are stranded by
+        # definition, so an immediate reap is the right answer.
+        rows = await fetch(
+            """
+            UPDATE app.jobs
+            SET status = $1, failure_reason = $2, locked_by_worker_id = NULL
+            WHERE status = $3
+              AND coalesce(heartbeat_at, created_at) < now() - make_interval(secs => $4)
+            RETURNING job_id, task, payload
+            """,
+            PERMANENTLY_FAILED,
+            INTERRUPTED_REASON,
+            IN_PROGRESS,
+            lease_seconds,
+        )
+
+        return [
+            ReapedJob(
+                job_id=row["job_id"],
+                task=row["task"],
+                payload=_payload_from_db(row["payload"]),
+            )
+            for row in rows
+        ]
 
     async def write_message(self, *, job_id: uuid.UUID, payload: Mapping[str, Any]) -> None:
         from src.postgres import execute
@@ -429,8 +548,3 @@ def _truncate(value: str, *, max_length: int = 4000) -> str:
     if len(value) <= max_length:
         return value
     return f"{value[: max_length - 3]}..."
-
-
-def run() -> None:
-    """Run the default job manager forever."""
-    asyncio.run(JobManager().run_forever())

--- a/apps/data/tests/test_import_source.py
+++ b/apps/data/tests/test_import_source.py
@@ -1,0 +1,85 @@
+"""Source-read failures reach the admin as something actionable.
+
+`SourceUnreadableError`'s message lands verbatim in `dataset_versions.error` and
+is rendered in the UI, so these pin the two ways a bad source shows up: a local
+path that isn't there, and anything the driver refuses to read (a bad URL being
+the common case — exercised here with an unreadable file, since it fails in the
+same place without needing the network).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.importers.base import SourceUnreadableError, redact_source
+from src.importers.nys_voter_file import NysVoterFileImporter
+
+# A presigned URL and a credential-in-URI, the two shapes that make a raw source
+# string a secret.
+PRESIGNED = (
+    "https://bucket.example.com/scratch/voters.parquet"
+    "?X-Amz-Credential=AKIAEXAMPLE%2F20260802%2Fus-east-1&X-Amz-Signature=deadbeefcafe"
+)
+CREDENTIALED = "s3://AKIAEXAMPLE:sUp3rS3cr3t@bucket/scratch/voters.parquet"
+
+
+class _Progress:
+    def __init__(self) -> None:
+        self.steps = 0
+
+    def advance(self, n: int = 1) -> None:
+        self.steps += n
+
+
+def test_missing_local_source_fails_before_touching_the_catalog() -> None:
+    # No connection needed: the up-front check runs before any schema work,
+    # which is what stops the fixed-width decode deadlocking on a missing file.
+    with pytest.raises(SourceUnreadableError, match="Import source not found"):
+        NysVoterFileImporter().load("/nope/not-here.parquet", "irrelevant", None, _Progress())
+
+
+def test_unreadable_source_is_wrapped_rather_than_surfacing_driver_text(conn, tmp_path) -> None:
+    not_parquet = tmp_path / "voters.parquet"
+    not_parquet.write_text("this is not a parquet file", encoding="utf-8")
+
+    with pytest.raises(SourceUnreadableError) as excinfo:
+        NysVoterFileImporter().load(str(not_parquet), "nys_voter_file_v1", conn, _Progress())
+
+    message = str(excinfo.value)
+    assert str(not_parquet) in message
+    assert "Check that it exists and is reachable." in message
+    # The driver's own wording stays off the user-facing message but remains on
+    # the chain, so the job log keeps the real diagnosis.
+    assert excinfo.value.__cause__ is not None
+
+
+def test_redact_source_drops_presigned_query_but_keeps_the_file_identifiable() -> None:
+    redacted = redact_source(PRESIGNED)
+
+    assert redacted == "https://bucket.example.com/scratch/voters.parquet"
+    assert "X-Amz-Signature" not in redacted
+    assert "deadbeefcafe" not in redacted
+
+
+def test_redact_source_drops_credentials_embedded_in_the_uri() -> None:
+    redacted = redact_source(CREDENTIALED)
+
+    assert redacted == "s3://bucket/scratch/voters.parquet"
+    assert "sUp3rS3cr3t" not in redacted
+    assert "AKIAEXAMPLE" not in redacted
+
+
+def test_redact_source_leaves_local_paths_alone() -> None:
+    assert redact_source("/data/voters.parquet") == "/data/voters.parquet"
+
+
+def test_error_message_never_carries_the_raw_source(conn) -> None:
+    # The message lands in `dataset_versions.error` and renders in the UI, so a
+    # presigned source must not survive into it.
+    with pytest.raises(SourceUnreadableError) as excinfo:
+        NysVoterFileImporter().load(PRESIGNED, "nys_voter_file_v1", conn, _Progress())
+
+    message = str(excinfo.value)
+    assert "X-Amz-Signature" not in message
+    assert "deadbeefcafe" not in message
+    assert "bucket.example.com/scratch/voters.parquet" in message

--- a/apps/data/tests/test_job_runner.py
+++ b/apps/data/tests/test_job_runner.py
@@ -11,12 +11,13 @@ from pydantic import BaseModel
 from src.job_runner import (
     COMPLETED,
     IN_PROGRESS,
+    INTERRUPTED_REASON,
     PERMANENTLY_FAILED,
     UNSTARTED,
     ClaimedJob,
     JobContext,
     JobManager,
-    JobRegistry,
+    ReapedJob,
     job,
 )
 
@@ -39,12 +40,16 @@ class StoredJob:
     result: Any = None
     failure_reason: str | None = None
     locked_by_worker_id: str | None = None
+    heartbeat_at: float | None = None
     messages: list[dict[str, Any]] = field(default_factory=list)
 
 
 class MemoryJobStore:
-    def __init__(self, jobs: list[StoredJob]) -> None:
+    """In-memory store with an explicit clock, so lease tests don't sleep."""
+
+    def __init__(self, jobs: list[StoredJob], *, now: float = 0.0) -> None:
         self.jobs = jobs
+        self.now = now
 
     async def claim_jobs(self, *, worker_id: str, tasks: Iterable[str], limit: int) -> list[ClaimedJob]:
         claimed: list[ClaimedJob] = []
@@ -66,6 +71,7 @@ class MemoryJobStore:
 
             stored_job.status = IN_PROGRESS
             stored_job.locked_by_worker_id = worker_id
+            stored_job.heartbeat_at = self.now
             if key is not None:
                 claimed_keys.add(key)
             claimed.append(
@@ -92,6 +98,29 @@ class MemoryJobStore:
         stored_job.failure_reason = failure_reason
         stored_job.locked_by_worker_id = None
 
+    async def heartbeat(self, *, worker_id: str, job_ids: Iterable[uuid.UUID]) -> None:
+        wanted = set(job_ids)
+        for stored_job in self.jobs:
+            if (
+                stored_job.job_id in wanted
+                and stored_job.status == IN_PROGRESS
+                and stored_job.locked_by_worker_id == worker_id
+            ):
+                stored_job.heartbeat_at = self.now
+
+    async def reap_expired_jobs(self, *, lease_seconds: float) -> list[ReapedJob]:
+        reaped: list[ReapedJob] = []
+        for stored_job in self.jobs:
+            if stored_job.status != IN_PROGRESS:
+                continue
+            if (stored_job.heartbeat_at or 0.0) >= self.now - lease_seconds:
+                continue
+            stored_job.status = PERMANENTLY_FAILED
+            stored_job.failure_reason = INTERRUPTED_REASON
+            stored_job.locked_by_worker_id = None
+            reaped.append(ReapedJob(job_id=stored_job.job_id, task=stored_job.task, payload=stored_job.payload))
+        return reaped
+
     async def write_message(self, *, job_id: uuid.UUID, payload: Mapping[str, Any]) -> None:
         self._job(job_id).messages.append(dict(payload))
 
@@ -102,24 +131,17 @@ class MemoryJobStore:
         raise KeyError(job_id)
 
 
-def test_job_decorator_registers_function_with_inferred_payload_model() -> None:
-    registry = JobRegistry()
-
-    @job(registry=registry)
+def test_job_decorator_builds_registered_job_with_inferred_payload_model() -> None:
+    @job
     def example(payload: Payload, ctx: JobContext) -> dict[str, Any]:
         return {"name": payload.name, "worker": ctx.worker_id}
 
-    registered = registry.get("example")
-
-    assert registered is not None
-    assert registered.func is example
-    assert registered.payload_model is Payload
+    assert example.task == "example"
+    assert example.payload_model is Payload
 
 
 def test_run_once_completes_successful_job_and_writes_messages() -> None:
-    registry = JobRegistry()
-
-    @job(registry=registry)
+    @job
     async def example(payload: Payload, ctx: JobContext) -> dict[str, Any]:
         await ctx.message("started", count=payload.count)
         await ctx.message({"phase": "done"})
@@ -128,7 +150,7 @@ def test_run_once_completes_successful_job_and_writes_messages() -> None:
     stored_job = StoredJob(job_id=uuid.uuid4(), task="example", payload={"name": "Ada", "count": 3})
     store = MemoryJobStore([stored_job])
 
-    handled = asyncio.run(JobManager(registry=registry, store=store, worker_id="worker-1").run_once())
+    handled = asyncio.run(JobManager(jobs=[example], store=store, worker_id="worker-1").run_once())
 
     assert handled == 1
     assert stored_job.status == COMPLETED
@@ -141,16 +163,14 @@ def test_run_once_completes_successful_job_and_writes_messages() -> None:
 
 
 def test_run_once_supports_payload_only_job_functions() -> None:
-    registry = JobRegistry()
-
-    @job(registry=registry)
+    @job
     def example(payload: Payload) -> dict[str, Any]:
         return {"name": payload.name}
 
     stored_job = StoredJob(job_id=uuid.uuid4(), task="example", payload={"name": "Ada"})
     store = MemoryJobStore([stored_job])
 
-    handled = asyncio.run(JobManager(registry=registry, store=store).run_once())
+    handled = asyncio.run(JobManager(jobs=[example], store=store).run_once())
 
     assert handled == 1
     assert stored_job.status == COMPLETED
@@ -158,16 +178,14 @@ def test_run_once_supports_payload_only_job_functions() -> None:
 
 
 def test_run_once_marks_validation_errors_permanently_failed() -> None:
-    registry = JobRegistry()
-
-    @job(registry=registry)
+    @job
     def example(payload: Payload, ctx: JobContext) -> None:
         raise AssertionError("job function should not run")
 
     stored_job = StoredJob(job_id=uuid.uuid4(), task="example", payload={"count": 3})
     store = MemoryJobStore([stored_job])
 
-    handled = asyncio.run(JobManager(registry=registry, store=store).run_once())
+    handled = asyncio.run(JobManager(jobs=[example], store=store).run_once())
 
     assert handled == 1
     assert stored_job.status == PERMANENTLY_FAILED
@@ -177,16 +195,14 @@ def test_run_once_marks_validation_errors_permanently_failed() -> None:
 
 
 def test_run_once_marks_exceptions_permanently_failed() -> None:
-    registry = JobRegistry()
-
-    @job(registry=registry)
+    @job
     def example(payload: Payload, ctx: JobContext) -> None:
         raise RuntimeError(f"boom {payload.name}")
 
     stored_job = StoredJob(job_id=uuid.uuid4(), task="example", payload={"name": "Ada"})
     store = MemoryJobStore([stored_job])
 
-    handled = asyncio.run(JobManager(registry=registry, store=store).run_once())
+    handled = asyncio.run(JobManager(jobs=[example], store=store).run_once())
 
     assert handled == 1
     assert stored_job.status == PERMANENTLY_FAILED
@@ -197,10 +213,9 @@ def test_run_once_marks_exceptions_permanently_failed() -> None:
 
 
 def test_run_once_claims_only_one_job_per_active_concurrency_key() -> None:
-    registry = JobRegistry()
     seen: list[str] = []
 
-    @job(registry=registry)
+    @job
     def example(payload: Payload, ctx: JobContext) -> dict[str, Any]:
         seen.append(payload.name)
         return {"name": payload.name}
@@ -211,7 +226,7 @@ def test_run_once_claims_only_one_job_per_active_concurrency_key() -> None:
         StoredJob(job_id=uuid.uuid4(), task="example", payload={"name": "third"}, concurrency_key="other-key"),
     ]
     store = MemoryJobStore(jobs)
-    manager = JobManager(registry=registry, store=store, max_concurrent_jobs=3)
+    manager = JobManager(jobs=[example], store=store, max_concurrent_jobs=3)
 
     handled = asyncio.run(manager.run_once())
 
@@ -223,9 +238,7 @@ def test_run_once_claims_only_one_job_per_active_concurrency_key() -> None:
 
 
 def test_run_once_skips_jobs_with_already_active_concurrency_key() -> None:
-    registry = JobRegistry()
-
-    @job(registry=registry)
+    @job
     def example(payload: Payload, ctx: JobContext) -> dict[str, Any]:
         return {"name": payload.name}
 
@@ -240,7 +253,7 @@ def test_run_once_skips_jobs_with_already_active_concurrency_key() -> None:
     runnable = StoredJob(job_id=uuid.uuid4(), task="example", payload={"name": "runnable"}, concurrency_key=None)
     store = MemoryJobStore([active, blocked, runnable])
 
-    handled = asyncio.run(JobManager(registry=registry, store=store, max_concurrent_jobs=3).run_once())
+    handled = asyncio.run(JobManager(jobs=[example], store=store, max_concurrent_jobs=3).run_once())
 
     assert handled == 1
     assert active.status == IN_PROGRESS
@@ -249,10 +262,107 @@ def test_run_once_skips_jobs_with_already_active_concurrency_key() -> None:
 
 
 def test_job_requires_payload_model_annotation() -> None:
-    registry = JobRegistry()
-
     with pytest.raises(TypeError, match="Pydantic payload model"):
 
-        @job(registry=registry)
+        @job
         def example(payload: dict[str, Any], ctx: JobContext) -> None:
             return None
+
+
+def test_maintain_once_reaps_job_whose_lease_expired() -> None:
+    statuses_seen_by_sweep: list[str] = []
+
+    # A job the previous process claimed and never finished. Reaping doesn't
+    # need the handler — it fails rows, it never runs them.
+    stored_job = StoredJob(
+        job_id=uuid.uuid4(),
+        task="example",
+        payload={"name": "Ada"},
+        status=IN_PROGRESS,
+        locked_by_worker_id="worker-that-died",
+        heartbeat_at=0.0,
+    )
+    store = MemoryJobStore([stored_job], now=1000.0)
+
+    # Sweeps run after reaping, so cleanup sees the job already failed and a
+    # freshly interrupted import is cleaned in the same tick.
+    async def sweep() -> None:
+        statuses_seen_by_sweep.append(stored_job.status)
+
+    manager = JobManager(store=store, lease_seconds=90.0, sweeps=(sweep,))
+
+    reaped = asyncio.run(manager.maintain_once())
+
+    assert [r.job_id for r in reaped] == [stored_job.job_id]
+    assert stored_job.status == PERMANENTLY_FAILED
+    assert stored_job.failure_reason == INTERRUPTED_REASON
+    assert stored_job.locked_by_worker_id is None
+    assert statuses_seen_by_sweep == [PERMANENTLY_FAILED]
+
+
+def test_maintain_once_contains_a_failing_sweep() -> None:
+    """A broken sweep is retried next tick anyway, so it must not take down the
+    maintenance pass or the sweeps after it."""
+    ran: list[str] = []
+
+    async def broken_sweep() -> None:
+        raise RuntimeError("transient")
+
+    async def working_sweep() -> None:
+        ran.append("worked")
+
+    store = MemoryJobStore([])
+    manager = JobManager(store=store, sweeps=(broken_sweep, working_sweep))
+
+    assert asyncio.run(manager.maintain_once()) == []
+    assert ran == ["worked"]
+
+
+def test_maintain_once_leaves_a_recently_stamped_job_alone() -> None:
+    stored_job = StoredJob(
+        job_id=uuid.uuid4(),
+        task="example",
+        payload={"name": "Ada"},
+        status=IN_PROGRESS,
+        locked_by_worker_id="live-worker",
+        heartbeat_at=950.0,
+    )
+    store = MemoryJobStore([stored_job], now=1000.0)
+    manager = JobManager(store=store, lease_seconds=90.0)
+
+    assert asyncio.run(manager.maintain_once()) == []
+    assert stored_job.status == IN_PROGRESS
+
+
+def test_heartbeat_keeps_a_long_running_job_from_being_reaped() -> None:
+    """The whole point: a job that outlives its lease survives while its worker
+    is alive to stamp it, and only then reports its own result."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @job
+    async def slow(payload: Payload) -> dict[str, Any]:
+        started.set()
+        await release.wait()
+        return {"done": payload.name}
+
+    stored_job = StoredJob(job_id=uuid.uuid4(), task="slow", payload={"name": "Ada"})
+    store = MemoryJobStore([stored_job])
+    manager = JobManager(jobs=[slow], store=store, lease_seconds=90.0)
+
+    async def scenario() -> None:
+        running = asyncio.create_task(manager.run_once())
+        await started.wait()
+
+        # Push well past the lease, ticking maintenance as the real loop would.
+        for _ in range(4):
+            store.now += 60.0
+            assert await manager.maintain_once() == []
+
+        assert stored_job.status == IN_PROGRESS
+        release.set()
+        await running
+        assert stored_job.status == COMPLETED
+        assert stored_job.result == {"done": "Ada"}
+
+    asyncio.run(scenario())

--- a/apps/web/src/routes/$orgSlug/data/$datasetId.tsx
+++ b/apps/web/src/routes/$orgSlug/data/$datasetId.tsx
@@ -217,9 +217,11 @@ function DatasetEditor({
           <Columns2 className="size-4" />
           Append
         </Button>
+        {/* Until an import has actually landed you're still importing, not
+            updating — a failed or in-flight first attempt isn't a version. */}
         <Button onClick={() => setUpdateOpen(true)} disabled={importing}>
           <Upload className="size-4" />
-          Update
+          {readyVersionId ? "Update" : "Import"}
         </Button>
       </EditorHeader>
 
@@ -228,6 +230,7 @@ function DatasetEditor({
         onOpenChange={setUpdateOpen}
         datasetId={dataset.datasetId}
         datasetName={dataset.name}
+        hasReadyVersion={readyVersionId != null}
         onUpdated={() => void queryClient.invalidateQueries({ queryKey: ["datasets"] })}
       />
       <AppendDialog
@@ -355,7 +358,12 @@ function VersionsCard({
             return (
               <TableRow key={v.versionId} className={cn(v.isArchived && "text-muted-foreground")}>
                 <TableCell>
-                  <Pill className="tabular-nums">v{v.versionNumber}</Pill>
+                  {/* A number is what a successful import earns. In-flight and
+                      failed attempts hold one internally (it names their
+                      DuckLake schema) but never show it. */}
+                  <Pill className="tabular-nums">
+                    {v.status === "ready" ? `v${v.versionNumber}` : ""}
+                  </Pill>
                 </TableCell>
                 <TableCell>
                   <Pill color={status.color} className="tabular-nums">
@@ -474,8 +482,8 @@ function DetailsDialog({
         <DialogTitle>Details</DialogTitle>
         <DialogCloseX />
         <DialogDescription>
-          Imported v{version?.versionNumber} of {version?.name} with type{" "}
-          {importerLabel(version?.importer ?? "")}, started{" "}
+          {version?.status === "ready" ? `Imported v${version.versionNumber} of ` : "Import of "}
+          {version?.name} with type {importerLabel(version?.importer ?? "")}, started{" "}
           {formatDateTime(version?.importedAt, timezone)}.
         </DialogDescription>
         {version?.status === "failed" ? (
@@ -808,12 +816,14 @@ function UpdateDialog({
   onOpenChange,
   datasetId,
   datasetName,
+  hasReadyVersion,
   onUpdated,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   datasetId: string;
   datasetName: string;
+  hasReadyVersion: boolean;
   onUpdated: () => void;
 }) {
   const [source, setSource] = useState("");
@@ -843,11 +853,20 @@ function UpdateDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <DialogTitle>Update dataset</DialogTitle>
+        <DialogTitle>{hasReadyVersion ? "Update dataset" : "Import dataset"}</DialogTitle>
         <DialogDescription>
-          Imports a new version of{" "}
-          <span className="font-medium text-foreground">{datasetName}</span>. Segments and campaigns
-          carry over; the new version stays inactive until you make it active.
+          {hasReadyVersion ? (
+            <>
+              Imports a new version of{" "}
+              <span className="font-medium text-foreground">{datasetName}</span>. Segments and
+              campaigns carry over; the new version stays inactive until you make it active.
+            </>
+          ) : (
+            <>
+              Imports <span className="font-medium text-foreground">{datasetName}</span>. It becomes
+              available once the import finishes.
+            </>
+          )}
         </DialogDescription>
         <form
           onSubmit={(e) => {
@@ -875,7 +894,7 @@ function UpdateDialog({
           <div className="mt-2 flex justify-end gap-2">
             <DialogClose render={<Button variant="outline" type="button" />}>Cancel</DialogClose>
             <Button type="submit" disabled={!valid} loading={pending}>
-              Import version
+              {hasReadyVersion ? "Import version" : "Import"}
             </Button>
           </div>
         </form>

--- a/apps/web/src/rpc/web/datasets.ts
+++ b/apps/web/src/rpc/web/datasets.ts
@@ -247,10 +247,11 @@ export const create = pub
     });
   });
 
-// Import a newer version into an existing dataset (the "Update" action). Adds
-// v(n+1) as `importing` and enqueues the geocode job; the org keeps running on
-// its current active version until the new one is Ready and explicitly made
-// active. Blocks a second concurrent import on the same dataset.
+// Import into an existing dataset — the "Update" action, or "Import" while the
+// dataset has no version that ever landed. Adds v(n+1) as `importing`, or takes
+// over a trailing failed row, and enqueues the geocode job; the org keeps
+// running on its current active version until the new one is Ready and
+// explicitly made active. Blocks a second concurrent import on the same dataset.
 export const update = pub
   .input(z.object({ datasetId: z.string().uuid(), sourceUri: z.string().min(1) }))
   .handler(async ({ context, input }) => {
@@ -270,7 +271,11 @@ export const update = pub
       if (!grant) throw new ORPCError("NOT_FOUND", { message: "Dataset not found." });
 
       const versions = await tx
-        .select({ versionNumber: datasetVersions.versionNumber, status: datasetVersions.status })
+        .select({
+          versionId: datasetVersions.datasetVersionId,
+          versionNumber: datasetVersions.versionNumber,
+          status: datasetVersions.status,
+        })
         .from(datasetVersions)
         .where(eq(datasetVersions.datasetId, input.datasetId))
         .orderBy(desc(datasetVersions.versionNumber));
@@ -278,20 +283,60 @@ export const update = pub
         throw new ORPCError("CONFLICT", {
           message: "An import is already in progress for this dataset. Wait for it to finish.",
         });
+
+      // A failed import produced nothing worth keeping and its number was never
+      // shown, so the next import takes that row over rather than stepping past
+      // it — a failure must not consume a version. The job drops and recreates
+      // the version's DuckLake schema, clearing whatever the attempt left.
+      const reclaimable = versions[0]?.status === "failed" ? versions[0] : null;
+
+      if (reclaimable) {
+        // Re-assert `failed` in the WHERE: the read above ran on this
+        // transaction's snapshot, so two concurrent imports both see the row as
+        // reclaimable. Whoever commits second matches nothing and is rejected,
+        // the way the unique index rejects a double insert.
+        const claimed = await tx
+          .update(datasetVersions)
+          .set({
+            status: "importing",
+            sourceUri: input.sourceUri,
+            error: null,
+            importStep: null,
+            importTotalSteps: null,
+            // Reset so the UI times this attempt, not the one that failed.
+            createdAt: new Date(),
+            createdBy: context.user.id,
+            archivedAt: null,
+          })
+          .where(
+            and(
+              eq(datasetVersions.datasetVersionId, reclaimable.versionId),
+              eq(datasetVersions.status, "failed"),
+            ),
+          )
+          .returning({ versionId: datasetVersions.datasetVersionId });
+        if (claimed.length === 0)
+          throw new ORPCError("CONFLICT", {
+            message: "An import is already in progress for this dataset. Wait for it to finish.",
+          });
+      }
+
       // The unique (dataset_id, version_number) index makes a concurrent double-
       // update fail on insert rather than mint a duplicate number.
-      const nextNumber = (versions[0]?.versionNumber ?? 0) + 1;
-
-      const [version] = await tx
-        .insert(datasetVersions)
-        .values({
-          datasetId: input.datasetId,
-          versionNumber: nextNumber,
-          status: "importing",
-          sourceUri: input.sourceUri,
-          createdBy: context.user.id,
-        })
-        .returning({ datasetVersionId: datasetVersions.datasetVersionId });
+      const version = reclaimable
+        ? { datasetVersionId: reclaimable.versionId }
+        : (
+            await tx
+              .insert(datasetVersions)
+              .values({
+                datasetId: input.datasetId,
+                versionNumber: (versions[0]?.versionNumber ?? 0) + 1,
+                status: "importing",
+                sourceUri: input.sourceUri,
+                createdBy: context.user.id,
+              })
+              .returning({ datasetVersionId: datasetVersions.datasetVersionId })
+          )[0];
       await tx.insert(jobs).values({
         task: "import_dataset_version",
         payload: {

--- a/packages/db/src/schema/jobs.ts
+++ b/packages/db/src/schema/jobs.ts
@@ -29,6 +29,9 @@ export const jobs = app.table("jobs", {
   result: jsonb(),
   concurrencyKey: text(),
   lockedByWorkerId: text(),
+  // Refreshed by the running worker. A job whose heartbeat has gone stale was
+  // killed without reporting (deploy, OOM), and gets reaped as failed.
+  heartbeatAt: timestamp({ withTimezone: true }),
 });
 
 export const jobMessages = app.table(


### PR DESCRIPTION
This PR cleans up the handling of failed imports in a couple ways, after the experience of encountering failures for the first time due to OOM crashes (which would leave permanently importing jobs and make it impossible to reimport a dataset with the same name). 

First, it adds a heartbeat signal for jobs from a dedicated maintenance task so that we can automatically cleanup jobs that fail and become stale (and would otherwise block new imports). Second, it prevents burning versions on failed imports, and improves the UX when importing after a failure. Third, it cleans up the error messages for missing remote files.