### PR TITLE
feat: progress tracker and standalone progress modal

### DIFF
--- a/apps/native/src/app/_layout.tsx
+++ b/apps/native/src/app/_layout.tsx
@@ -48,7 +48,7 @@ function GlobalMenuButton() {
   // close controls (same spot) — yield to them there.
   if (
     Platform.OS === "android" &&
-    ["/settings", "/canvasser", "/scan", "/share"].includes(pathname)
+    ["/settings", "/canvasser", "/scan", "/share", "/progress"].includes(pathname)
   ) {
     return null;
   }
@@ -132,6 +132,14 @@ function ThemedStack() {
         />
         <Stack.Screen
           name="share"
+          options={{
+            headerShown: false,
+            presentation: "modal",
+            contentStyle: { backgroundColor: isDark ? "#0a0a0a" : "#fcfcfc" },
+          }}
+        />
+        <Stack.Screen
+          name="progress"
           options={{
             headerShown: false,
             presentation: "modal",

--- a/apps/native/src/app/progress.tsx
+++ b/apps/native/src/app/progress.tsx
@@ -1,0 +1,230 @@
+import { router } from "expo-router";
+import { useAtomValue } from "jotai";
+import { X } from "lucide-react-native";
+import { Fragment, useMemo } from "react";
+import { Platform, Pressable, ScrollView, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useQuery } from "@tanstack/react-query";
+import { activeTurfAtom } from "@/lib/atoms/active-turf";
+import { themeAtom } from "@/lib/atoms/theme";
+import { derivePersonSummaries, useCanvassEvents } from "@/lib/canvass-events";
+import { useColors } from "@/lib/colors";
+import { deriveResponseTallies, deriveTurfProgress } from "@/lib/progress";
+import { useTurf } from "@/lib/turf-data";
+import { client } from "@/rpc/client";
+import { Pill } from "@/components/pill";
+
+// Progress modal — the active turf's completion breakdown: people and
+// doors counts, results by outcome, and per-question response tallies.
+export default function ProgressScreen() {
+  const insets = useSafeAreaInsets();
+  const isDark = useAtomValue(themeAtom) === "dark";
+  const activeTurf = useAtomValue(activeTurfAtom);
+
+  // The title row and the X share this offset so they stay vertically
+  // aligned regardless of device inset. iOS's deep top inset lets the
+  // control tuck up beside the notch; Android's slim status bar needs it
+  // pushed below instead.
+  const closeTop = Platform.OS === "android" ? insets.top + 12 : Math.max(insets.top - 41, 12);
+
+  return (
+    <View className="flex-1 bg-background dark:bg-background-dark">
+      {/* X close button (matches Settings) */}
+      <Pressable
+        onPress={() => router.back()}
+        hitSlop={4}
+        className="absolute z-10 items-center justify-center w-12 h-12 rounded-full bg-surface dark:bg-surface-dark active:opacity-60"
+        style={{
+          top: closeTop,
+          right: 22,
+          shadowColor: "#000",
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.15,
+          shadowRadius: 6,
+          elevation: 4,
+        }}
+      >
+        <X size={20} color={isDark ? "#ededed" : "#1b1b1b"} strokeWidth={2} />
+      </Pressable>
+
+      <View className="flex-1" style={{ paddingTop: closeTop }}>
+        {/* Same height as the X so the title centers on it. */}
+        <View className="h-12 justify-center">
+          <Text
+            className="self-center text-3xl transform -skew-x-12 text-foreground dark:text-foreground-dark"
+            style={{
+              fontFamily: Platform.OS === "android" ? "Geist_700Bold_Italic" : "Geist_700Bold",
+            }}
+          >
+            Progress
+          </Text>
+        </View>
+
+        {activeTurf ? (
+          <ProgressContent turfId={activeTurf.turfId} bottomInset={insets.bottom} />
+        ) : (
+          <Text
+            className="mt-6 text-center text-xl text-muted-foreground dark:text-muted-foreground-dark"
+            style={{ fontFamily: "Geist_400Regular" }}
+          >
+            No active turf
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+// Separate component so the event-log hooks only mount when a turf is
+// active.
+function ProgressContent({ turfId, bottomInset }: { turfId: string; bottomInset: number }) {
+  const events = useCanvassEvents(turfId);
+  const summaries = useMemo(() => derivePersonSummaries(events), [events]);
+  const { meta, indexes } = useTurf(turfId);
+  const scriptId = meta?.scriptId;
+  const scriptQuery = useQuery({
+    queryKey: ["script", scriptId] as const,
+    queryFn: () => client.scripts.get({ scriptId: scriptId! }),
+    enabled: !!scriptId,
+    staleTime: Infinity,
+  });
+
+  const progress = useMemo(
+    () => (indexes ? deriveTurfProgress(indexes, summaries) : null),
+    [indexes, summaries],
+  );
+  const tallies = useMemo(
+    () => (scriptQuery.data ? deriveResponseTallies(scriptQuery.data.steps, summaries) : []),
+    [scriptQuery.data, summaries],
+  );
+
+  if (!progress) return null;
+
+  return (
+    <ScrollView
+      contentContainerStyle={{
+        paddingTop: 24,
+        paddingHorizontal: 24,
+        paddingBottom: bottomInset + 20,
+      }}
+    >
+      <SectionHeader first>Overall</SectionHeader>
+      <StatRow label="People" done={progress.people.done} total={progress.people.total} />
+      <StatRow label="Doors" done={progress.doors.done} total={progress.doors.total} />
+
+      <SectionHeader>Results</SectionHeader>
+      {progress.outcomes.length === 0 ? (
+        <Text className="py-2 font-sans text-xl text-muted-foreground dark:text-muted-foreground-dark">
+          No results yet
+        </Text>
+      ) : (
+        progress.outcomes.map((outcome) => (
+          <TallyRow
+            key={outcome.value}
+            label={outcome.label}
+            count={outcome.count}
+            percent={outcome.percent}
+            role={outcome.value === "canvassed" ? "contacted" : "unavailable"}
+          />
+        ))
+      )}
+
+      {tallies.length > 0 && (
+        <>
+          <SectionHeader>Responses</SectionHeader>
+          {tallies.map((question, idx) => (
+            <Fragment key={question.questionId}>
+              {idx > 0 && <View className="h-px bg-border dark:bg-border-dark my-2" />}
+              <View className="mb-1">
+                <Text className="py-1 font-sans text-xl text-foreground dark:text-foreground-dark">
+                  {question.text}
+                </Text>
+                {question.options.map((option) => (
+                  <TallyRow
+                    key={option.responseOptionId}
+                    label={option.text}
+                    count={option.count}
+                    percent={option.percent}
+                  />
+                ))}
+              </View>
+            </Fragment>
+          ))}
+        </>
+      )}
+    </ScrollView>
+  );
+}
+
+function SectionHeader({ children, first }: { children: string; first?: boolean }) {
+  return (
+    <Text
+      className={`mb-2 text-xl text-foreground dark:text-foreground-dark ${first ? "" : "mt-6"}`}
+      style={{ fontFamily: "Geist_700Bold" }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+function StatRow({ label, done, total }: { label: string; done: number; total: number }) {
+  const percent = total > 0 ? Math.min(100, Math.round((100 * done) / total)) : 0;
+  return (
+    <View className="flex-row items-center py-2">
+      <Text className="flex-1 font-sans text-xl text-foreground dark:text-foreground-dark">
+        {label}
+      </Text>
+      <Text
+        className="mr-3 font-sans text-xl text-muted-foreground dark:text-muted-foreground-dark"
+        style={{ fontVariant: ["tabular-nums"] }}
+      >
+        {done}/{total}
+      </Text>
+      <PercentPill percent={percent} />
+    </View>
+  );
+}
+
+function TallyRow({
+  label,
+  count,
+  percent,
+  role,
+}: {
+  label: string;
+  count: number;
+  percent: number;
+  role?: "contacted" | "unavailable";
+}) {
+  return (
+    <View className="flex-row items-center py-1.5">
+      <Text
+        className="flex-1 font-sans text-xl text-foreground dark:text-foreground-dark"
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+      <Text
+        className="mr-3 font-sans text-xl text-muted-foreground dark:text-muted-foreground-dark"
+        style={{ fontVariant: ["tabular-nums"] }}
+      >
+        {count}
+      </Text>
+      <PercentPill percent={percent} role={role} />
+    </View>
+  );
+}
+
+// Fixed-width wrapper keeps the pills right-aligned down the list; wide
+// enough for a three-digit "100%".
+function PercentPill({ percent, role }: { percent: number; role?: "contacted" | "unavailable" }) {
+  const colors = useColors();
+  const variant = role ? colors[role] : null;
+  return (
+    <View style={{ width: 72, alignItems: "flex-end" }}>
+      <Pill style={variant ? { backgroundColor: variant.background } : undefined}>
+        <Text style={variant ? { color: variant.foreground } : null}>{percent}%</Text>
+      </Pill>
+    </View>
+  );
+}

--- a/apps/native/src/app/settings.tsx
+++ b/apps/native/src/app/settings.tsx
@@ -454,7 +454,7 @@ function SyncStatusLine({
     pendingCount > 0
       ? `${pendingCount} ${pendingCount === 1 ? "result" : "results"} pending`
       : null,
-    progress != null ? `Turf progress ${progress}%` : null,
+    progress != null ? `Turf progress: ${progress}%` : null,
   ].filter((line): line is string => line != null);
   return (
     <View className="items-center gap-0.5" style={{ minHeight: 84 }}>

--- a/apps/native/src/app/turfs/[turfId]/index.tsx
+++ b/apps/native/src/app/turfs/[turfId]/index.tsx
@@ -109,6 +109,7 @@ export default function TurfListScreen() {
   useScreenNav({
     title: turfTitle,
     showBack: false,
+    progressTurfId: turfId,
     bottomButtons: ["search", "list", "next", "mic"],
     onBottomPress: (action) => {
       if (action === "list") {

--- a/apps/native/src/components/progress.tsx
+++ b/apps/native/src/components/progress.tsx
@@ -1,0 +1,105 @@
+import { router } from "expo-router";
+import { useAtomValue } from "jotai";
+import { useMemo } from "react";
+import { Pressable, Text } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+import { themeAtom } from "@/lib/atoms/theme";
+import { derivePersonSummaries, useCanvassEvents } from "@/lib/canvass-events";
+import { useColors } from "@/lib/colors";
+import { deriveTurfProgress } from "@/lib/progress";
+import { useTurf } from "@/lib/turf-data";
+
+const SIZE = 48;
+const STROKE = 3;
+// Inset the ring a hair so it doesn't clip at the button edge.
+const RADIUS = (SIZE - STROKE) / 2 - 1;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+const SHADOW = {
+  shadowColor: "#000",
+  shadowOffset: { width: 0, height: 2 },
+  shadowOpacity: 0.15,
+  shadowRadius: 6,
+  elevation: 4,
+};
+
+// Turf progress chrome button: percent-marked number inside a two-segment
+// ring (contacted + unavailable, matching the map dot colors), in the
+// top-nav slot where back would be. Tapping opens the Progress modal.
+export function ProgressButton({ turfId }: { turfId: string }) {
+  const isDark = useAtomValue(themeAtom) === "dark";
+  const colors = useColors();
+
+  const events = useCanvassEvents(turfId);
+  const summaries = useMemo(() => derivePersonSummaries(events), [events]);
+  const { indexes } = useTurf(turfId);
+  const progress = useMemo(
+    () => (indexes ? deriveTurfProgress(indexes, summaries) : null),
+    [indexes, summaries],
+  );
+  if (!progress) return null;
+
+  const percent = progress.percent;
+  const total = progress.people.total;
+  const contactedFrac = total > 0 ? progress.people.contacted / total : 0;
+  const unavailableFrac =
+    total > 0 ? (progress.people.done - progress.people.contacted) / total : 0;
+
+  return (
+    <Pressable
+      onPress={() => router.push("/progress")}
+      hitSlop={4}
+      className="items-center justify-center w-12 h-12 rounded-full bg-surface dark:bg-surface-dark active:opacity-60"
+      style={SHADOW}
+    >
+      <Svg width={SIZE} height={SIZE} style={{ position: "absolute" }}>
+        <Circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          stroke={isDark ? "#333333" : "#e5e5e5"}
+          strokeWidth={STROKE}
+          fill="none"
+        />
+        {contactedFrac > 0 && (
+          <Circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            stroke={colors.contacted.solid}
+            strokeWidth={STROKE}
+            fill="none"
+            strokeDasharray={`${CIRCUMFERENCE * contactedFrac} ${CIRCUMFERENCE}`}
+            transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+          />
+        )}
+        {unavailableFrac > 0 && (
+          <Circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            stroke={colors.unavailable.solid}
+            strokeWidth={STROKE}
+            fill="none"
+            strokeDasharray={`${CIRCUMFERENCE * unavailableFrac} ${CIRCUMFERENCE}`}
+            transform={`rotate(${-90 + 360 * contactedFrac} ${SIZE / 2} ${SIZE / 2})`}
+          />
+        )}
+      </Svg>
+      <Text
+        className="text-foreground dark:text-foreground-dark"
+        style={{
+          fontFamily: "Geist_700Bold",
+          // Three digits + % need a smaller face to clear the ring.
+          fontSize: percent === 100 ? 11 : 13,
+          fontVariant: ["tabular-nums"],
+          // The trailing % reads lighter than the digits, dragging the
+          // optical center left — nudge right to compensate.
+          transform: [{ translateX: 1 }],
+        }}
+      >
+        {percent}%
+      </Text>
+    </Pressable>
+  );
+}

--- a/apps/native/src/components/top-nav.tsx
+++ b/apps/native/src/components/top-nav.tsx
@@ -2,6 +2,7 @@ import { router } from "expo-router";
 import { ChevronLeft } from "lucide-react-native";
 import { Platform, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ProgressButton } from "@/components/progress";
 
 const ICON_SIZE = 20;
 const SHADOW = {
@@ -18,12 +19,21 @@ type Props = {
   // first, so a long street ellipsizes while the unit stays visible.
   titleSuffix?: string | null;
   showBack: boolean;
+  // Turf progress button in the left slot when back is off.
+  progressTurfId?: string | null;
   // "minimal" hides the title and border (used on the map/list screen).
   variant?: "default" | "minimal";
   isDark: boolean;
 };
 
-export function TopNav({ title, titleSuffix, showBack, variant = "default", isDark }: Props) {
+export function TopNav({
+  title,
+  titleSuffix,
+  showBack,
+  progressTurfId,
+  variant = "default",
+  isDark,
+}: Props) {
   const insets = useSafeAreaInsets();
   const isMinimal = variant === "minimal";
 
@@ -43,7 +53,7 @@ export function TopNav({ title, titleSuffix, showBack, variant = "default", isDa
       >
         {/* Left: back button (h-11 always to keep consistent height) */}
         <View className="w-12 h-12">
-          {showBack && (
+          {showBack ? (
             <Pressable
               onPress={() => router.back()}
               hitSlop={4}
@@ -56,7 +66,9 @@ export function TopNav({ title, titleSuffix, showBack, variant = "default", isDa
                 strokeWidth={2}
               />
             </Pressable>
-          )}
+          ) : progressTurfId ? (
+            <ProgressButton turfId={progressTurfId} />
+          ) : null}
         </View>
 
         {/* Center: title */}

--- a/apps/native/src/lib/colors.ts
+++ b/apps/native/src/lib/colors.ts
@@ -5,12 +5,15 @@
 // Shades:
 //   background — fill color used for badge backgrounds and map dots.
 //   foreground — deep text/icon color paired with `background`.
+//   solid      — saturated mid-tone for standalone marks (thin strokes,
+//                progress ring segments) that must hold their hue at small
+//                sizes against the surface color.
 
 import { useAtomValue } from "jotai";
 import { themeAtom } from "@/lib/atoms/theme";
 
 type Role = "contacted" | "unavailable";
-type Variant = { background: string; foreground: string };
+type Variant = { background: string; foreground: string; solid: string };
 type Themed = { light: Variant; dark: Variant };
 
 export const colors: Record<Role, Themed> = {
@@ -18,20 +21,24 @@ export const colors: Record<Role, Themed> = {
     light: {
       background: "#f5d0fe", // fuscia 200
       foreground: "#86198f", // fuscia 800
+      solid: "#e879f9", // fuscia 400
     },
     dark: {
       background: "#5D0F61", // fuschia 925
       foreground: "#F2BEFD", // fuscia 250
+      solid: "#c026d3", // fuscia 600
     },
   },
   unavailable: {
     light: {
       background: "#fed7aa", // orange 200
       foreground: "#9a3412", // orange 800
+      solid: "#fb923c", // orange 400
     },
     dark: {
       background: "#5F2009", // orange 925
       foreground: "#FED4A4", // orange 250
+      solid: "#ea580c", // orange 600
     },
   },
 };

--- a/apps/native/src/lib/nav-context.tsx
+++ b/apps/native/src/lib/nav-context.tsx
@@ -22,6 +22,8 @@ type TopNavConfig = {
   title: string;
   titleSuffix: string | null;
   showBack: boolean;
+  // Renders the turf progress button in the left slot (back must be off).
+  progressTurfId: string | null;
   variant: TopNavVariant;
 };
 
@@ -53,6 +55,7 @@ export function NavProvider({ children }: { children: ReactNode }) {
             title={topConfig.title}
             titleSuffix={topConfig.titleSuffix}
             showBack={topConfig.showBack}
+            progressTurfId={topConfig.progressTurfId}
             variant={topConfig.variant}
             isDark={isDark}
           />
@@ -75,6 +78,7 @@ export function useScreenNav(options: {
   title: string;
   titleSuffix?: string | null;
   showBack?: boolean;
+  progressTurfId?: string;
   topVariant?: TopNavVariant;
   bottomButtons: Array<ButtonAction | null>;
   onBottomPress: (action: ButtonAction) => void;
@@ -89,15 +93,22 @@ export function useScreenNav(options: {
   const titleKey = options.title;
   const titleSuffix = options.titleSuffix ?? null;
   const showBack = options.showBack ?? true;
+  const progressTurfId = options.progressTurfId ?? null;
   const variant = options.topVariant ?? "default";
 
   useFocusEffect(
     useCallback(() => {
-      ctxRef.current?.setTopConfig({ title: titleKey, titleSuffix, showBack, variant });
+      ctxRef.current?.setTopConfig({
+        title: titleKey,
+        titleSuffix,
+        showBack,
+        progressTurfId,
+        variant,
+      });
       ctxRef.current?.setBottomConfig({
         buttons: buttonsKey.split(",") as Array<ButtonAction>,
         onPress: (action) => optionsRef.current.onBottomPress(action),
       });
-    }, [buttonsKey, titleKey, titleSuffix, showBack, variant]),
+    }, [buttonsKey, titleKey, titleSuffix, showBack, progressTurfId, variant]),
   );
 }

--- a/apps/native/src/lib/progress.ts
+++ b/apps/native/src/lib/progress.ts
@@ -1,0 +1,139 @@
+import { type PersonSummary, isRecorded } from "@/lib/canvass-events";
+import type { TurfIndexes } from "@/lib/turf-data";
+
+// Labels for every outcome a result event can carry. The native UI only
+// offers a subset, but events from other clients can carry the rest.
+const OUTCOME_LABELS: Record<string, string> = {
+  canvassed: "Canvassed",
+  not_home: "Not home",
+  deceased: "Deceased",
+  hostile: "Hostile",
+  moved: "Moved",
+  address_not_found: "Address not found",
+  inaccessible: "Inaccessible",
+};
+
+export type TurfProgress = {
+  // Headline number: people marked / total, 0-100.
+  percent: number;
+  // `contacted` (canvassed) vs the rest of `done` drives the two ring segments.
+  people: { done: number; total: number; contacted: number };
+  doors: { done: number; total: number };
+  // Nonzero outcome tallies in display order; percent is the share of
+  // marked people, so the breakdown sums to ~100%.
+  outcomes: Array<{ value: string; label: string; count: number; percent: number }>;
+};
+
+export function deriveTurfProgress(
+  indexes: TurfIndexes,
+  summaries: Map<string, PersonSummary>,
+): TurfProgress {
+  const persons = indexes.personsInOrder;
+  const peopleDone = persons.filter((p) => isRecorded(summaries, p.personId)).length;
+
+  // A door is done when every resident is marked — same rule as the
+  // building-complete alerts. Doors with no residents can't be recorded
+  // against, so they're excluded from the denominator.
+  let doorsDone = 0;
+  let doorsTotal = 0;
+  for (const door of indexes.doorsById.values()) {
+    if (door.persons.length === 0) continue;
+    doorsTotal += 1;
+    if (door.persons.every((p) => isRecorded(summaries, p.personId))) doorsDone += 1;
+  }
+
+  // The summary collapses outcome "canvassed" to null, so a person with
+  // no unavailable outcome but recorded responses counts as canvassed.
+  const counts = new Map<string, number>();
+  for (const person of persons) {
+    const summary = summaries.get(person.personId);
+    if (!summary) continue;
+    const outcome =
+      summary.currentOutcome ?? (summary.responsesByQuestion.size > 0 ? "canvassed" : null);
+    if (!outcome) continue;
+    counts.set(outcome, (counts.get(outcome) ?? 0) + 1);
+  }
+  const known = Object.keys(OUTCOME_LABELS);
+  const outcomes = [...counts.keys()]
+    .sort((a, b) => {
+      const ai = known.indexOf(a);
+      const bi = known.indexOf(b);
+      return (ai === -1 ? known.length : ai) - (bi === -1 ? known.length : bi);
+    })
+    .map((value) => ({
+      value,
+      label: OUTCOME_LABELS[value] ?? value,
+      count: counts.get(value)!,
+      percent: peopleDone > 0 ? Math.round((100 * counts.get(value)!) / peopleDone) : 0,
+    }));
+
+  return {
+    percent:
+      persons.length > 0 ? Math.min(100, Math.round((100 * peopleDone) / persons.length)) : 0,
+    people: { done: peopleDone, total: persons.length, contacted: counts.get("canvassed") ?? 0 },
+    doors: { done: doorsDone, total: doorsTotal },
+    outcomes,
+  };
+}
+
+// Minimal structural view of the script payload — mirrors ScriptStepLike
+// on the person screen rather than importing server types.
+type ScriptStep = {
+  stepType: string;
+  questionId?: string;
+  responseType?: string;
+  text: string;
+  options?: Array<{ responseOptionId: string; text: string }>;
+};
+
+export type QuestionTally = {
+  questionId: string;
+  text: string;
+  // People with a stored response for this question.
+  answered: number;
+  // Percent is the share of answerers; multi-selects can sum past 100.
+  options: Array<{ responseOptionId: string; text: string; count: number; percent: number }>;
+};
+
+// Tally selections per option for each question step, in script order.
+// Open-ended questions are skipped — free text has no useful aggregate.
+// The current script is the only source of labels, so a person counts as
+// an answerer only when at least one of their selections is a current
+// option — answers referencing only archived options drop out of both
+// numerator and denominator, keeping percentages a share of what's shown.
+export function deriveResponseTallies(
+  steps: ScriptStep[],
+  summaries: Map<string, PersonSummary>,
+): QuestionTally[] {
+  const tallies: QuestionTally[] = [];
+  for (const step of steps) {
+    if (step.stepType !== "question" || !step.questionId) continue;
+    if (step.responseType === "open_ended") continue;
+    const validIds = new Set((step.options ?? []).map((o) => o.responseOptionId));
+    let answered = 0;
+    const counts = new Map<string, number>();
+    for (const summary of summaries.values()) {
+      const response = summary.responsesByQuestion.get(step.questionId);
+      if (!response || !("optionIds" in response)) continue;
+      const chosen = response.optionIds.filter((id) => validIds.has(id));
+      if (chosen.length === 0) continue;
+      answered += 1;
+      for (const id of chosen) counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    tallies.push({
+      questionId: step.questionId,
+      text: step.text,
+      answered,
+      options: (step.options ?? []).map((option) => {
+        const count = counts.get(option.responseOptionId) ?? 0;
+        return {
+          responseOptionId: option.responseOptionId,
+          text: option.text,
+          count,
+          percent: answered > 0 ? Math.round((100 * count) / answered) : 0,
+        };
+      }),
+    });
+  }
+  return tallies;
+}


### PR DESCRIPTION
This PR adds a more visible progress tracker in the form of a circle with a number and a "ring" indicator in the upper left on the main map/list page. Tapping it opens a modal that shows some useful progress stats, including a breakdown of response types and also script question answers.