### PR TITLE
feat: turf list maps

### DIFF
--- a/apps/data/src/publish_turfs.py
+++ b/apps/data/src/publish_turfs.py
@@ -446,6 +446,15 @@ def _build_publish_temp_table_sql(schema: str, where_sql: str, present_optional:
         FROM building_payloads
         GROUP BY polygon_idx
     ),
+    turf_coords AS (
+        -- Slim [lng, lat] projection stored on the turf row so map
+        -- reads never have to open the full turf_data payload.
+        SELECT
+            polygon_idx,
+            json_group_array(json_array(longitude, latitude)) AS building_coords
+        FROM building_payloads
+        GROUP BY polygon_idx
+    ),
     counts AS (
         SELECT
             polygon_idx,
@@ -487,16 +496,18 @@ def _build_publish_temp_table_sql(schema: str, where_sql: str, present_optional:
             ?::UUID AS created_by,
             -- Record the dataset version this turf was published against.
             ?::UUID AS dataset_version_id,
-            coalesce(tb.buildings, json('[]')) AS buildings
+            coalesce(tb.buildings, json('[]')) AS buildings,
+            coalesce(tc.building_coords, json('[]')) AS building_coords
         FROM drafts d
         LEFT JOIN counts c ON c.polygon_idx = d.idx
         LEFT JOIN turf_buildings tb ON tb.polygon_idx = d.idx
+        LEFT JOIN turf_coords tc ON tc.polygon_idx = d.idx
     )
     SELECT
         turf_id, turf_code,
         campaign_id, segment_id, zone_id, zone_name, zone_keys_json,
         zone_group_id, script_id,
-        criteria_json, name, geometry_json,
+        criteria_json, name, geometry_json, building_coords,
         door_count, person_count,
         created_by, dataset_version_id,
         json_object(
@@ -515,12 +526,12 @@ def _insert_turfs_sql() -> str:
     INSERT INTO {OPERATIONAL_PG_ALIAS}.app.turfs (
         turf_id, campaign_id, segment_id, zone_id, zone_name, zone_keys,
         zone_group_id, script_id, name, turf_code, criteria, geometry,
-        door_count, person_count, created_by, dataset_version_id
+        building_coords, door_count, person_count, created_by, dataset_version_id
     )
     SELECT
         turf_id, campaign_id, segment_id, zone_id, zone_name, json(zone_keys_json),
         zone_group_id, script_id, name, turf_code, json(criteria_json), json(geometry_json),
-        door_count, person_count, created_by, dataset_version_id
+        json(building_coords), door_count, person_count, created_by, dataset_version_id
     FROM published_turf_rows;
     """
 

--- a/apps/web/src/components/map.tsx
+++ b/apps/web/src/components/map.tsx
@@ -56,6 +56,14 @@ type MapProps = {
   // turf-cutter.
   zonePerimeters?: GeoJSON.FeatureCollection;
   onZoneClick?: (zoneId: string) => void;
+  // Optional label points — point features with `properties.label`,
+  // drawn as text above the perimeter fills. Callers compute placement
+  // (e.g. bbox centers): letting MapLibre self-label polygons
+  // duplicates text across tile splits. Features with
+  // `properties.badge` get a theme-aware translucent plate behind mono
+  // text — sized for short numeric labels, not names — and collision-
+  // hide (with a fade) when the map gets crowded.
+  shapeLabels?: GeoJSON.FeatureCollection;
   // The currently-selected zone's id. Its perimeter line renders
   // with a heavier stroke + full opacity; the rest stay thin and
   // faded so the selection reads at a glance.
@@ -148,6 +156,45 @@ const ZONE_PERIMETERS_SOURCE_ID = "zone-perimeters";
 const ZONE_PERIMETERS_FILL_LAYER = "zone-perimeters-fill";
 const ZONE_PERIMETERS_LINE_LAYER = "zone-perimeters-line";
 const BOUNDARIES_LINE_LAYER = "boundaries-line";
+const SHAPE_LABELS_SOURCE_ID = "shape-labels";
+// The two shape-label layers, in stacking order. The points layer is
+// kept immediately below these (badges stay readable over the dots) —
+// shared with PointsLayer via its `keepBelow` option.
+const SHAPE_LABEL_LAYER_IDS = ["shape-labels-badged", "shape-labels"];
+const LABEL_BADGE_IMAGES = {
+  light: "shape-label-plate-light",
+  dark: "shape-label-plate-dark",
+} as const;
+
+// The label plate: a translucent rounded rectangle drawn once at 2x,
+// with stretch zones between the corners so icon-text-fit can size it
+// to any label width without distorting the radius. Coordinates in the
+// metadata below are image pixels (36px image = 18 CSS px, radius 12 =
+// rounded-md's 6). Both theme variants are registered; the layer picks
+// per theme.
+function badgePlateImage(variant: keyof typeof LABEL_BADGE_IMAGES): ImageData {
+  const size = 36;
+  const radius = 12;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d")!;
+  ctx.beginPath();
+  ctx.roundRect(1, 1, size - 2, size - 2, radius);
+  ctx.fillStyle = variant === "dark" ? "rgba(20, 20, 20, 0.85)" : "rgba(255, 255, 255, 0.82)";
+  ctx.fill();
+  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = variant === "dark" ? "rgba(255, 255, 255, 0.28)" : "rgba(0, 0, 0, 0.25)";
+  ctx.stroke();
+  return ctx.getImageData(0, 0, size, size);
+}
+
+const LABEL_BADGE_METADATA = {
+  pixelRatio: 2,
+  stretchX: [[14, 22]] as [number, number][],
+  stretchY: [[14, 22]] as [number, number][],
+  content: [12, 12, 24, 24] as [number, number, number, number],
+};
 
 export function Map({
   initialViewState,
@@ -158,6 +205,7 @@ export function Map({
   activeKeys,
   zonePerimeters,
   onZoneClick,
+  shapeLabels,
   selectedZoneId,
   fitBounds,
   onPolygonClick,
@@ -413,6 +461,31 @@ export function Map({
     }
   };
 
+  // Register the label plate images. `setStyle` (theme toggle) wipes
+  // images, so `styleimagemissing` is the durable re-add hook — it
+  // fires whenever a layer wants an image that isn't there.
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    const ensure = (variant: keyof typeof LABEL_BADGE_IMAGES) => {
+      const id = LABEL_BADGE_IMAGES[variant];
+      if (!map.hasImage(id)) {
+        map.addImage(id, badgePlateImage(variant), LABEL_BADGE_METADATA);
+      }
+    };
+    ensure("light");
+    ensure("dark");
+    const onMissing = (e: { id: string }) => {
+      if (e.id === LABEL_BADGE_IMAGES.light) ensure("light");
+      if (e.id === LABEL_BADGE_IMAGES.dark) ensure("dark");
+    };
+    map.on("styleimagemissing", onMissing);
+    return () => {
+      map.off("styleimagemissing", onMissing);
+    };
+  }, [mapReady]);
+
   // Add the WebGL points layer once the map is up. We add even when
   // `points` is undefined so a later prop change doesn't cost a layer
   // re-create — `setPoints` just toggles the visible point count.
@@ -420,7 +493,7 @@ export function Map({
     if (!mapReady) return;
     const map = mapRef.current?.getMap();
     if (!map) return;
-    const layer = new PointsLayer({ id: "segment-points" });
+    const layer = new PointsLayer({ id: "segment-points", keepBelow: SHAPE_LABEL_LAYER_IDS });
     pointsLayerRef.current = layer;
     if (!map.getLayer(layer.id)) map.addLayer(layer);
     return () => {
@@ -429,29 +502,54 @@ export function Map({
     };
   }, [mapReady]);
 
-  // Keep the points layer on top of every other layer, whenever the
-  // style changes. The JSX-driven Source/Layer components
-  // (boundaries, zone perimeters) add their layers via react-map-
-  // gl's own internal effects, which we don't directly observe and
-  // which run on a different schedule from our imperative addLayer
-  // for points. Result: any time someone else adds a layer (style
-  // load, source mount, dynamic toggle), points can end up beneath
-  // it and stay there.
+  // Keep the points layer stacked correctly, whenever the style
+  // changes: above every other layer EXCEPT the shape labels, whose
+  // badges must stay readable over the dots. The JSX-driven
+  // Source/Layer components (boundaries, zone perimeters, labels) add
+  // their layers via react-map-gl's own internal effects, which we
+  // don't directly observe and which run on a different schedule from
+  // our imperative addLayer for points. Result: any time someone else
+  // adds a layer (style load, source mount, dynamic toggle), points
+  // can end up mis-stacked and stay there.
   //
   // `styledata` fires after every style mutation, so we just listen
-  // and re-stack whenever points isn't already the topmost layer.
-  // moveLayer itself fires `styledata` again, but the next check
-  // sees points at the top and exits — no loop.
+  // and re-stack whenever points isn't already in position. moveLayer
+  // itself fires `styledata` again, but the next check sees points in
+  // place and exits — no loop. This logic MUST stay in lockstep with
+  // PointsLayer.nudgeOnTop (which gets the same target via the
+  // `keepBelow` option) — if the two disagree, they re-stack against
+  // each other on every styledata: a permanent repaint loop.
+  //
+  // IMPORTANT: the order check must use `getLayersOrder()`, never
+  // `getStyle().layers` — the latter is a serialization that omits
+  // custom layers, so points could never satisfy the position check
+  // and every styledata triggered a moveLayer, which fired styledata
+  // again: a permanent 60fps repaint loop that kept the map from ever
+  // going idle (and disabled symbol fades, which are gated behind the
+  // first `idle`).
   useEffect(() => {
     if (!mapReady) return;
     const map = mapRef.current?.getMap();
     if (!map) return;
     const ensure = () => {
       if (!map.getLayer("segment-points")) return;
-      const layers = map.getStyle().layers;
-      if (!layers || layers.length === 0) return;
-      if (layers[layers.length - 1]?.id === "segment-points") return;
-      map.moveLayer("segment-points");
+      const order = map.getLayersOrder();
+      const idx = order.indexOf("segment-points");
+      if (idx < 0) return;
+      // In position iff everything above the dots is a shape-label
+      // layer and no shape-label layer sits below them.
+      const above = order.slice(idx + 1);
+      const labelsPresent = order.filter((id) => SHAPE_LABEL_LAYER_IDS.includes(id));
+      if (
+        above.length === labelsPresent.length &&
+        above.every((id) => SHAPE_LABEL_LAYER_IDS.includes(id))
+      ) {
+        return;
+      }
+      map.moveLayer(
+        "segment-points",
+        order.find((id) => SHAPE_LABEL_LAYER_IDS.includes(id)),
+      );
     };
     // `styledata` covers most reorder triggers; `idle` is the
     // belt-and-suspenders hook — fires when the map has fully
@@ -522,12 +620,17 @@ export function Map({
     const map = mapRef.current?.getMap();
     if (!map) return;
     const fit = () => {
+      // Padding scales with the container: a flat 40px reads right on
+      // desktop editors but eats over a quarter of a phone-width
+      // dialog, leaving the shape floating under-zoomed.
+      const el = map.getContainer();
+      const padding = Math.min(40, Math.round(Math.min(el.clientWidth, el.clientHeight) * 0.08));
       map.fitBounds(
         [
           [fitBounds[0], fitBounds[1]],
           [fitBounds[2], fitBounds[3]],
         ],
-        { padding: 40, duration: 0 },
+        { padding, duration: 0 },
       );
       lastFitBoundsRef.current = fitBounds;
       setPendingFit(false);
@@ -600,7 +703,14 @@ export function Map({
         mapStyle={getMaptilerStyleUrl(isDark)}
         attributionControl={false}
         style={{ width: "100%", height: "100%" }}
-        onLoad={() => setMapReady(true)}
+        onLoad={() => {
+          setMapReady(true);
+          // Dev-only console handle for render-loop / placement
+          // diagnostics (label-fade gate, idle behavior).
+          if (import.meta.env.DEV) {
+            (window as { __map?: unknown }).__map = mapRef.current?.getMap();
+          }
+        }}
         // Disabled: MapLibre's box-zoom handler intercepts
         // shift+drag (and effectively shift+click) to draw a zoom
         // rectangle. The zone editor uses shift+click to toggle
@@ -707,29 +817,93 @@ export function Map({
                   ["get", "color"],
                   isDark ? "hsl(0, 0%, 80%)" : "hsl(0, 0%, 20%)",
                 ],
-                "fill-opacity": 0.65,
+                // Per-feature `opacity` override for callers that encode
+                // state in fill strength (the turfs board's walk states).
+                "fill-opacity": ["coalesce", ["get", "opacity"], 0.65],
               }}
             />
             <Layer
               id={ZONE_PERIMETERS_LINE_LAYER}
               type="line"
               paint={{
-                "line-color": isDark ? "hsl(0, 0%, 95%)" : "hsl(0, 0%, 5%)",
+                // Per-feature `lineColor` override (drawn solid); the
+                // theme-neutral stroke is the fallback. The turf maps
+                // use it to match each outline to its fill color.
+                "line-color": [
+                  "coalesce",
+                  ["get", "lineColor"],
+                  isDark ? "hsl(0, 0%, 95%)" : "hsl(0, 0%, 5%)",
+                ],
                 // Thin and faded by default; the selected zone gets
                 // the heavier stroke at full opacity so it reads as
                 // the active one without disrupting the others.
                 "line-width": ["case", ["==", ["feature-state", "selected"], true], 1.5, 0.75],
-                "line-opacity": ["case", ["==", ["feature-state", "selected"], true], 1, 0.5],
+                "line-opacity": [
+                  "case",
+                  ["==", ["feature-state", "selected"], true],
+                  1,
+                  ["!=", ["get", "lineColor"], null],
+                  1,
+                  0.5,
+                ],
               }}
             />
           </Source>
         ) : null}
 
+        {shapeLabels ? (
+          <Source id={SHAPE_LABELS_SOURCE_ID} type="geojson" data={shapeLabels}>
+            {/* Badged labels ride a stretchable rounded-rect plate
+                (icon-text-fit sizes it to the text); plate and text
+                colors flip with the theme. */}
+            <Layer
+              id="shape-labels-badged"
+              type="symbol"
+              filter={["==", ["get", "badge"], true]}
+              layout={{
+                "text-field": ["get", "label"],
+                "text-size": 15,
+                // Served by MapTiler's glyph endpoint (verified) — the
+                // style's default stack isn't mono, and mono digits keep
+                // plate widths steady across equal-length labels.
+                "text-font": ["Roboto Mono Regular"],
+                "text-allow-overlap": false,
+                "icon-image": isDark ? LABEL_BADGE_IMAGES.dark : LABEL_BADGE_IMAGES.light,
+                "icon-text-fit": "both",
+                "icon-text-fit-padding": [0, 0, 0, 0],
+                "icon-allow-overlap": false,
+              }}
+              paint={{ "text-color": isDark ? "hsl(0, 0%, 92%)" : "hsl(0, 0%, 10%)" }}
+            />
+            <Layer
+              id="shape-labels"
+              type="symbol"
+              filter={["!=", ["get", "badge"], true]}
+              layout={{
+                "text-field": ["get", "label"],
+                "text-size": 13,
+                // Counts are small and every label sits inside its own
+                // shape — collision-hiding tiny turfs' numbers would
+                // defeat the layer's purpose.
+                "text-allow-overlap": true,
+              }}
+              paint={LABEL_PAINT(isDark)}
+            />
+          </Source>
+        ) : null}
+
+        {/* Street labels sit BELOW the shape labels when both exist —
+            symbol placement runs top-down, so whichever layer is higher
+            claims collision space first. Badges above streets = badges
+            always place, street names flow around the plates. (MapLibre
+            has no per-layer collision groups; layer order is the only
+            priority mechanism.) */}
         {showLabels ? (
           <Source id={LABELS_SOURCE_ID} type="vector" url={MAPTILER_OPENMAPTILES_TILEJSON_URL}>
             {/* Cities (zoom 4–14) */}
             <Layer
               id="labels-city"
+              beforeId={shapeLabels ? "shape-labels-badged" : undefined}
               type="symbol"
               source-layer="place"
               minzoom={4}
@@ -745,6 +919,7 @@ export function Map({
             {/* Towns (zoom 6+) */}
             <Layer
               id="labels-town"
+              beforeId={shapeLabels ? "shape-labels-badged" : undefined}
               type="symbol"
               source-layer="place"
               minzoom={6}
@@ -759,6 +934,7 @@ export function Map({
             {/* Neighborhoods, hamlets, etc. (zoom 8+) */}
             <Layer
               id="labels-other"
+              beforeId={shapeLabels ? "shape-labels-badged" : undefined}
               type="symbol"
               source-layer="place"
               minzoom={8}
@@ -776,6 +952,7 @@ export function Map({
             {/* Roads (zoom 9+) */}
             <Layer
               id="labels-road"
+              beforeId={shapeLabels ? "shape-labels-badged" : undefined}
               type="symbol"
               source-layer="transportation_name"
               minzoom={9}
@@ -792,6 +969,7 @@ export function Map({
             {/* House numbers (zoom 17+) */}
             <Layer
               id="labels-housenumber"
+              beforeId={shapeLabels ? "shape-labels-badged" : undefined}
               type="symbol"
               source-layer="housenumber"
               minzoom={17}

--- a/apps/web/src/components/points-layer.ts
+++ b/apps/web/src/components/points-layer.ts
@@ -65,16 +65,20 @@ uniform mat4 u_matrix;
 uniform vec2 u_shiftHi;
 uniform vec2 u_shiftLo;
 uniform float u_zoom;
+// devicePixelRatio — gl_PointSize is in physical framebuffer pixels,
+// so without this scale dots render visibly smaller on high-DPR
+// phones than on desktop.
+uniform float u_pixelRatio;
 
 out vec3 v_color;
 
-// Zoom range and pixel-size endpoints for the dot. Each zoom level
+// Zoom range and CSS-pixel size endpoints for the dot. Each zoom level
 // scales the dot by the same factor (geometric ramp), matching the
 // way map scale doubles per zoom level.
 const float Z_MIN = 9.0;
 const float Z_MAX = 18.0;
-const float PX_MIN = 2.0;
-const float PX_MAX = 14.0;
+const float PX_MIN = 1.0;
+const float PX_MAX = 7.0;
 
 void main() {
   // (merc - cameraMerc) = (merc - storedOrigin) - (cameraMerc - storedOrigin).
@@ -87,7 +91,7 @@ void main() {
 
   float t = clamp((u_zoom - Z_MIN) / (Z_MAX - Z_MIN), 0.0, 1.0);
   float baseSize = PX_MIN * pow(PX_MAX / PX_MIN, t);
-  gl_PointSize = baseSize * a_size;
+  gl_PointSize = baseSize * a_size * u_pixelRatio;
 }
 `;
 
@@ -143,6 +147,7 @@ export class PointsLayer implements CustomLayerInterface {
   private locU_matrix: WebGLUniformLocation | null = null;
   private locU_shiftHi: WebGLUniformLocation | null = null;
   private locU_shiftLo: WebGLUniformLocation | null = null;
+  private locU_pixelRatio: WebGLUniformLocation | null = null;
   private locU_zoom: WebGLUniformLocation | null = null;
 
   // Reusable scratch buffer for the shifted matrix; one allocation
@@ -166,8 +171,14 @@ export class PointsLayer implements CustomLayerInterface {
 
   private style: PointsLayerStyle = DEFAULT_STYLE;
 
-  constructor(opts: { id?: string } = {}) {
+  // Layer ids allowed to sit above the dots (e.g. label badges); the
+  // re-stacking keeps this layer immediately below them, topmost
+  // otherwise.
+  private readonly keepBelow: string[];
+
+  constructor(opts: { id?: string; keepBelow?: string[] } = {}) {
     this.id = opts.id ?? "points-layer";
+    this.keepBelow = opts.keepBelow ?? [];
   }
 
   onAdd(map: MapLibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
@@ -288,6 +299,8 @@ export class PointsLayer implements CustomLayerInterface {
     gl2.uniform2f(this.locU_shiftHi, sxHi, syHi);
     gl2.uniform2f(this.locU_shiftLo, sxLo, syLo);
     gl2.uniform1f(this.locU_zoom, this.map.getZoom());
+    // Per frame: DPR changes with browser zoom and cross-screen moves.
+    gl2.uniform1f(this.locU_pixelRatio, window.devicePixelRatio || 1);
 
     gl2.drawArrays(gl2.POINTS, 0, this.pointCount);
   }
@@ -373,19 +386,36 @@ export class PointsLayer implements CustomLayerInterface {
     gl.bufferData(gl.ARRAY_BUFFER, this.userSizes, gl.DYNAMIC_DRAW);
   }
 
-  // Re-stack the layer to the top of the style if it isn't already.
-  // The Map component has its own listener that does this on
-  // `styledata` / `idle`, but those events don't fire reliably for
-  // every reorder trigger — calling here on every data upload is a
-  // cheap belt-and-suspenders so a buried-points race never
-  // outlives the next prop change. No-op when already on top.
+  // Re-stack the layer to its position (top, except `keepBelow`
+  // layers) if it isn't there already. The Map component has its own
+  // listener that does this on `styledata` / `idle`, but those events
+  // don't fire reliably for every reorder trigger — calling here on
+  // every data upload is a cheap belt-and-suspenders so a buried-
+  // points race never outlives the next prop change. MUST match the
+  // Map component's ensure() logic exactly — two re-stackers with
+  // different targets would fight on every styledata (repaint loop).
   private nudgeOnTop(): void {
     if (!this.map) return;
     if (!this.map.getLayer(this.id)) return;
-    const layers = this.map.getStyle().layers;
-    if (!layers || layers.length === 0) return;
-    if (layers[layers.length - 1]?.id === this.id) return;
-    this.map.moveLayer(this.id);
+    // `getLayersOrder()`, never `getStyle().layers` — the serialized
+    // list omits custom layers, so this layer would never test as
+    // topmost and every call would moveLayer (see the repaint-loop
+    // note in map.tsx).
+    const order = this.map.getLayersOrder();
+    const idx = order.indexOf(this.id);
+    if (idx < 0) return;
+    const above = order.slice(idx + 1);
+    const keepBelowPresent = order.filter((id) => this.keepBelow.includes(id));
+    if (
+      above.length === keepBelowPresent.length &&
+      above.every((id) => this.keepBelow.includes(id))
+    ) {
+      return;
+    }
+    this.map.moveLayer(
+      this.id,
+      order.find((id) => this.keepBelow.includes(id)),
+    );
   }
 
   private compileProgram(): void {
@@ -410,6 +440,7 @@ export class PointsLayer implements CustomLayerInterface {
     this.locU_shiftHi = gl.getUniformLocation(program, "u_shiftHi");
     this.locU_shiftLo = gl.getUniformLocation(program, "u_shiftLo");
     this.locU_zoom = gl.getUniformLocation(program, "u_zoom");
+    this.locU_pixelRatio = gl.getUniformLocation(program, "u_pixelRatio");
   }
 }
 

--- a/apps/web/src/lib/permissions.ts
+++ b/apps/web/src/lib/permissions.ts
@@ -55,6 +55,8 @@ export function hasPermission(role: string, permission: Permission): boolean {
 const LEAD_RPC_ALLOWLIST = new Set([
   "healthcheck",
   "turfs.listForOrg",
+  "turfs.turfMapData",
+  "turfs.zoneMapData",
   "walks.listForOrg",
   "progress.forOrg",
   "campaigns.list",

--- a/apps/web/src/lib/queries/turfs.ts
+++ b/apps/web/src/lib/queries/turfs.ts
@@ -7,6 +7,18 @@ export const turfsListQuery = (campaignId: string | null) =>
     queryFn: () => client.turfs.listForOrg(campaignId ? { campaignId } : undefined),
   });
 
+export const turfMapDataQuery = (turfId: string) =>
+  queryOptions({
+    queryKey: ["turf-map-data", turfId] as const,
+    queryFn: () => client.turfs.turfMapData({ turfId }),
+  });
+
+export const zoneMapDataQuery = (campaignId: string, zoneId: string | null) =>
+  queryOptions({
+    queryKey: ["zone-map-data", campaignId, zoneId] as const,
+    queryFn: () => client.turfs.zoneMapData({ campaignId, zoneId }),
+  });
+
 export const turfStatsForCampaignQuery = (campaignId: string) =>
   queryOptions({
     queryKey: ["turf-stats", campaignId] as const,

--- a/apps/web/src/routes/$orgSlug/turfs/index.tsx
+++ b/apps/web/src/routes/$orgSlug/turfs/index.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import type { Feature, FeatureCollection } from "geojson";
 import {
   Check,
   CheckCheck,
@@ -8,6 +9,7 @@ import {
   DoorClosed,
   LayoutGrid,
   LoaderCircle,
+  Map as MapIcon,
   Megaphone,
   Phone,
   QrCode,
@@ -17,12 +19,14 @@ import {
   UsersRound,
   Waypoints,
 } from "lucide-react";
+import { useAtomValue } from "jotai";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "~/components/button";
 import { Dialog, DialogClose, DialogCloseX, DialogContent, DialogTitle } from "~/components/dialog";
 import { EditorHeader } from "~/components/editor-header";
 import { Filter } from "~/components/filter";
+import { Map as MapView } from "~/components/map";
 import { Page } from "~/components/page";
 import { tintStyle } from "~/components/badge";
 import { BLUE, GREEN, RED, YELLOW } from "~/lib/palette";
@@ -32,10 +36,12 @@ import { ToggleGroup, ToggleGroupItem } from "~/components/toggle-group";
 import { formatMonthDay, formatTime } from "~/lib/format";
 import { campaignsListQuery } from "~/lib/queries/campaigns";
 import { progressQuery } from "~/lib/queries/progress";
-import { turfsListQuery } from "~/lib/queries/turfs";
+import { turfMapDataQuery, turfsListQuery, zoneMapDataQuery } from "~/lib/queries/turfs";
 import { walksListQuery } from "~/lib/queries/walks";
+import { darkAtom } from "~/lib/atoms/theme";
+import { colorFor } from "~/lib/zone-colors";
 import { DEFAULT_DISPLAY_TIMEZONE } from "~/lib/timezones";
-import { cn } from "~/lib/utils";
+import { cn, parseHexRgb } from "~/lib/utils";
 import { useFadeOnce } from "~/lib/use-fade-once";
 import { client } from "~/rpc/client";
 
@@ -124,6 +130,32 @@ function TurfsIndex() {
   const showWalks = (turf: TurfRow) => {
     setWalksTurf(turf);
     setWalksOpen(true);
+  };
+  // Map-of-a-group dialog: the group is every turf sharing the clicked
+  // row's (campaign, region) — resolved against the zone-unfiltered rows
+  // so the map always shows the whole zone, whatever the filter.
+  const allRows = useTurfRows(campaignId, null);
+  const [zoneMapGroup, setZoneMapGroup] = useState<ZoneMapGroup | null>(null);
+  const [zoneMapOpen, setZoneMapOpen] = useState(false);
+  const showZoneMap = (turf: TurfRow) => {
+    const region = regionName(turf);
+    setZoneMapGroup({
+      campaignId: turf.campaignId,
+      zoneId: turf.zoneId,
+      name: region ? `${turf.campaignName} / ${region}` : turf.campaignName,
+      turfs: allRows.filter(
+        (r) => r.campaignId === turf.campaignId && regionId(r) === regionId(turf),
+      ),
+    });
+    setZoneMapOpen(true);
+  };
+  // Single-turf map dialog — the hand-off view: just this turf's
+  // boundary and building dots.
+  const [turfMapTurf, setTurfMapTurf] = useState<TurfRow | null>(null);
+  const [turfMapOpen, setTurfMapOpen] = useState(false);
+  const showTurfMap = (turf: TurfRow) => {
+    setTurfMapTurf(turf);
+    setTurfMapOpen(true);
   };
 
   // Back/Next page the QR dialog through the current filter's rows in
@@ -237,13 +269,21 @@ function TurfsIndex() {
       </div>
       <div className="md:hidden">
         {view === "cards" ? (
-          <TurfCards campaignId={campaignId} zoneId={zoneId} onShowQr={showQr} />
+          <TurfCards
+            campaignId={campaignId}
+            zoneId={zoneId}
+            onShowQr={showQr}
+            onShowZoneMap={showZoneMap}
+            onShowTurfMap={showTurfMap}
+          />
         ) : (
           <CompactList
             campaignId={campaignId}
             zoneId={zoneId}
             onShowQr={showQr}
             onShowWalks={showWalks}
+            onShowZoneMap={showZoneMap}
+            onShowTurfMap={showTurfMap}
           />
         )}
       </div>
@@ -253,6 +293,8 @@ function TurfsIndex() {
           zoneId={zoneId}
           onShowQr={showQr}
           onShowWalks={showWalks}
+          onShowZoneMap={showZoneMap}
+          onShowTurfMap={showTurfMap}
         />
       </div>
       <QrDialog
@@ -269,6 +311,8 @@ function TurfsIndex() {
         open={walksOpen}
         onOpenChange={setWalksOpen}
       />
+      <ZoneMapDialog group={zoneMapGroup} open={zoneMapOpen} onOpenChange={setZoneMapOpen} />
+      <TurfMapDialog turf={turfMapTurf} open={turfMapOpen} onOpenChange={setTurfMapOpen} />
     </Page>
   );
 }
@@ -387,15 +431,84 @@ function groupRows(rows: TurfRow[]) {
   return groups;
 }
 
+// Mobile group heading — "Campaign / Zone" label with a right-aligned
+// "View map" text action (baseline-aligned with the label, no button
+// chrome) that opens the whole zone, no turf highlighted. The label
+// gets the remaining width and wraps rather than pushing the action off.
+function GroupHeader({
+  group,
+  onShowZoneMap,
+  className,
+}: {
+  group: { name: string | null; rows: TurfRow[] };
+  onShowZoneMap: (turf: TurfRow) => void;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex items-baseline gap-3", className)}>
+      <p className="min-w-0 flex-1 text-muted-foreground leading-5">{group.name}</p>
+      <button
+        type="button"
+        className="flex shrink-0 items-center gap-1.5 text-muted-foreground leading-5"
+        onClick={() => onShowZoneMap(group.rows[0]!)}
+      >
+        View map
+        <MapIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}
+
 // "01" — the label is the number; the word is the column header's job.
 function turfLabel(name: string) {
   const label = name.replace(/^turf\s+/i, "");
   return /^\d+$/.test(label) ? label.padStart(2, "0") : label;
 }
 
+// Door counts get three characters: past 999 the exact number stops
+// mattering on the board, and "1k+" keeps the cell width fixed.
+function doorLabel(count: number | null) {
+  if (count == null) return "—";
+  return count > 999 ? "1k+" : String(count);
+}
+
 function progressPct(attempted: number | undefined, personCount: number | null) {
   if (!personCount) return null;
   return Math.round(((attempted ?? 0) / personCount) * 100);
+}
+
+function bboxOfFeatures(features: Feature[]): [number, number, number, number] | null {
+  let minLng = Infinity;
+  let minLat = Infinity;
+  let maxLng = -Infinity;
+  let maxLat = -Infinity;
+  const visit = (coords: unknown) => {
+    if (!Array.isArray(coords)) return;
+    if (typeof coords[0] === "number" && typeof coords[1] === "number") {
+      minLng = Math.min(minLng, coords[0]);
+      maxLng = Math.max(maxLng, coords[0]);
+      minLat = Math.min(minLat, coords[1]);
+      maxLat = Math.max(maxLat, coords[1]);
+      return;
+    }
+    for (const c of coords) visit(c);
+  };
+  for (const f of features) {
+    if ("coordinates" in f.geometry) visit(f.geometry.coordinates);
+  }
+  return minLng === Infinity ? null : [minLng, minLat, maxLng, maxLat];
+}
+
+// Bbox center — good enough placement for mostly-convex turf shapes,
+// without pulling in a pole-of-inaccessibility dependency. `badge`
+// requests the map's plate treatment for the numeric label.
+function labelPoint(f: Feature, label: string): Feature {
+  const b = bboxOfFeatures([f]);
+  return {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: b ? [(b[0] + b[2]) / 2, (b[1] + b[3]) / 2] : [0, 0] },
+    properties: { label, badge: true },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -563,6 +676,213 @@ function QrDialog({
   );
 }
 
+type ZoneMapGroup = {
+  campaignId: string;
+  zoneId: string | null;
+  name: string;
+  turfs: TurfRow[];
+};
+
+// A group's turfs on a map — geometry, number badges, and building
+// dots, colored by the app palette in row order. Scoped to one
+// (campaign, region) by construction, so overlapping campaigns can't
+// collide here the way they can in the full map view.
+function ZoneMapDialog({
+  group,
+  open,
+  onOpenChange,
+}: {
+  group: ZoneMapGroup | null;
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+}) {
+  const isDark = useAtomValue(darkAtom);
+  const { data: zoneData } = useQuery({
+    ...zoneMapDataQuery(group?.campaignId ?? "", group?.zoneId ?? null),
+    enabled: group !== null,
+  });
+
+  const { shapes, labels, bounds, points, pointColors } = useMemo(() => {
+    const turfs = group?.turfs ?? [];
+    const geometryByTurf = new Map((zoneData ?? []).map((g) => [g.turfId, g.geometry]));
+    const shapeFeatures: Feature[] = [];
+    const labelFeatures: Feature[] = [];
+    turfs.forEach((t, i) => {
+      const geometry = geometryByTurf.get(t.turfId);
+      if (!geometry) return;
+      // Index-based palette assignment, so a turf keeps the color the
+      // cutter's point clouds gave it while it was drawn.
+      const feature: Feature = {
+        type: "Feature",
+        geometry,
+        properties: {
+          zoneId: t.turfId,
+          color: colorFor(i),
+          // Solid same-hue outline; the fill stays light enough that
+          // the dots read on top of it — the dots carry the density
+          // now, the fill just claims area.
+          lineColor: colorFor(i),
+          opacity: 0.4,
+        },
+      };
+      shapeFeatures.push(feature);
+      labelFeatures.push(labelPoint(feature, turfLabel(t.name)));
+    });
+    const bounds = bboxOfFeatures(shapeFeatures);
+
+    // Building dots: the turf's hue mixed toward a theme-contrast
+    // base. Dots this small are mostly anti-aliased rim, so pure
+    // palette colors read inconsistently (light hues wash out against
+    // the basemap); the base anchor keeps contrast even across turfs.
+    // One merged buffer for the whole zone.
+    const HUE_SHARE = 0.7;
+    const base = isDark ? 229 : 26; // matches the points layer's theme default
+    let points: { deltas: Float32Array; origin: [number, number] } | null = null;
+    let pointColors: Uint8Array | null = null;
+    if (zoneData && bounds) {
+      const coordsByTurf = new Map(zoneData.map((r) => [r.turfId, r.buildingCoords ?? []]));
+      let total = 0;
+      for (const t of turfs) total += (coordsByTurf.get(t.turfId) ?? []).length;
+      const origin: [number, number] = [
+        mercatorX((bounds[0] + bounds[2]) / 2),
+        mercatorY((bounds[1] + bounds[3]) / 2),
+      ];
+      const deltas = new Float32Array(total * 2);
+      const colors = new Uint8Array(total * 3);
+      let k = 0;
+      turfs.forEach((t, i) => {
+        const [r, g, b] = parseHexRgb(colorFor(i)).map((c) =>
+          Math.round(base + (c - base) * HUE_SHARE),
+        ) as [number, number, number];
+        for (const [lng, lat] of coordsByTurf.get(t.turfId) ?? []) {
+          deltas[k * 2] = mercatorX(lng) - origin[0];
+          deltas[k * 2 + 1] = mercatorY(lat) - origin[1];
+          colors[k * 3] = r;
+          colors[k * 3 + 1] = g;
+          colors[k * 3 + 2] = b;
+          k += 1;
+        }
+      });
+      points = { deltas, origin };
+      pointColors = colors;
+    }
+
+    return {
+      shapes: { type: "FeatureCollection", features: shapeFeatures } as FeatureCollection,
+      labels: { type: "FeatureCollection", features: labelFeatures } as FeatureCollection,
+      bounds,
+      points,
+      pointColors,
+    };
+  }, [group, zoneData, isDark]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] md:w-[720px] md:max-w-[720px]">
+        {group ? (
+          <>
+            <DialogTitle className="text-sm font-normal tracking-normal text-foreground italic">
+              {group.name}
+            </DialogTitle>
+            <DialogCloseX />
+            <MapView
+              className="h-[65dvh] md:h-[60vh]"
+              zonePerimeters={shapes}
+              shapeLabels={labels}
+              points={points}
+              pointColors={pointColors}
+              fitBounds={bounds}
+              loading={!zoneData}
+            />
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// One turf on its own — boundary plus building dots, the view a lead
+// wants at hand-off ("this is what you're walking"). Buildings come
+// from the slim coordinates-only projection on the turf row and ride
+// the shared WebGL points channel.
+function TurfMapDialog({
+  turf,
+  open,
+  onOpenChange,
+}: {
+  turf: TurfRow | null;
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+}) {
+  const { data } = useQuery({
+    ...turfMapDataQuery(turf?.turfId ?? ""),
+    enabled: turf !== null,
+  });
+
+  const { shapes, points, bounds } = useMemo(() => {
+    if (!turf || !data?.geometry) {
+      return { shapes: undefined, points: null, bounds: null };
+    }
+    // Neutral fill (no `color` property falls through to the layer's
+    // theme gray), heavier outline via the selected-zone state.
+    const feature: Feature = {
+      type: "Feature",
+      geometry: data.geometry,
+      properties: { zoneId: turf.turfId, opacity: 0.2 },
+    };
+    const b = bboxOfFeatures([feature]);
+    // fp64 origin at the bbox center + fp32 deltas — the same split the
+    // segment/campaign point buffers use, computed client-side since a
+    // single turf is at most a few hundred buildings.
+    const origin: [number, number] = b
+      ? [mercatorX((b[0] + b[2]) / 2), mercatorY((b[1] + b[3]) / 2)]
+      : [0, 0];
+    const coords = data.buildingCoords ?? [];
+    const deltas = new Float32Array(coords.length * 2);
+    coords.forEach(([lng, lat], i) => {
+      deltas[i * 2] = mercatorX(lng) - origin[0];
+      deltas[i * 2 + 1] = mercatorY(lat) - origin[1];
+    });
+    return {
+      shapes: { type: "FeatureCollection", features: [feature] } as FeatureCollection,
+      points: { deltas, origin },
+      bounds: b,
+    };
+  }, [data, turf]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] md:w-[720px] md:max-w-[720px]">
+        {turf ? (
+          <>
+            <DialogTitle className="text-sm font-normal tracking-normal text-foreground italic tabular-nums">
+              Turf {turfLabel(turf.name)}
+              {regionName(turf) ? ` — ${regionName(turf)}` : ""}
+            </DialogTitle>
+            <DialogCloseX />
+            <MapView
+              className="h-[65dvh] md:h-[60vh]"
+              zonePerimeters={shapes}
+              points={points}
+              fitBounds={bounds}
+              loading={!data}
+              selectedZoneId={turf.turfId}
+            />
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// Web Mercator lng/lat → [0,1]² — must match PointsLayer's transform.
+function mercatorX(lng: number) {
+  return (lng + 180) / 360;
+}
+function mercatorY(lat: number) {
+  return 0.5 - Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI) / 360)) / (2 * Math.PI);
+}
+
 function WalksDialog({
   turf,
   campaignId,
@@ -721,10 +1041,14 @@ function TurfCards({
   campaignId,
   zoneId,
   onShowQr,
+  onShowZoneMap,
+  onShowTurfMap,
 }: {
   campaignId: string | null;
   zoneId: string | null;
   onShowQr: (turf: TurfRow) => void;
+  onShowZoneMap: (turf: TurfRow) => void;
+  onShowTurfMap: (turf: TurfRow) => void;
 }) {
   const { session } = Route.useRouteContext();
   const tz = session?.user.displayTimezone ?? DEFAULT_DISPLAY_TIMEZONE;
@@ -743,7 +1067,7 @@ function TurfCards({
     <div className="flex flex-col gap-6 pb-8">
       {groupRows(rows).map((group) => (
         <div key={group.key} className="flex flex-col gap-3">
-          {group.name ? <p className="text-muted-foreground leading-5">{group.name}</p> : null}
+          {group.name ? <GroupHeader group={group} onShowZoneMap={onShowZoneMap} /> : null}
           {group.rows.map((t) => (
             <TurfCard
               key={t.turfId}
@@ -752,6 +1076,7 @@ function TurfCards({
               pct={progressPct(progressByTurf.get(t.turfId), t.personCount)}
               tz={tz}
               onShowQr={onShowQr}
+              onShowTurfMap={onShowTurfMap}
             />
           ))}
         </div>
@@ -769,12 +1094,14 @@ function TurfCard({
   pct,
   tz,
   onShowQr,
+  onShowTurfMap,
 }: {
   turf: TurfRow;
   summary: WalkSummary;
   pct: number | null;
   tz: string;
   onShowQr: (turf: TurfRow) => void;
+  onShowTurfMap: (turf: TurfRow) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const { pending } = summary;
@@ -814,7 +1141,7 @@ function TurfCard({
           </span>
           <span className={cn(badge, "bg-muted font-mono tabular-nums")}>
             <DoorClosed className="size-3.5" />
-            {turf.doorCount != null ? turf.doorCount.toLocaleString() : "—"}
+            {doorLabel(turf.doorCount)}
           </span>
           {pct !== null ? (
             <span
@@ -848,6 +1175,19 @@ function TurfCard({
           {turf.turfCode ?? "—"}
         </span>
         <span className="flex-1" />
+        {/* Row-level map: just this turf — boundary + building dots —
+            so a lead deep in the list can see the turf they're about
+            to hand out. The zone-level map lives on the group header. */}
+        <Button
+          variant="outline"
+          onClick={(e) => {
+            e.stopPropagation();
+            onShowTurfMap(turf);
+          }}
+        >
+          <MapIcon className="size-3.5" />
+          Map
+        </Button>
         <Button
           variant="outline"
           disabled={!turf.turfCode || turf.status !== "active"}
@@ -880,11 +1220,15 @@ function CompactList({
   zoneId,
   onShowQr,
   onShowWalks,
+  onShowZoneMap,
+  onShowTurfMap,
 }: {
   campaignId: string | null;
   zoneId: string | null;
   onShowQr: (turf: TurfRow) => void;
   onShowWalks: (turf: TurfRow) => void;
+  onShowZoneMap: (turf: TurfRow) => void;
+  onShowTurfMap: (turf: TurfRow) => void;
 }) {
   const rows = useTurfRows(campaignId, zoneId);
   const summaries = useWalkSummaries(campaignId);
@@ -902,7 +1246,9 @@ function CompactList({
     <div className="flex flex-col gap-5 pb-8">
       {groupRows(rows).map((group) => (
         <div key={group.key} className="flex flex-col gap-1">
-          {group.name ? <p className="mb-2 text-muted-foreground leading-5">{group.name}</p> : null}
+          {group.name ? (
+            <GroupHeader group={group} onShowZoneMap={onShowZoneMap} className="mb-2" />
+          ) : null}
           {group.rows.map((t) => {
             const summary = summaries(t.turfId);
             const pct = progressPct(progressByTurf.get(t.turfId), t.personCount);
@@ -911,10 +1257,22 @@ function CompactList({
                 <span className={cn(cell, "w-9 bg-muted font-mono font-semibold tabular-nums")}>
                   {turfLabel(t.name)}
                 </span>
+                {/* px-0 on the icon-only flex buttons: the padding is
+                    invisible under justify-center but sets each
+                    button's shrink floor — with three of them, default
+                    padding overflows 360–375px viewports. */}
+                <Button
+                  variant="outline"
+                  aria-label="Map"
+                  className="min-w-0 flex-1 px-0"
+                  onClick={() => onShowTurfMap(t)}
+                >
+                  <MapIcon className="size-3.5" />
+                </Button>
                 <Button
                   variant="outline"
                   aria-label="Scan"
-                  className="min-w-0 flex-1"
+                  className="min-w-0 flex-1 px-0"
                   disabled={!t.turfCode || t.status !== "active"}
                   onClick={() => onShowQr(t)}
                 >
@@ -935,7 +1293,7 @@ function CompactList({
                   )}
                 >
                   <DoorClosed className="size-3.5 shrink-0" />
-                  {t.doorCount != null ? t.doorCount.toLocaleString() : "—"}
+                  {doorLabel(t.doorCount)}
                 </span>
                 <span
                   className={cn(
@@ -950,7 +1308,7 @@ function CompactList({
                 <Button
                   variant="outline"
                   aria-label="Canvassers"
-                  className="min-w-0 flex-1"
+                  className="min-w-0 flex-1 px-0"
                   disabled={summary.walks.length === 0}
                   onClick={() => onShowWalks(t)}
                 >
@@ -991,11 +1349,15 @@ function TurfsTable({
   zoneId,
   onShowQr,
   onShowWalks,
+  onShowZoneMap,
+  onShowTurfMap,
 }: {
   campaignId: string | null;
   zoneId: string | null;
   onShowQr: (turf: TurfRow) => void;
   onShowWalks: (turf: TurfRow) => void;
+  onShowZoneMap: (turf: TurfRow) => void;
+  onShowTurfMap: (turf: TurfRow) => void;
 }) {
   const { session } = Route.useRouteContext();
   const tz = session?.user.displayTimezone ?? DEFAULT_DISPLAY_TIMEZONE;
@@ -1007,7 +1369,7 @@ function TurfsTable({
     <Table containerClassName="h-[calc(100vh-9rem)] overflow-y-auto" className="table-fixed">
       <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-background">
         <TableRow>
-          <TableHead className="w-14">Turf</TableHead>
+          <TableHead className="w-20">Turf</TableHead>
           <TableHead className="w-30">Code</TableHead>
           <TableHead className="w-24">Walked</TableHead>
           <TableHead className="w-16">Status</TableHead>
@@ -1035,9 +1397,16 @@ function TurfsTable({
           return (
             <TableRow key={t.turfId}>
               <TableCell>
-                <Pill variant="number" className="font-semibold">
-                  {turfLabel(t.name)}
-                </Pill>
+                {/* Single-turf map (boundary + building dots); the Zone
+                    cell covers the zone-in-context view. */}
+                <Button
+                  variant="outline"
+                  className="w-full justify-start"
+                  onClick={() => onShowTurfMap(t)}
+                >
+                  <MapIcon className="size-3.5 shrink-0" />
+                  <span className="font-mono tabular-nums">{turfLabel(t.name)}</span>
+                </Button>
               </TableCell>
               <TableCell>
                 <Button
@@ -1065,7 +1434,7 @@ function TurfsTable({
               <TableCell>
                 <Pill variant="number" className="gap-1.5">
                   <DoorClosed className="size-3.5 shrink-0 text-foreground" />
-                  {t.doorCount != null ? t.doorCount.toLocaleString() : "—"}
+                  {doorLabel(t.doorCount)}
                 </Pill>
               </TableCell>
               <TableCell>
@@ -1083,9 +1452,20 @@ function TurfsTable({
                 </Button>
               </TableCell>
               <TableCell>
-                <Pill className="min-w-0">
-                  <span className="truncate">{regionName(t) ?? "—"}</span>
-                </Pill>
+                {regionName(t) ? (
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start"
+                    onClick={() => onShowZoneMap(t)}
+                  >
+                    <MapIcon className="size-3.5 shrink-0" />
+                    <span className="min-w-0 truncate">{regionName(t)}</span>
+                  </Button>
+                ) : (
+                  <Pill className="min-w-0">
+                    <span className="truncate">—</span>
+                  </Pill>
+                )}
               </TableCell>
               <TableCell>
                 <Pill className="min-w-0">

--- a/apps/web/src/rpc/index.ts
+++ b/apps/web/src/rpc/index.ts
@@ -96,6 +96,8 @@ export const webRouter = {
   },
   turfs: {
     listForOrg: webTurfs.listForOrg,
+    turfMapData: webTurfs.turfMapData,
+    zoneMapData: webTurfs.zoneMapData,
     statsForCampaign: webTurfs.statsForCampaign,
     publish: webTurfs.publish,
   },

--- a/apps/web/src/rpc/web/turfs.ts
+++ b/apps/web/src/rpc/web/turfs.ts
@@ -52,6 +52,45 @@ export const listForOrg = pub
     return rows;
   });
 
+// One turf's map payload: polygon + building coordinates, straight off
+// the turf row's slim publish-time projection — the full turf_data
+// payload is never touched on this hot path.
+export const turfMapData = pub
+  .input(z.object({ turfId: z.string().uuid() }))
+  .handler(async ({ context, input }) => {
+    const rows = await context.db
+      .select({ geometry: turfs.geometry, buildingCoords: turfs.buildingCoords })
+      .from(turfs)
+      .innerJoin(campaigns, eq(turfs.campaignId, campaigns.campaignId))
+      .where(
+        and(eq(turfs.turfId, input.turfId), eq(campaigns.organizationId, context.organizationId)),
+      );
+    return rows[0] ?? null;
+  });
+
+// Every turf's polygon + building coordinates for one (campaign, zone)
+// — the zone map's payload. `zoneId: null` covers zoneless campaigns,
+// whose turfs cut against the whole segment.
+export const zoneMapData = pub
+  .input(z.object({ campaignId: z.string().uuid(), zoneId: z.string().uuid().nullable() }))
+  .handler(async ({ context, input }) => {
+    return context.db
+      .select({
+        turfId: turfs.turfId,
+        geometry: turfs.geometry,
+        buildingCoords: turfs.buildingCoords,
+      })
+      .from(turfs)
+      .innerJoin(campaigns, eq(turfs.campaignId, campaigns.campaignId))
+      .where(
+        and(
+          eq(campaigns.organizationId, context.organizationId),
+          eq(turfs.campaignId, input.campaignId),
+          input.zoneId ? eq(turfs.zoneId, input.zoneId) : isNull(turfs.zoneId),
+        ),
+      );
+  });
+
 // Per-zone turf counts for a campaign — drafts (work-in-progress in the
 // cutter) and published (rows in `turfs`). Drives the campaign editor's
 // at-a-glance progress indicators.

--- a/packages/db/src/schema/turfs.ts
+++ b/packages/db/src/schema/turfs.ts
@@ -75,6 +75,9 @@ export const turfs = app.table(
     criteria: jsonb(),
     status: text().$type<TurfStatus>().notNull().default("active"),
     geometry: jsonb().$type<GeoJsonPolygon>(),
+    // [lng, lat] per building — slim publish-time projection so map
+    // reads never detoast the full turf_data payload.
+    buildingCoords: jsonb().$type<[number, number][]>(),
     doorCount: integer(),
     personCount: integer(),
     createdBy: uuid()


### PR DESCRIPTION
This PR adds maps to the turf list view, making it easier for a Field Lead (or similar) see where turfs are located. There are two maps: a zone level map, and an individual turf level map. Each has a dedicated RPC endpoint to load the necessary boundaries and points data, and otherwise just required some minor tweaks to the shared `Map` component to render labels. Because these maps render building coordinates, which are stored with turf data but require extracting from JSON, we store a copy of just the building coordinates for each published turf as one new column `turfs.buildingCoords` (maps will be rendered frequently and repeatedly so it's a trivially cheap and useful perf win).

As part of this work, identified and fixed a bug that was going maps in `web` to refresh unnecessarily.