### PR TITLE
fix: cache cleanup

### DIFF
--- a/apps/web/src/lib/queries/campaigns.ts
+++ b/apps/web/src/lib/queries/campaigns.ts
@@ -4,10 +4,14 @@ import { fetchSegmentPoints, liveAwareStaleTime, type SegmentCriteria } from "./
 
 export type KeyFilter = { keyGroup: string; keys: string[] };
 
+// gcTime: Infinity — a tiny list read by chrome (the turfs-page campaign
+// filter) on cached-match revisits, where eviction would render the control
+// label-less until the refetch lands. Stale names self-correct on refetch.
 export const campaignsListQuery = () =>
   queryOptions({
     queryKey: ["campaigns"] as const,
     queryFn: () => client.campaigns.list(),
+    gcTime: Number.POSITIVE_INFINITY,
   });
 
 export const campaignDetailQuery = (campaignId: string) =>

--- a/apps/web/src/lib/settle.ts
+++ b/apps/web/src/lib/settle.ts
@@ -1,0 +1,27 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+
+// The settle invariant for server writes: every owned key gets
+// cancel → patch → evict → invalidate, in that order.
+//
+// Cancel must come first: a response that started pre-write would land after
+// the patch, overwrite it, and count as fresh for `staleTime`. The invalidate
+// below restarts in-flight fetches for *active* queries, but fetches without
+// observers (route loaders mid-navigation) are only covered by cancellation.
+//
+// `patch` owns the setQueryData/navigation choreography — some flows must
+// navigate before patching or after (see the archive handlers) — and runs
+// after cancellation. Invalidations are fire-and-forget: the patch already
+// shows the intended state; the refetch is server reconciliation.
+export async function settleMutation(
+  queryClient: QueryClient,
+  opts: {
+    keys: QueryKey[];
+    patch?: () => void | Promise<void>;
+    evict?: QueryKey[];
+  },
+): Promise<void> {
+  await Promise.all(opts.keys.map((queryKey) => queryClient.cancelQueries({ queryKey })));
+  await opts.patch?.();
+  for (const queryKey of opts.evict ?? []) queryClient.removeQueries({ queryKey });
+  for (const queryKey of opts.keys) void queryClient.invalidateQueries({ queryKey });
+}

--- a/apps/web/src/lib/use-dialog-mutation.ts
+++ b/apps/web/src/lib/use-dialog-mutation.ts
@@ -17,10 +17,9 @@ import { useCallback, useRef, useState } from "react";
 // Per-call `mutate(input, { onSuccess })` is awaited before the dialog
 // closes — that's how delete-with-fallback flows ensure their navigate(...)
 // settles before the modal disappears. The hook-level `opts.onSuccess`
-// runs fire-and-forget: its synchronous work (setQueryData, etc.) lands
-// before close, but any returned Promise (navigate, invalidate) is
-// dropped so async post-work overlaps with the close animation rather
-// than holding the dialog open through it.
+// runs fire-and-forget: its returned Promise (settleMutation, navigate) is
+// dropped so cache work overlaps with the close animation rather than
+// holding the dialog open through it.
 export function useDialogMutation<TInput, TOutput>(opts: {
   mutationFn: (input: TInput) => Promise<TOutput>;
   onSuccess?: (data: TOutput, input: TInput) => void | Promise<void>;
@@ -34,6 +33,8 @@ export function useDialogMutation<TInput, TOutput>(opts: {
   const mutation = useMutation({
     mutationFn: opts.mutationFn,
     onError: opts.onError,
+    // Errors render inline via `error` below; skip the global toast.
+    meta: { errorHandled: true },
   });
 
   type PerCallOptions = Parameters<typeof mutation.mutate>[1];

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,5 +1,6 @@
-import { hashKey, QueryClient } from "@tanstack/react-query";
+import { hashKey, MutationCache, QueryClient } from "@tanstack/react-query";
 import { createRouter, defaultStringifySearch } from "@tanstack/react-router";
+import { toast } from "sonner";
 import { routerWithQueryClient } from "@tanstack/react-router-with-query";
 import { __registerRouter } from "./lib/current-route";
 import { routeTree } from "./routeTree.gen";
@@ -33,6 +34,15 @@ export function getRouter() {
   let routerRef: RouterLike | null = null;
 
   const queryClient: QueryClient = new QueryClient({
+    // Default error surface: a mutation without its own onError (and not
+    // flagged `meta.errorHandled`, e.g. dialogs showing inline errors) gets a
+    // toast — a failed write must never be silent.
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        if (mutation.options.onError || mutation.meta?.errorHandled) return;
+        toast.error(error.message);
+      },
+    }),
     defaultOptions: {
       // 15s default — long enough that "tab away and back" hits cache,
       // short enough that "data is roughly current." Per-query overrides

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -72,6 +72,10 @@ export function getRouter() {
     // resolves; pending UI only shows past 300ms.
     defaultPendingMs: 300,
     defaultPendingMinMs: 300,
+    // Skip loader re-runs entirely while the route's data is inside the
+    // query-fresh window — a background reload that fetchQuery would
+    // satisfy from cache is pure overhead.
+    defaultStaleTime: 15_000,
     // No hover preload: our list queries are staleTime-0 so a preload never
     // saves the navigation fetch, and a preloaded index match commits before
     // its redirect — flashing the empty state.

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
@@ -594,8 +594,6 @@ function FullSegmentRow({
   turfStats: { drafts: number; published: number; active: number } | null;
   onCut: () => void;
 }) {
-  const turfCount = turfStats?.drafts ?? 0;
-  const hasPublished = (turfStats?.published ?? 0) > 0;
   return (
     <div
       className={cn(
@@ -621,22 +619,26 @@ function FullSegmentRow({
             <DoorClosed className="size-3.5 text-foreground" />
             {counts.doors.toLocaleString()}
           </Pill>
-          {hasPublished ? (
-            <Pill
-              variant="number"
-              className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100 [&_svg]:[stroke-width:2]"
-            >
-              <Send className="size-3.5 text-foreground" />
-              {(turfStats?.published ?? 0).toLocaleString()}
-            </Pill>
+          {turfStats ? (
+            <>
+              {turfStats.published > 0 ? (
+                <Pill
+                  variant="number"
+                  className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100 [&_svg]:[stroke-width:2]"
+                >
+                  <Send className="size-3.5 text-foreground" />
+                  {turfStats.published.toLocaleString()}
+                </Pill>
+              ) : null}
+              <Pill
+                variant="number"
+                className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
+              >
+                <CircleDotDashed className="size-3.5 text-foreground" />
+                {turfStats.drafts}
+              </Pill>
+            </>
           ) : null}
-          <Pill
-            variant="number"
-            className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
-          >
-            <CircleDotDashed className="size-3.5 text-foreground" />
-            {turfCount}
-          </Pill>
         </Fragment>
       ) : null}
       <Button variant="outline" className="h-[31px]" onClick={onCut}>
@@ -666,8 +668,6 @@ function ZoneRow({
   onSelect: () => void;
   onCut: () => void;
 }) {
-  const turfCount = turfStats?.drafts ?? 0;
-  const hasPublished = (turfStats?.published ?? 0) > 0;
   return (
     <div
       role="button"
@@ -705,22 +705,26 @@ function ZoneRow({
             <DoorClosed className="size-3.5 text-foreground" />
             {counts.doors.toLocaleString()}
           </Pill>
-          {hasPublished ? (
-            <Pill
-              variant="number"
-              className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100 [&_svg]:[stroke-width:2]"
-            >
-              <Send className="size-3.5 text-foreground" />
-              {(turfStats?.published ?? 0).toLocaleString()}
-            </Pill>
+          {turfStats ? (
+            <>
+              {turfStats.published > 0 ? (
+                <Pill
+                  variant="number"
+                  className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100 [&_svg]:[stroke-width:2]"
+                >
+                  <Send className="size-3.5 text-foreground" />
+                  {turfStats.published.toLocaleString()}
+                </Pill>
+              ) : null}
+              <Pill
+                variant="number"
+                className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
+              >
+                <CircleDotDashed className="size-3.5 text-foreground" />
+                {turfStats.drafts}
+              </Pill>
+            </>
           ) : null}
-          <Pill
-            variant="number"
-            className="!w-fit shrink-0 gap-1.5 animate-in fade-in duration-100"
-          >
-            <CircleDotDashed className="size-3.5 text-foreground" />
-            {turfCount}
-          </Pill>
         </Fragment>
       ) : null}
       <Button

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
@@ -577,8 +577,16 @@ function Stat({ label, value }: { label: string; value: number | null }) {
   return (
     <div className="flex flex-col">
       <span className="text-muted-foreground">{label}</span>
-      {/* Non-breaking space holds the row height while the value resolves. */}
-      <span className="tabular-nums">{value === null ? " " : value.toLocaleString()}</span>
+      {/* Non-breaking space holds the row height while the value resolves;
+          the value span mounts on arrival so fade-in fires, matching the
+          sibling pills. */}
+      <span className="tabular-nums">
+        {value === null ? (
+          " "
+        ) : (
+          <span className="animate-in fade-in duration-100">{value.toLocaleString()}</span>
+        )}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/$campaignId/index.tsx
@@ -242,18 +242,17 @@ function CampaignEditor() {
     return out;
   }, [perKeyCounts, zones, countsStale]);
 
-  // Campaign-wide turf stats. Prefetched in the loader, so they arrive
-  // on first render and don't need fade-in handling.
+  // Campaign-wide turf stats. Null until the stats load — zeros are a fact
+  // of a loaded result, never a stand-in for one that hasn't arrived.
   const totals = useMemo(() => {
+    if (!turfStats) return null;
     let drafts = 0;
     let active = 0;
     let published = 0;
-    if (turfStats) {
-      for (const s of Object.values(turfStats)) {
-        drafts += s.drafts;
-        active += s.active;
-        published += s.published;
-      }
+    for (const s of Object.values(turfStats)) {
+      drafts += s.drafts;
+      active += s.active;
+      published += s.published;
     }
     return { drafts, active, published };
   }, [turfStats]);
@@ -494,7 +493,7 @@ function ZonesList({
     drafts: number;
     active: number;
     published: number;
-  };
+  } | null;
   fullSegmentCounts: { doors: number; people: number } | null;
   segmentName: string | null;
   scriptName: string | null;
@@ -550,7 +549,7 @@ function ConfigSummary({
     drafts: number;
     active: number;
     published: number;
-  };
+  } | null;
 }) {
   return (
     <div className="flex flex-col gap-2 rounded-md border border-border bg-card px-3 py-2">
@@ -566,19 +565,20 @@ function ConfigSummary({
       </div>
       <hr className="my-1 border-t border-border" />
       <div className="grid grid-cols-3 gap-2">
-        <Stat label="Draft turfs" value={totals.drafts} />
-        <Stat label="Published turfs" value={totals.published} />
-        <Stat label="Active turfs" value={totals.active} />
+        <Stat label="Draft turfs" value={totals?.drafts ?? null} />
+        <Stat label="Published turfs" value={totals?.published ?? null} />
+        <Stat label="Active turfs" value={totals?.active ?? null} />
       </div>
     </div>
   );
 }
 
-function Stat({ label, value }: { label: string; value: number }) {
+function Stat({ label, value }: { label: string; value: number | null }) {
   return (
     <div className="flex flex-col">
       <span className="text-muted-foreground">{label}</span>
-      <span className="tabular-nums">{value.toLocaleString()}</span>
+      {/* Non-breaking space holds the row height while the value resolves. */}
+      <span className="tabular-nums">{value === null ? " " : value.toLocaleString()}</span>
     </div>
   );
 }

--- a/apps/web/src/routes/$orgSlug/campaigns/route.tsx
+++ b/apps/web/src/routes/$orgSlug/campaigns/route.tsx
@@ -53,6 +53,7 @@ import { segmentsListQuery } from "~/lib/queries/segments";
 import { hasPermission } from "~/lib/permissions";
 import { turfStatsForCampaignQuery } from "~/lib/queries/turfs";
 import { zoneGroupsQuery, zonesQuery } from "~/lib/queries/zones";
+import { settleMutation } from "~/lib/settle";
 import { useConfirmHotkey } from "~/lib/use-confirm-hotkey";
 import { useDeferredRadioDropdown } from "~/lib/use-deferred-radio-dropdown";
 import { useDialogMutation } from "~/lib/use-dialog-mutation";
@@ -188,15 +189,24 @@ function CampaignsLayout() {
 
   const renameCampaign = useDialogMutation({
     mutationFn: (input: { campaignId: string; name: string }) => client.campaigns.rename(input),
-    onSuccess: (_data, input) => {
-      queryClient.setQueryData<typeof campaigns>(
-        ["campaigns"],
-        (old) =>
-          old?.map((c) => (c.campaignId === input.campaignId ? { ...c, name: input.name } : c)) ??
-          old,
-      );
-      void queryClient.invalidateQueries({ queryKey: ["campaigns"] });
-    },
+    onSuccess: (_data, input) =>
+      settleMutation(queryClient, {
+        keys: [["campaigns"], ["campaign", input.campaignId]],
+        patch: () => {
+          queryClient.setQueryData<typeof campaigns>(
+            ["campaigns"],
+            (old) =>
+              old?.map((c) =>
+                c.campaignId === input.campaignId ? { ...c, name: input.name } : c,
+              ) ?? old,
+          );
+          queryClient.setQueryData(
+            ["campaign", input.campaignId],
+            (old: Record<string, unknown> | null | undefined) =>
+              old ? { ...old, name: input.name } : old,
+          );
+        },
+      }),
   });
 
   // Wrapping zoneGroups.createWithDefaultZone + campaigns.create in one
@@ -215,26 +225,34 @@ function CampaignsLayout() {
         zoneGroupId: input.zoneGroupId,
       });
     },
-    onSuccess: (created) => {
-      queryClient.setQueryData<typeof campaigns>(["campaigns"], (old) =>
-        old ? [...old, created] : [created],
-      );
-      queryClient.setQueryData(["campaign", created.campaignId], created);
-      void queryClient.invalidateQueries({ queryKey: ["campaigns"] });
-      return goToCampaign(created.campaignId);
-    },
+    onSuccess: (created) =>
+      settleMutation(queryClient, {
+        keys: [["campaigns"], ["campaign", created.campaignId]],
+        // Inject and navigate in one synchronous block so React batches both
+        // updates — otherwise the new row renders unselected for a frame.
+        patch: () => {
+          queryClient.setQueryData<typeof campaigns>(["campaigns"], (old) =>
+            old ? [...old, created] : [created],
+          );
+          queryClient.setQueryData(["campaign", created.campaignId], created);
+          return goToCampaign(created.campaignId);
+        },
+      }),
   });
 
   const cloneCampaign = useDialogMutation({
     mutationFn: (input: { campaignId: string; newName: string }) => client.campaigns.clone(input),
-    onSuccess: (created) => {
-      queryClient.setQueryData<typeof campaigns>(["campaigns"], (old) =>
-        old ? [...old, created] : [created],
-      );
-      queryClient.setQueryData(["campaign", created.campaignId], created);
-      void queryClient.invalidateQueries({ queryKey: ["campaigns"] });
-      return goToCampaign(created.campaignId);
-    },
+    onSuccess: (created) =>
+      settleMutation(queryClient, {
+        keys: [["campaigns"], ["campaign", created.campaignId]],
+        patch: () => {
+          queryClient.setQueryData<typeof campaigns>(["campaigns"], (old) =>
+            old ? [...old, created] : [created],
+          );
+          queryClient.setQueryData(["campaign", created.campaignId], created);
+          return goToCampaign(created.campaignId);
+        },
+      }),
   });
 
   const setCampaignArchived = useMutation({
@@ -242,42 +260,40 @@ function CampaignsLayout() {
       input.archived
         ? client.campaigns.archive({ campaignId: input.campaignId })
         : client.campaigns.unarchive({ campaignId: input.campaignId }),
-    onSuccess: async (_data, input) => {
-      // Cancel in-flight list fetches so a pre-mutation response can't
-      // land after the patch and clobber it.
-      await queryClient.cancelQueries({ queryKey: ["campaigns"] });
-      const patch = () =>
-        queryClient.setQueryData<typeof campaigns>(
-          ["campaigns"],
-          (old) =>
-            old?.map((c) =>
-              c.campaignId === input.campaignId ? { ...c, isArchived: input.archived } : c,
-            ) ?? old,
-        );
-      if (input.archived) {
-        // Leave before the cache says "archived" — a patched cache under
-        // a still-selected item renders a one-frame "Unarchive" flash.
-        // With a fallback, move first and patch after. On the last
-        // active item the index redirect needs the patched list (else it
-        // bounces back here), so patch and navigate in one synchronous
-        // block — batched into a single render, like the create flows.
-        const idx = activeCampaigns.findIndex((c) => c.campaignId === input.campaignId);
-        const fallback = activeCampaigns[idx - 1] ?? activeCampaigns[idx + 1] ?? null;
-        if (fallback) {
-          await goToCampaign(fallback.campaignId);
-          patch();
-        } else {
-          patch();
-          await navigate({ to: "/$orgSlug/campaigns", params: { orgSlug } });
-        }
-      } else {
-        patch();
-      }
-      void queryClient.invalidateQueries({ queryKey: ["campaigns"] });
-      // Archived state changes which turfs the board shows.
-      void queryClient.invalidateQueries({ queryKey: ["turfs"] });
-    },
-    onError: (e) => toast.error(e.message),
+    onSuccess: (_data, input) =>
+      settleMutation(queryClient, {
+        // Archived state changes which turfs the board shows.
+        keys: [["campaigns"], ["turfs"]],
+        patch: async () => {
+          const patch = () =>
+            queryClient.setQueryData<typeof campaigns>(
+              ["campaigns"],
+              (old) =>
+                old?.map((c) =>
+                  c.campaignId === input.campaignId ? { ...c, isArchived: input.archived } : c,
+                ) ?? old,
+            );
+          if (input.archived) {
+            // Leave before the cache says "archived" — a patched cache under
+            // a still-selected item renders a one-frame "Unarchive" flash.
+            // With a fallback, move first and patch after. On the last
+            // active item the index redirect needs the patched list (else it
+            // bounces back here), so patch and navigate in one synchronous
+            // block — batched into a single render, like the create flows.
+            const idx = activeCampaigns.findIndex((c) => c.campaignId === input.campaignId);
+            const fallback = activeCampaigns[idx - 1] ?? activeCampaigns[idx + 1] ?? null;
+            if (fallback) {
+              await goToCampaign(fallback.campaignId);
+              patch();
+            } else {
+              patch();
+              await navigate({ to: "/$orgSlug/campaigns", params: { orgSlug } });
+            }
+          } else {
+            patch();
+          }
+        },
+      }),
   });
 
   const updateCampaignMutation = useMutation({
@@ -351,30 +367,37 @@ function CampaignsLayout() {
 
   const removeCampaign = useMutation({
     mutationFn: (input: { campaignId: string }) => client.campaigns.remove(input),
-    onSuccess: async (_data, input) => {
+    onSuccess: (_data, input) => {
       setRemoveOpen(false);
-      await queryClient.cancelQueries({ queryKey: ["campaigns"] });
-      // Exit to a neighbor in the visible rail (archived rows are shown
-      // while one is selected), patch the row out, then let the redirect
-      // land — same ordering rationale as the archive flow above.
-      const visible = sortedCampaigns.filter((c) => c.campaignId !== input.campaignId);
-      const idx = sortedCampaigns.findIndex((c) => c.campaignId === input.campaignId);
-      const fallback = visible[idx - 1] ?? visible[idx] ?? null;
-      const patch = () =>
-        queryClient.setQueryData<typeof campaigns>(
-          ["campaigns"],
-          (old) => old?.filter((c) => c.campaignId !== input.campaignId) ?? old,
-        );
-      if (fallback) {
-        await goToCampaign(fallback.campaignId);
-        patch();
-      } else {
-        patch();
-        await navigate({ to: "/$orgSlug/campaigns", params: { orgSlug } });
-      }
-      void queryClient.invalidateQueries({ queryKey: ["campaigns"] });
+      return settleMutation(queryClient, {
+        keys: [["campaigns"]],
+        evict: [
+          ["campaign", input.campaignId],
+          ["turf-stats", input.campaignId],
+          ["turf-drafts", input.campaignId],
+        ],
+        patch: async () => {
+          // Exit to a neighbor in the visible rail (archived rows are shown
+          // while one is selected), patch the row out, then let the redirect
+          // land — same ordering rationale as the archive flow above.
+          const visible = sortedCampaigns.filter((c) => c.campaignId !== input.campaignId);
+          const idx = sortedCampaigns.findIndex((c) => c.campaignId === input.campaignId);
+          const fallback = visible[idx - 1] ?? visible[idx] ?? null;
+          const patch = () =>
+            queryClient.setQueryData<typeof campaigns>(
+              ["campaigns"],
+              (old) => old?.filter((c) => c.campaignId !== input.campaignId) ?? old,
+            );
+          if (fallback) {
+            await goToCampaign(fallback.campaignId);
+            patch();
+          } else {
+            patch();
+            await navigate({ to: "/$orgSlug/campaigns", params: { orgSlug } });
+          }
+        },
+      });
     },
-    onError: (e) => toast.error(e.message),
   });
 
   const deleteActiveCampaign = async () => {

--- a/apps/web/src/routes/$orgSlug/scripts/$scriptId.tsx
+++ b/apps/web/src/routes/$orgSlug/scripts/$scriptId.tsx
@@ -86,6 +86,19 @@ function ScriptEditor() {
   const [draft, setDraft] = useState<ScriptStepRow[] | null>(null);
   const displaySteps = draft ?? steps;
 
+  // Step bodies and the preview render from per-question detail queries; on
+  // slow fetches a partial column (condition annotations without content)
+  // would render and then grow, yanking restored scroll around. Gate the
+  // first render until every detail is cached — a one-shot latch, so a step
+  // added later (detail still prefetching) falls back to its own inline
+  // placeholder instead of blanking the editor.
+  const detailQueries = useQueries({
+    queries: steps.filter((s) => s.questionId).map((s) => questionDetailQuery(s.questionId!)),
+  });
+  const detailsReady = detailQueries.every((d) => d.data !== undefined);
+  const readyOnceRef = useRef(false);
+  if (detailsReady) readyOnceRef.current = true;
+
   const setSteps = (updater: (prev: ScriptStepRow[]) => ScriptStepRow[]) => {
     const key = ["script", scriptId];
     const prev = queryClient.getQueryData<{ steps: ScriptStepRow[] } & object>(key);
@@ -259,7 +272,7 @@ function ScriptEditor() {
     prevStepsRef.current = { scriptId, length: steps.length };
   }, [scriptId, steps.length]);
 
-  if (!script) return null;
+  if (!script || !readyOnceRef.current) return null;
 
   return (
     <>

--- a/apps/web/src/routes/$orgSlug/scripts/$scriptId.tsx
+++ b/apps/web/src/routes/$orgSlug/scripts/$scriptId.tsx
@@ -95,7 +95,9 @@ function ScriptEditor() {
   const detailQueries = useQueries({
     queries: steps.filter((s) => s.questionId).map((s) => questionDetailQuery(s.questionId!)),
   });
-  const detailsReady = detailQueries.every((d) => d.data !== undefined);
+  // `!!script` guards the vacuous case: before the script loads, steps is []
+  // and every() over zero queries is true — the latch must not engage then.
+  const detailsReady = !!script && detailQueries.every((d) => d.data !== undefined);
   const readyOnceRef = useRef(false);
   if (detailsReady) readyOnceRef.current = true;
 
@@ -257,6 +259,9 @@ function ScriptEditor() {
   // Track per-script so tabbing between scripts doesn't read "count grew."
   const prevStepsRef = useRef<{ scriptId: string; length: number } | null>(null);
   useEffect(() => {
+    // While the script itself is loading, steps going 0→N is data arrival,
+    // not a user add — don't record a baseline or scroll.
+    if (!script) return;
     const prev = prevStepsRef.current;
     if (
       prev &&
@@ -270,7 +275,7 @@ function ScriptEditor() {
       });
     }
     prevStepsRef.current = { scriptId, length: steps.length };
-  }, [scriptId, steps.length]);
+  }, [script, scriptId, steps.length]);
 
   if (!script || !readyOnceRef.current) return null;
 

--- a/apps/web/src/routes/$orgSlug/scripts/route.tsx
+++ b/apps/web/src/routes/$orgSlug/scripts/route.tsx
@@ -18,6 +18,7 @@ import { EditorPage } from "~/components/editor-page";
 import { Input } from "~/components/input";
 import { Rail, useShowArchived } from "~/components/rail";
 import { scriptsListQuery } from "~/lib/queries/scripts";
+import { settleMutation } from "~/lib/settle";
 import { useConfirmHotkey } from "~/lib/use-confirm-hotkey";
 import { useDialogMutation } from "~/lib/use-dialog-mutation";
 import { useFadeOnce } from "~/lib/use-fade-once";
@@ -54,44 +55,53 @@ function ScriptsLayout() {
 
   const renameScript = useDialogMutation({
     mutationFn: (input: { scriptId: string; name: string }) => client.scripts.rename(input),
-    onSuccess: (_data, input) => {
-      queryClient.setQueryData<typeof scripts>(
-        ["scripts"],
-        (old) =>
-          old?.map((s) => (s.scriptId === input.scriptId ? { ...s, name: input.name } : s)) ?? old,
-      );
-      queryClient.setQueryData<{ name: string } & object>(["script", input.scriptId], (old) =>
-        old ? { ...old, name: input.name } : old,
-      );
-      void queryClient.invalidateQueries({ queryKey: ["scripts"] });
-      void queryClient.invalidateQueries({ queryKey: ["script", input.scriptId] });
-    },
+    onSuccess: (_data, input) =>
+      settleMutation(queryClient, {
+        keys: [["scripts"], ["script", input.scriptId]],
+        patch: () => {
+          queryClient.setQueryData<typeof scripts>(
+            ["scripts"],
+            (old) =>
+              old?.map((s) => (s.scriptId === input.scriptId ? { ...s, name: input.name } : s)) ??
+              old,
+          );
+          queryClient.setQueryData<{ name: string } & object>(["script", input.scriptId], (old) =>
+            old ? { ...old, name: input.name } : old,
+          );
+        },
+      }),
   });
 
   // New scripts are created immediately as "Untitled script" (no naming step).
   const createScript = useMutation({
     mutationFn: (input: { name: string }) => client.scripts.create(input),
-    onSuccess: (created) => {
-      queryClient.setQueryData<typeof scripts>(["scripts"], (old) =>
-        old ? [...old, created] : [created],
-      );
-      queryClient.setQueryData(["script", created.scriptId], { ...created, steps: [] });
-      void queryClient.invalidateQueries({ queryKey: ["scripts"] });
-      return goToScript(created.scriptId);
-    },
-    onError: (e) => toast.error(e.message),
+    onSuccess: (created) =>
+      settleMutation(queryClient, {
+        keys: [["scripts"], ["script", created.scriptId]],
+        // Inject and navigate in one synchronous block so React batches both
+        // updates — otherwise the new row renders unselected for a frame.
+        patch: () => {
+          queryClient.setQueryData<typeof scripts>(["scripts"], (old) =>
+            old ? [...old, created] : [created],
+          );
+          queryClient.setQueryData(["script", created.scriptId], { ...created, steps: [] });
+          return goToScript(created.scriptId);
+        },
+      }),
   });
 
   const cloneScript = useDialogMutation({
     mutationFn: (input: { scriptId: string; newName: string }) => client.scripts.clone(input),
-    onSuccess: (created) => {
-      queryClient.setQueryData<typeof scripts>(["scripts"], (old) =>
-        old ? [...old, created] : [created],
-      );
-      void queryClient.invalidateQueries({ queryKey: ["scripts"] });
-      void queryClient.invalidateQueries({ queryKey: ["script", created.scriptId] });
-      return goToScript(created.scriptId);
-    },
+    onSuccess: (created) =>
+      settleMutation(queryClient, {
+        keys: [["scripts"], ["script", created.scriptId]],
+        patch: () => {
+          queryClient.setQueryData<typeof scripts>(["scripts"], (old) =>
+            old ? [...old, created] : [created],
+          );
+          return goToScript(created.scriptId);
+        },
+      }),
   });
 
   const setScriptArchived = useMutation({
@@ -99,41 +109,41 @@ function ScriptsLayout() {
       input.archived
         ? client.scripts.archive({ scriptId: input.scriptId })
         : client.scripts.unarchive({ scriptId: input.scriptId }),
-    onSuccess: async (_data, input) => {
-      // Cancel in-flight list fetches so a pre-mutation response can't
-      // land after the patch and clobber it.
-      await queryClient.cancelQueries({ queryKey: ["scripts"] });
-      const patch = () =>
-        queryClient.setQueryData<typeof scripts>(
-          ["scripts"],
-          (old) =>
-            old?.map((s) =>
-              s.scriptId === input.scriptId ? { ...s, isArchived: input.archived } : s,
-            ) ?? old,
-        );
-      if (input.archived) {
-        // Leave before the cache says "archived" — a patched cache under
-        // a still-selected item renders a one-frame "Unarchive" flash.
-        // With a fallback, move first and patch after. On the last
-        // active item the index redirect needs the patched list (else it
-        // bounces back here), so patch and navigate in one synchronous
-        // block — batched into a single render, like the create flows.
-        setArchiveOpen(false);
-        const idx = activeScripts.findIndex((s) => s.scriptId === input.scriptId);
-        const fallback = activeScripts[idx - 1] ?? activeScripts[idx + 1] ?? null;
-        if (fallback) {
-          await goToScript(fallback.scriptId);
-          patch();
-        } else {
-          patch();
-          await navigate({ to: "/$orgSlug/scripts", params: { orgSlug } });
-        }
-      } else {
-        patch();
-      }
-      void queryClient.invalidateQueries({ queryKey: ["scripts"] });
+    onSuccess: (_data, input) => {
+      setArchiveOpen(false);
+      return settleMutation(queryClient, {
+        keys: [["scripts"]],
+        patch: async () => {
+          const patch = () =>
+            queryClient.setQueryData<typeof scripts>(
+              ["scripts"],
+              (old) =>
+                old?.map((s) =>
+                  s.scriptId === input.scriptId ? { ...s, isArchived: input.archived } : s,
+                ) ?? old,
+            );
+          if (input.archived) {
+            // Leave before the cache says "archived" — a patched cache under
+            // a still-selected item renders a one-frame "Unarchive" flash.
+            // With a fallback, move first and patch after. On the last
+            // active item the index redirect needs the patched list (else it
+            // bounces back here), so patch and navigate in one synchronous
+            // block — batched into a single render, like the create flows.
+            const idx = activeScripts.findIndex((s) => s.scriptId === input.scriptId);
+            const fallback = activeScripts[idx - 1] ?? activeScripts[idx + 1] ?? null;
+            if (fallback) {
+              await goToScript(fallback.scriptId);
+              patch();
+            } else {
+              patch();
+              await navigate({ to: "/$orgSlug/scripts", params: { orgSlug } });
+            }
+          } else {
+            patch();
+          }
+        },
+      });
     },
-    onError: (e) => toast.error(e.message),
   });
 
   // Archive flow: archive checks for active campaigns first and confirms
@@ -175,30 +185,33 @@ function ScriptsLayout() {
 
   const removeScript = useMutation({
     mutationFn: (input: { scriptId: string }) => client.scripts.remove(input),
-    onSuccess: async (_data, input) => {
+    onSuccess: (_data, input) => {
       setRemoveOpen(false);
-      await queryClient.cancelQueries({ queryKey: ["scripts"] });
-      // Exit to a neighbor in the visible rail (archived rows are shown
-      // while one is selected), patch the row out, then let the redirect
-      // land — same ordering rationale as the archive flow above.
-      const visible = sortedScripts.filter((s) => s.scriptId !== input.scriptId);
-      const idx = sortedScripts.findIndex((s) => s.scriptId === input.scriptId);
-      const fallback = visible[idx - 1] ?? visible[idx] ?? null;
-      const patch = () =>
-        queryClient.setQueryData<typeof scripts>(
-          ["scripts"],
-          (old) => old?.filter((s) => s.scriptId !== input.scriptId) ?? old,
-        );
-      if (fallback) {
-        await goToScript(fallback.scriptId);
-        patch();
-      } else {
-        patch();
-        await navigate({ to: "/$orgSlug/scripts", params: { orgSlug } });
-      }
-      void queryClient.invalidateQueries({ queryKey: ["scripts"] });
+      return settleMutation(queryClient, {
+        keys: [["scripts"]],
+        evict: [["script", input.scriptId]],
+        patch: async () => {
+          // Exit to a neighbor in the visible rail (archived rows are shown
+          // while one is selected), patch the row out, then let the redirect
+          // land — same ordering rationale as the archive flow above.
+          const visible = sortedScripts.filter((s) => s.scriptId !== input.scriptId);
+          const idx = sortedScripts.findIndex((s) => s.scriptId === input.scriptId);
+          const fallback = visible[idx - 1] ?? visible[idx] ?? null;
+          const patch = () =>
+            queryClient.setQueryData<typeof scripts>(
+              ["scripts"],
+              (old) => old?.filter((s) => s.scriptId !== input.scriptId) ?? old,
+            );
+          if (fallback) {
+            await goToScript(fallback.scriptId);
+            patch();
+          } else {
+            patch();
+            await navigate({ to: "/$orgSlug/scripts", params: { orgSlug } });
+          }
+        },
+      });
     },
-    onError: (e) => toast.error(e.message),
   });
 
   const deleteActiveScript = async () => {

--- a/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
+++ b/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
@@ -965,7 +965,7 @@ function CanvassResponseEditor({
           <ChevronDown className="text-muted-foreground" />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="min-w-48 max-h-[291px] overflow-y-auto">
-          {!questions || questions.length === 0 ? (
+          {!questions ? null : questions.length === 0 ? (
             <DropdownMenuItem disabled>No questions available</DropdownMenuItem>
           ) : (
             <>

--- a/apps/web/src/routes/$orgSlug/segments/route.tsx
+++ b/apps/web/src/routes/$orgSlug/segments/route.tsx
@@ -30,6 +30,7 @@ import { electionsQuery } from "~/lib/queries/elections";
 import { manifestQuery } from "~/lib/queries/manifest";
 import { hasPermission } from "~/lib/permissions";
 import { segmentCountsQuery, segmentDetailQuery, segmentsListQuery } from "~/lib/queries/segments";
+import { settleMutation } from "~/lib/settle";
 import { useConfirmHotkey } from "~/lib/use-confirm-hotkey";
 import { useDialogMutation } from "~/lib/use-dialog-mutation";
 import { useFadeOnce } from "~/lib/use-fade-once";
@@ -122,54 +123,56 @@ function SegmentsLayout() {
 
   const renameSegment = useDialogMutation({
     mutationFn: (input: { segmentId: string; name: string }) => client.segments.rename(input),
-    onSuccess: async (_data, input) => {
-      // Cancel any in-flight list fetch before patching — a response that
-      // started pre-rename carries the old name and would land after the
-      // patch and clobber it (the invalidate below dedupes into an
-      // in-flight fetch instead of starting a fresh one).
-      await queryClient.cancelQueries({ queryKey: ["segments"] });
-      queryClient.setQueryData<typeof segments>(
-        ["segments"],
-        (old) =>
-          old?.map((s) => (s.segmentId === input.segmentId ? { ...s, name: input.name } : s)) ??
-          old,
-      );
-      queryClient.setQueryData(
-        ["segment", input.segmentId],
-        (old: Record<string, unknown> | null | undefined) =>
-          old ? { ...old, name: input.name } : old,
-      );
-      void queryClient.invalidateQueries({ queryKey: ["segments"] });
-    },
+    onSuccess: (_data, input) =>
+      settleMutation(queryClient, {
+        keys: [["segments"], ["segment", input.segmentId]],
+        patch: () => {
+          queryClient.setQueryData<typeof segments>(
+            ["segments"],
+            (old) =>
+              old?.map((s) => (s.segmentId === input.segmentId ? { ...s, name: input.name } : s)) ??
+              old,
+          );
+          queryClient.setQueryData(
+            ["segment", input.segmentId],
+            (old: Record<string, unknown> | null | undefined) =>
+              old ? { ...old, name: input.name } : old,
+          );
+        },
+      }),
   });
 
   // New segments are created immediately as "Untitled segment" (no naming step).
   const createSegment = useMutation({
     mutationFn: (input: { name: string }) => client.segments.create(input),
-    onSuccess: (created) => {
-      // Inject and navigate synchronously so React batches both updates
-      // into one render — otherwise the new row appears unselected for a
-      // frame before the URL catches up.
-      queryClient.setQueryData<typeof segments>(["segments"], (old) =>
-        old ? [...old, created] : [created],
-      );
-      queryClient.setQueryData(["segment", created.segmentId], created);
-      void queryClient.invalidateQueries({ queryKey: ["segments"] });
-      return goToSegment(created.segmentId);
-    },
-    onError: (e) => toast.error(e.message),
+    onSuccess: (created) =>
+      settleMutation(queryClient, {
+        keys: [["segments"], ["segment", created.segmentId]],
+        // Inject and navigate in one synchronous block so React batches both
+        // updates — otherwise the new row renders unselected for a frame.
+        patch: () => {
+          queryClient.setQueryData<typeof segments>(["segments"], (old) =>
+            old ? [...old, created] : [created],
+          );
+          queryClient.setQueryData(["segment", created.segmentId], created);
+          return goToSegment(created.segmentId);
+        },
+      }),
   });
 
   const cloneSegment = useDialogMutation({
     mutationFn: (input: { segmentId: string; newName: string }) => client.segments.clone(input),
-    onSuccess: (created) => {
-      queryClient.setQueryData<typeof segments>(["segments"], (old) =>
-        old ? [...old, created] : [created],
-      );
-      queryClient.setQueryData(["segment", created.segmentId], created);
-      void queryClient.invalidateQueries({ queryKey: ["segments"] });
-      return goToSegment(created.segmentId);
-    },
+    onSuccess: (created) =>
+      settleMutation(queryClient, {
+        keys: [["segments"], ["segment", created.segmentId]],
+        patch: () => {
+          queryClient.setQueryData<typeof segments>(["segments"], (old) =>
+            old ? [...old, created] : [created],
+          );
+          queryClient.setQueryData(["segment", created.segmentId], created);
+          return goToSegment(created.segmentId);
+        },
+      }),
   });
 
   const setSegmentArchived = useMutation({
@@ -177,41 +180,41 @@ function SegmentsLayout() {
       input.archived
         ? client.segments.archive({ segmentId: input.segmentId })
         : client.segments.unarchive({ segmentId: input.segmentId }),
-    onSuccess: async (_data, input) => {
-      // Cancel in-flight list fetches so a pre-mutation response can't
-      // land after the patch and clobber it.
-      await queryClient.cancelQueries({ queryKey: ["segments"] });
-      const patch = () =>
-        queryClient.setQueryData<typeof segments>(
-          ["segments"],
-          (old) =>
-            old?.map((s) =>
-              s.segmentId === input.segmentId ? { ...s, isArchived: input.archived } : s,
-            ) ?? old,
-        );
-      if (input.archived) {
-        // Leave before the cache says "archived" — a patched cache under
-        // a still-selected item renders a one-frame "Unarchive" flash.
-        // With a fallback, move first and patch after. On the last
-        // active item the index redirect needs the patched list (else it
-        // bounces back here), so patch and navigate in one synchronous
-        // block — batched into a single render, like the create flows.
-        setArchiveOpen(false);
-        const idx = activeSegments.findIndex((s) => s.segmentId === input.segmentId);
-        const fallback = activeSegments[idx - 1] ?? activeSegments[idx + 1] ?? null;
-        if (fallback) {
-          await goToSegment(fallback.segmentId);
-          patch();
-        } else {
-          patch();
-          await navigate({ to: "/$orgSlug/segments", params: { orgSlug } });
-        }
-      } else {
-        patch();
-      }
-      void queryClient.invalidateQueries({ queryKey: ["segments"] });
+    onSuccess: (_data, input) => {
+      setArchiveOpen(false);
+      return settleMutation(queryClient, {
+        keys: [["segments"]],
+        patch: async () => {
+          const patch = () =>
+            queryClient.setQueryData<typeof segments>(
+              ["segments"],
+              (old) =>
+                old?.map((s) =>
+                  s.segmentId === input.segmentId ? { ...s, isArchived: input.archived } : s,
+                ) ?? old,
+            );
+          if (input.archived) {
+            // Leave before the cache says "archived" — a patched cache under
+            // a still-selected item renders a one-frame "Unarchive" flash.
+            // With a fallback, move first and patch after. On the last
+            // active item the index redirect needs the patched list (else it
+            // bounces back here), so patch and navigate in one synchronous
+            // block — batched into a single render, like the create flows.
+            const idx = activeSegments.findIndex((s) => s.segmentId === input.segmentId);
+            const fallback = activeSegments[idx - 1] ?? activeSegments[idx + 1] ?? null;
+            if (fallback) {
+              await goToSegment(fallback.segmentId);
+              patch();
+            } else {
+              patch();
+              await navigate({ to: "/$orgSlug/segments", params: { orgSlug } });
+            }
+          } else {
+            patch();
+          }
+        },
+      });
     },
-    onError: (e) => toast.error(e.message),
   });
 
   // Archive flow: archive checks for active campaigns first and confirms
@@ -253,30 +256,33 @@ function SegmentsLayout() {
 
   const removeSegment = useMutation({
     mutationFn: (input: { segmentId: string }) => client.segments.remove(input),
-    onSuccess: async (_data, input) => {
+    onSuccess: (_data, input) => {
       setRemoveOpen(false);
-      await queryClient.cancelQueries({ queryKey: ["segments"] });
-      // Exit to a neighbor in the visible rail (archived rows are shown
-      // while one is selected), patch the row out, then let the redirect
-      // land — same ordering rationale as the archive flow above.
-      const visible = sortedSegments.filter((s) => s.segmentId !== input.segmentId);
-      const idx = sortedSegments.findIndex((s) => s.segmentId === input.segmentId);
-      const fallback = visible[idx - 1] ?? visible[idx] ?? null;
-      const patch = () =>
-        queryClient.setQueryData<typeof segments>(
-          ["segments"],
-          (old) => old?.filter((s) => s.segmentId !== input.segmentId) ?? old,
-        );
-      if (fallback) {
-        await goToSegment(fallback.segmentId);
-        patch();
-      } else {
-        patch();
-        await navigate({ to: "/$orgSlug/segments", params: { orgSlug } });
-      }
-      void queryClient.invalidateQueries({ queryKey: ["segments"] });
+      return settleMutation(queryClient, {
+        keys: [["segments"]],
+        evict: [["segment", input.segmentId]],
+        patch: async () => {
+          // Exit to a neighbor in the visible rail (archived rows are shown
+          // while one is selected), patch the row out, then let the redirect
+          // land — same ordering rationale as the archive flow above.
+          const visible = sortedSegments.filter((s) => s.segmentId !== input.segmentId);
+          const idx = sortedSegments.findIndex((s) => s.segmentId === input.segmentId);
+          const fallback = visible[idx - 1] ?? visible[idx] ?? null;
+          const patch = () =>
+            queryClient.setQueryData<typeof segments>(
+              ["segments"],
+              (old) => old?.filter((s) => s.segmentId !== input.segmentId) ?? old,
+            );
+          if (fallback) {
+            await goToSegment(fallback.segmentId);
+            patch();
+          } else {
+            patch();
+            await navigate({ to: "/$orgSlug/segments", params: { orgSlug } });
+          }
+        },
+      });
     },
-    onError: (e) => toast.error(e.message),
   });
 
   const deleteActiveSegment = async () => {

--- a/apps/web/src/routes/$orgSlug/turfs/index.tsx
+++ b/apps/web/src/routes/$orgSlug/turfs/index.tsx
@@ -22,7 +22,7 @@ import {
 import { useAtomValue } from "jotai";
 import polylabel from "polylabel";
 import { QRCodeSVG } from "qrcode.react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "~/components/button";
 import { Dialog, DialogClose, DialogCloseX, DialogContent, DialogTitle } from "~/components/dialog";
 import { EditorHeader } from "~/components/editor-header";
@@ -80,18 +80,13 @@ export const Route = createFileRoute("/$orgSlug/turfs/")({
     zoneId: typeof search.zoneId === "string" ? search.zoneId : null,
   }),
   loaderDeps: ({ search }) => ({ campaignId: search.campaignId }),
-  loader: async ({ context: { queryClient }, deps }) => {
-    // TEMP boot-audit logging (remove before merge)
-    console.log("[boot] turfs loader start", Math.round(performance.now()));
-    const result = await Promise.all([
+  loader: ({ context: { queryClient }, deps }) =>
+    Promise.all([
       queryClient.fetchQuery(turfsListQuery(deps.campaignId)),
       queryClient.fetchQuery(walksListQuery(deps.campaignId)),
       queryClient.fetchQuery(progressQuery(deps.campaignId)),
       queryClient.fetchQuery(campaignsListQuery()),
-    ]);
-    console.log("[boot] turfs loader done", Math.round(performance.now()));
-    return result;
-  },
+    ]),
   component: TurfsIndex,
 });
 
@@ -123,15 +118,6 @@ function TurfsIndex() {
   const { data: campaigns } = useSuspenseQuery(campaignsListQuery());
   const { data: turfs } = useSuspenseQuery(turfsListQuery(campaignId));
   const rows = useTurfRows(campaignId, zoneId);
-
-  // TEMP boot-audit logging (remove before merge)
-  const bootLoggedRef = useRef(false);
-  if (!bootLoggedRef.current) {
-    bootLoggedRef.current = true;
-    console.log("[boot] TurfsIndex first render", Math.round(performance.now()), {
-      campaignsPresent: campaigns !== undefined,
-    });
-  }
 
   // Mobile-only rendering choice; desktop is always the table.
   const [view, setView] = useState<"cards" | "table">("cards");
@@ -985,8 +971,9 @@ function WalksDialog({
 function WalkedBadge({ summary, tz }: { summary: WalkSummary; tz: string }) {
   if (summary.walks.length === 0) return <Pill />;
   const last = summary.walks[summary.walks.length - 1]!;
+  // Keyed so the blank→filled switch remounts and fade-in fires.
   return (
-    <Pill className="gap-1.5 font-mono tabular-nums">
+    <Pill key="filled" className="gap-1.5 font-mono tabular-nums animate-in fade-in duration-100">
       {summary.walks.length >= 2 ? <CheckCheck className="size-4" /> : <Check className="size-4" />}
       {formatMonthDay(last.openedAt, tz)}
     </Pill>
@@ -1017,8 +1004,14 @@ function StatusBadge({ summary }: { summary: WalkSummary }) {
 
 function ProgressPill({ pct }: { pct: number | null }) {
   if (pct === null) return <Pill variant="number" />;
+  // Keyed so the blank→filled switch remounts and fade-in fires.
   return (
-    <Pill variant="number" color={pct > 0 ? progressColor(pct) : undefined}>
+    <Pill
+      key="filled"
+      variant="number"
+      className="animate-in fade-in duration-100"
+      color={pct > 0 ? progressColor(pct) : undefined}
+    >
       {pct}%
     </Pill>
   );

--- a/apps/web/src/routes/$orgSlug/turfs/index.tsx
+++ b/apps/web/src/routes/$orgSlug/turfs/index.tsx
@@ -416,9 +416,11 @@ function useWalkSummaries(campaignId: string | null) {
   }, [data]);
 }
 
+// Null until progress loads — a turf absent from a loaded result means
+// genuinely zero attempts; an absent result means "don't know yet".
 function useProgressByTurf(campaignId: string | null) {
   const { data } = useQuery(progressQuery(campaignId));
-  return useMemo(() => new Map((data ?? []).map((r) => [r.turfId, r.attempted])), [data]);
+  return useMemo(() => (data ? new Map(data.map((r) => [r.turfId, r.attempted])) : null), [data]);
 }
 
 // Region-grouped rendering for the mobile views: one group per
@@ -488,9 +490,9 @@ function doorLabel(count: number | null) {
   return count > 999 ? "1k+" : String(count);
 }
 
-function progressPct(attempted: number | undefined, personCount: number | null) {
+function progressPct(attempted: number, personCount: number | null) {
   if (!personCount) return null;
-  return Math.round(((attempted ?? 0) / personCount) * 100);
+  return Math.round((attempted / personCount) * 100);
 }
 
 function bboxOfFeatures(features: Feature[]): [number, number, number, number] | null {
@@ -1102,7 +1104,11 @@ function TurfCards({
               key={t.turfId}
               turf={t}
               summary={summaries(t.turfId)}
-              pct={progressPct(progressByTurf.get(t.turfId), t.personCount)}
+              pct={
+                progressByTurf
+                  ? progressPct(progressByTurf.get(t.turfId) ?? 0, t.personCount)
+                  : null
+              }
               tz={tz}
               onShowQr={onShowQr}
               onShowTurfMap={onShowTurfMap}
@@ -1281,7 +1287,9 @@ function CompactList({
           ) : null}
           {group.rows.map((t) => {
             const summary = summaries(t.turfId);
-            const pct = progressPct(progressByTurf.get(t.turfId), t.personCount);
+            const pct = progressByTurf
+              ? progressPct(progressByTurf.get(t.turfId) ?? 0, t.personCount)
+              : null;
             return (
               <div key={t.turfId} data-turf-row={t.turfId} className="flex items-center gap-1">
                 <span className={cn(cell, "w-9 bg-muted font-mono font-semibold tabular-nums")}>
@@ -1423,7 +1431,9 @@ function TurfsTable({
         ) : null}
         {rows.map((t) => {
           const summary = summaries(t.turfId);
-          const pct = progressPct(progressByTurf.get(t.turfId), t.personCount);
+          const pct = progressByTurf
+            ? progressPct(progressByTurf.get(t.turfId) ?? 0, t.personCount)
+            : null;
           return (
             <TableRow key={t.turfId} data-turf-row={t.turfId}>
               <TableCell>

--- a/apps/web/src/routes/$orgSlug/turfs/index.tsx
+++ b/apps/web/src/routes/$orgSlug/turfs/index.tsx
@@ -22,7 +22,7 @@ import {
 import { useAtomValue } from "jotai";
 import polylabel from "polylabel";
 import { QRCodeSVG } from "qrcode.react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "~/components/button";
 import { Dialog, DialogClose, DialogCloseX, DialogContent, DialogTitle } from "~/components/dialog";
 import { EditorHeader } from "~/components/editor-header";
@@ -80,13 +80,18 @@ export const Route = createFileRoute("/$orgSlug/turfs/")({
     zoneId: typeof search.zoneId === "string" ? search.zoneId : null,
   }),
   loaderDeps: ({ search }) => ({ campaignId: search.campaignId }),
-  loader: ({ context: { queryClient }, deps }) =>
-    Promise.all([
+  loader: async ({ context: { queryClient }, deps }) => {
+    // TEMP boot-audit logging (remove before merge)
+    console.log("[boot] turfs loader start", Math.round(performance.now()));
+    const result = await Promise.all([
       queryClient.fetchQuery(turfsListQuery(deps.campaignId)),
       queryClient.fetchQuery(walksListQuery(deps.campaignId)),
       queryClient.fetchQuery(progressQuery(deps.campaignId)),
       queryClient.fetchQuery(campaignsListQuery()),
-    ]),
+    ]);
+    console.log("[boot] turfs loader done", Math.round(performance.now()));
+    return result;
+  },
   component: TurfsIndex,
 });
 
@@ -112,9 +117,21 @@ function TurfsIndex() {
   const shouldFade = useFadeOnce("/turfs");
   useLiveRefresh();
 
-  const { data: campaigns } = useQuery(campaignsListQuery());
+  // Suspense (not useQuery): on prod cold boots the SPA shell hydration
+  // skips route loaders, so data arrives via component mount — a plain
+  // useQuery would paint the campaign filter label-less and widen later.
+  const { data: campaigns } = useSuspenseQuery(campaignsListQuery());
   const { data: turfs } = useSuspenseQuery(turfsListQuery(campaignId));
   const rows = useTurfRows(campaignId, zoneId);
+
+  // TEMP boot-audit logging (remove before merge)
+  const bootLoggedRef = useRef(false);
+  if (!bootLoggedRef.current) {
+    bootLoggedRef.current = true;
+    console.log("[boot] TurfsIndex first render", Math.round(performance.now()), {
+      campaignsPresent: campaigns !== undefined,
+    });
+  }
 
   // Mobile-only rendering choice; desktop is always the table.
   const [view, setView] = useState<"cards" | "table">("cards");

--- a/apps/web/src/routes/$orgSlug/zones/$zoneGroupId.tsx
+++ b/apps/web/src/routes/$orgSlug/zones/$zoneGroupId.tsx
@@ -384,11 +384,17 @@ function ZoneGroupEditor() {
               )}
               {zoneOverlay ? (
                 <>
-                  <Pill variant="number" className="!w-fit shrink-0 justify-end gap-1.5">
+                  <Pill
+                    variant="number"
+                    className="!w-fit shrink-0 justify-end gap-1.5 animate-in fade-in duration-100"
+                  >
                     <UserRound className="size-3.5 text-foreground" />
                     {(zoneOverlay.people[zone.zoneId] ?? 0).toLocaleString()}
                   </Pill>
-                  <Pill variant="number" className="!w-fit shrink-0 justify-end gap-1.5">
+                  <Pill
+                    variant="number"
+                    className="!w-fit shrink-0 justify-end gap-1.5 animate-in fade-in duration-100"
+                  >
                     <DoorClosed className="size-3.5 text-foreground" />
                     {(zoneOverlay.doors[zone.zoneId] ?? 0).toLocaleString()}
                   </Pill>

--- a/apps/web/src/routes/$orgSlug/zones/route.tsx
+++ b/apps/web/src/routes/$orgSlug/zones/route.tsx
@@ -22,6 +22,7 @@ import { useFilterCatalog } from "~/lib/manifest";
 import { manifestQuery } from "~/lib/queries/manifest";
 import { hasPermission } from "~/lib/permissions";
 import { zoneGroupsQuery } from "~/lib/queries/zones";
+import { settleMutation } from "~/lib/settle";
 import { useConfirmHotkey } from "~/lib/use-confirm-hotkey";
 import { useDialogMutation } from "~/lib/use-dialog-mutation";
 import { useFadeOnce } from "~/lib/use-fade-once";
@@ -64,49 +65,55 @@ function ZonesLayout() {
 
   const renameGroup = useDialogMutation({
     mutationFn: (input: { zoneGroupId: string; name: string }) => client.zoneGroups.rename(input),
-    onSuccess: (_data, input) => {
-      queryClient.setQueryData<typeof zoneGroups>(
-        ["zone-groups"],
-        (old) =>
-          old?.map((g) => (g.zoneGroupId === input.zoneGroupId ? { ...g, name: input.name } : g)) ??
-          old,
-      );
-      void queryClient.invalidateQueries({ queryKey: ["zone-groups"] });
-    },
+    onSuccess: (_data, input) =>
+      settleMutation(queryClient, {
+        keys: [["zone-groups"]],
+        patch: () => {
+          queryClient.setQueryData<typeof zoneGroups>(
+            ["zone-groups"],
+            (old) =>
+              old?.map((g) =>
+                g.zoneGroupId === input.zoneGroupId ? { ...g, name: input.name } : g,
+              ) ?? old,
+          );
+        },
+      }),
   });
 
   const createGroup = useDialogMutation({
     mutationFn: (input: { name: string; keyGroup: string }) => client.zoneGroups.create(input),
-    onSuccess: (created) => {
-      // Inject and navigate synchronously (no await between) so React
-      // batches both updates into one render — otherwise the new row
-      // appears in the list for a frame as unselected before the URL
-      // catches up. Loader sees the cache injection because it runs in
-      // the same microtask wave.
-      queryClient.setQueryData<typeof zoneGroups>(["zone-groups"], (old) =>
-        old ? [...old, created] : [created],
-      );
-      void queryClient.invalidateQueries({ queryKey: ["zone-groups"] });
-      return goToGroup(created.zoneGroupId);
-    },
+    onSuccess: (created) =>
+      settleMutation(queryClient, {
+        keys: [["zone-groups"]],
+        // Inject and navigate in one synchronous block so React batches both
+        // updates — otherwise the new row renders unselected for a frame.
+        patch: () => {
+          queryClient.setQueryData<typeof zoneGroups>(["zone-groups"], (old) =>
+            old ? [...old, created] : [created],
+          );
+          return goToGroup(created.zoneGroupId);
+        },
+      }),
   });
 
   const cloneGroup = useDialogMutation({
     mutationFn: (input: { zoneGroupId: string; newName: string }) => client.zoneGroups.clone(input),
-    onSuccess: (created) => {
-      queryClient.setQueryData<typeof zoneGroups>(["zone-groups"], (old) =>
-        old ? [...old, created] : [created],
-      );
-      void queryClient.invalidateQueries({ queryKey: ["zone-groups"] });
-      return goToGroup(created.zoneGroupId);
-    },
+    onSuccess: (created) =>
+      settleMutation(queryClient, {
+        keys: [["zone-groups"]],
+        patch: () => {
+          queryClient.setQueryData<typeof zoneGroups>(["zone-groups"], (old) =>
+            old ? [...old, created] : [created],
+          );
+          return goToGroup(created.zoneGroupId);
+        },
+      }),
   });
 
   const clearZones = useDialogMutation({
     mutationFn: (zoneGroupId: string) => client.zones.removeAllInGroup({ zoneGroupId }),
-    onSuccess: (_data, zoneGroupId) => {
-      void queryClient.invalidateQueries({ queryKey: ["zones", zoneGroupId] });
-    },
+    onSuccess: (_data, zoneGroupId) =>
+      settleMutation(queryClient, { keys: [["zones", zoneGroupId]] }),
   });
 
   const setGroupArchived = useMutation({
@@ -114,41 +121,41 @@ function ZonesLayout() {
       input.archived
         ? client.zoneGroups.archive({ zoneGroupId: input.zoneGroupId })
         : client.zoneGroups.unarchive({ zoneGroupId: input.zoneGroupId }),
-    onSuccess: async (_data, input) => {
-      // Cancel in-flight list fetches so a pre-mutation response can't
-      // land after the patch and clobber it.
-      await queryClient.cancelQueries({ queryKey: ["zone-groups"] });
-      const patch = () =>
-        queryClient.setQueryData<typeof zoneGroups>(
-          ["zone-groups"],
-          (old) =>
-            old?.map((g) =>
-              g.zoneGroupId === input.zoneGroupId ? { ...g, isArchived: input.archived } : g,
-            ) ?? old,
-        );
-      if (input.archived) {
-        // Leave before the cache says "archived" — a patched cache under
-        // a still-selected item renders a one-frame "Unarchive" flash.
-        // With a fallback, move first and patch after. On the last
-        // active item the index redirect needs the patched list (else it
-        // bounces back here), so patch and navigate in one synchronous
-        // block — batched into a single render, like the create flows.
-        setArchiveOpen(false);
-        const idx = activeZoneGroups.findIndex((g) => g.zoneGroupId === input.zoneGroupId);
-        const fallback = activeZoneGroups[idx - 1] ?? activeZoneGroups[idx + 1] ?? null;
-        if (fallback) {
-          await goToGroup(fallback.zoneGroupId);
-          patch();
-        } else {
-          patch();
-          await navigate({ to: "/$orgSlug/zones", params: { orgSlug } });
-        }
-      } else {
-        patch();
-      }
-      void queryClient.invalidateQueries({ queryKey: ["zone-groups"] });
+    onSuccess: (_data, input) => {
+      setArchiveOpen(false);
+      return settleMutation(queryClient, {
+        keys: [["zone-groups"]],
+        patch: async () => {
+          const patch = () =>
+            queryClient.setQueryData<typeof zoneGroups>(
+              ["zone-groups"],
+              (old) =>
+                old?.map((g) =>
+                  g.zoneGroupId === input.zoneGroupId ? { ...g, isArchived: input.archived } : g,
+                ) ?? old,
+            );
+          if (input.archived) {
+            // Leave before the cache says "archived" — a patched cache under
+            // a still-selected item renders a one-frame "Unarchive" flash.
+            // With a fallback, move first and patch after. On the last
+            // active item the index redirect needs the patched list (else it
+            // bounces back here), so patch and navigate in one synchronous
+            // block — batched into a single render, like the create flows.
+            const idx = activeZoneGroups.findIndex((g) => g.zoneGroupId === input.zoneGroupId);
+            const fallback = activeZoneGroups[idx - 1] ?? activeZoneGroups[idx + 1] ?? null;
+            if (fallback) {
+              await goToGroup(fallback.zoneGroupId);
+              patch();
+            } else {
+              patch();
+              await navigate({ to: "/$orgSlug/zones", params: { orgSlug } });
+            }
+          } else {
+            patch();
+          }
+        },
+      });
     },
-    onError: (e) => toast.error(e.message),
   });
 
   // Archive flow: archive checks for active campaigns first and confirms
@@ -190,30 +197,34 @@ function ZonesLayout() {
 
   const removeGroup = useMutation({
     mutationFn: (input: { zoneGroupId: string }) => client.zoneGroups.remove(input),
-    onSuccess: async (_data, input) => {
+    onSuccess: (_data, input) => {
       setRemoveOpen(false);
-      await queryClient.cancelQueries({ queryKey: ["zone-groups"] });
-      // Exit to a neighbor in the visible rail (archived rows are shown
-      // while one is selected), patch the row out, then let the redirect
-      // land — same ordering rationale as the archive flow above.
-      const visible = sortedZoneGroups.filter((g) => g.zoneGroupId !== input.zoneGroupId);
-      const idx = sortedZoneGroups.findIndex((g) => g.zoneGroupId === input.zoneGroupId);
-      const fallback = visible[idx - 1] ?? visible[idx] ?? null;
-      const patch = () =>
-        queryClient.setQueryData<typeof zoneGroups>(
-          ["zone-groups"],
-          (old) => old?.filter((g) => g.zoneGroupId !== input.zoneGroupId) ?? old,
-        );
-      if (fallback) {
-        await goToGroup(fallback.zoneGroupId);
-        patch();
-      } else {
-        patch();
-        await navigate({ to: "/$orgSlug/zones", params: { orgSlug } });
-      }
-      void queryClient.invalidateQueries({ queryKey: ["zone-groups"] });
+      return settleMutation(queryClient, {
+        keys: [["zone-groups"]],
+        // Zones cascade server-side; drop their cache with the group.
+        evict: [["zones", input.zoneGroupId]],
+        patch: async () => {
+          // Exit to a neighbor in the visible rail (archived rows are shown
+          // while one is selected), patch the row out, then let the redirect
+          // land — same ordering rationale as the archive flow above.
+          const visible = sortedZoneGroups.filter((g) => g.zoneGroupId !== input.zoneGroupId);
+          const idx = sortedZoneGroups.findIndex((g) => g.zoneGroupId === input.zoneGroupId);
+          const fallback = visible[idx - 1] ?? visible[idx] ?? null;
+          const patch = () =>
+            queryClient.setQueryData<typeof zoneGroups>(
+              ["zone-groups"],
+              (old) => old?.filter((g) => g.zoneGroupId !== input.zoneGroupId) ?? old,
+            );
+          if (fallback) {
+            await goToGroup(fallback.zoneGroupId);
+            patch();
+          } else {
+            patch();
+            await navigate({ to: "/$orgSlug/zones", params: { orgSlug } });
+          }
+        },
+      });
     },
-    onError: (e) => toast.error(e.message),
   });
 
   const deleteActiveGroup = async () => {


### PR DESCRIPTION
This PR consolidates and makes more consistent handling of cache invalidations. Prior to this change, real usage surfaced a handful of occasionally occurring bugs. 

One category was related to cache writes being overwritten by in-flight responses. When doing something like creating or renaming a segment, the app updates its local copy of the data immediately (so the UI responds without waiting for the server) via a mutation, and then asks the server for the real list to make sure everything matches. But if a request for that same list was already in the air (for example, kicked off a moment earlier by a navigation or a tab refocus) its response describes the world from before the change. When that response lands after the local update, it overwrites it, and the app treats it as current for the next 15 seconds. This could cause, for example, the Segment Editor to show "No segments yet" moments after creating a first segment, or the Campaign Editor to show the old name moments after renaming something. The fix is a shared `settleMutation` helper that every mutation now goes through, doing the steps in one fixed order: cancel any in-flight requests for the affected data (so a stale response can't land late), then apply the local update, then clear caches for anything deleted, then re-request from the server in the background. Previously we were hand-rolling some subset of those steps at every mutation site, and about half were missing the cancel step, which is where the bugs occurred. As part of the same consolidation, any mutation that fails now surfaces an error toast by default instead of failing silently (though these should appear rarely if ever in practice).

The second, simpler category of bug was absent data at render time, resulting in a brief flash of the wrong value. This is now handled through a consistent pattern where missing data renders as a blank that holds the layout, so that progress pills, campaign stats, etc. fade in quickly as soon as data exist instead of flashing an wrong initial value (like 0%) first (while a genuine 0 still renders correctly).

A couple other related fixes are included: the script editor now waits until the script and every step's question details are cached before first rendering; the turf board reads the campaigns list via suspense so the campaign filter can never paint without its label; and two small cache-lifetime tunings (a router-level staleTime matching the query default so navigations don't re-run loaders the cache would satisfy, and keeping the small campaigns list cached indefinitely).