### PR TITLE
fix: reports perf improvements

### DIFF
--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -930,17 +930,20 @@ async def results_aggregate(req: _ResultsAggregateRequest):
 
         with timed("query"):
             # One event-log reduction per request; the aggregates read it
-            # by the returned name.
-            joined = materialize(
-                conn,
-                "joined",
-                f"{latest_results_cte(persons, where, scope.event_filters)} SELECT * FROM joined",
-                scope.event_params + where_params,
-            )
-            day_rows = conn.execute(canvass_days_sql(scope.base_filters), [req.tz, *scope.base_params]).fetchall()
-            stage_rows = conn.execute(stages_sql(joined)).fetchall()
-            response_rows = conn.execute(responses_sql(joined)).fetchall()
-            answered_rows = conn.execute(answered_sql(joined)).fetchall()
+            # by the returned name. Sub-phases decompose Server-Timing.
+            with timed("reduce"):
+                joined = materialize(
+                    conn,
+                    "joined",
+                    f"{latest_results_cte(persons, where, scope.event_filters)} SELECT * FROM joined",
+                    scope.event_params + where_params,
+                )
+            with timed("days"):
+                day_rows = conn.execute(canvass_days_sql(scope.base_filters), [req.tz, *scope.base_params]).fetchall()
+            with timed("aggregate"):
+                stage_rows = conn.execute(stages_sql(joined)).fetchall()
+                response_rows = conn.execute(responses_sql(joined)).fetchall()
+                answered_rows = conn.execute(answered_sql(joined)).fetchall()
 
         return {
             "days": [r[0] for r in day_rows],

--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -21,7 +21,6 @@ from src import timing
 from src.canvass_events import (
     answered_sql,
     assemble_zone_rows,
-    base_events_sql,
     canvass_days_sql,
     event_scope,
     latest_results_cte,
@@ -930,16 +929,15 @@ async def results_aggregate(req: _ResultsAggregateRequest):
         ).fetchall()
 
         with timed("query"):
-            # One Postgres event scan per request; the reduction, the day
-            # list, and the aggregates all read the materialized relations.
-            base = materialize(conn, "base_events", base_events_sql(scope.base_filters), scope.base_params)
+            # One event-log reduction per request; the aggregates read it
+            # by the returned name.
             joined = materialize(
                 conn,
                 "joined",
-                f"{latest_results_cte(persons, where, base, scope.date_filters)} SELECT * FROM joined",
-                scope.date_params + where_params,
+                f"{latest_results_cte(persons, where, scope.event_filters)} SELECT * FROM joined",
+                scope.event_params + where_params,
             )
-            day_rows = conn.execute(canvass_days_sql(base), [req.tz]).fetchall()
+            day_rows = conn.execute(canvass_days_sql(scope.base_filters), [req.tz, *scope.base_params]).fetchall()
             stage_rows = conn.execute(stages_sql(joined)).fetchall()
             response_rows = conn.execute(responses_sql(joined)).fetchall()
             answered_rows = conn.execute(answered_sql(joined)).fetchall()

--- a/apps/data/main.py
+++ b/apps/data/main.py
@@ -21,6 +21,7 @@ from src import timing
 from src.canvass_events import (
     answered_sql,
     assemble_zone_rows,
+    base_events_sql,
     canvass_days_sql,
     event_scope,
     latest_results_cte,
@@ -43,6 +44,7 @@ from src.duckdb import (
     OPERATIONAL_PG_ALIAS,
     attach_operational_postgres,
     get_connection,
+    materialize,
     query_cursor,
     refresh_s3_secret_on_shared_connection,
     s3_secret_expires,
@@ -905,7 +907,6 @@ async def results_aggregate(req: _ResultsAggregateRequest):
         persons = resolve("{persons_geocoded}", version.schema)
 
         scope = event_scope(req.org_slug, req.campaign_ids, req.start, req.end, req.day, req.tz)
-        joined = latest_results_cte(persons, where, scope.event_filters)
 
         # Zones of the scoped campaigns' groups — every zone gets a row
         # (zeros when unwalked); which rows to surface is the client's
@@ -928,12 +929,20 @@ async def results_aggregate(req: _ResultsAggregateRequest):
             zone_params,
         ).fetchall()
 
-        params = scope.event_params + where_params
         with timed("query"):
-            day_rows = conn.execute(canvass_days_sql(scope.base_filters), [req.tz, *scope.base_params]).fetchall()
-            stage_rows = conn.execute(stages_sql(joined), params).fetchall()
-            response_rows = conn.execute(responses_sql(joined), params).fetchall()
-            answered_rows = conn.execute(answered_sql(joined), params).fetchall()
+            # One Postgres event scan per request; the reduction, the day
+            # list, and the aggregates all read the materialized relations.
+            base = materialize(conn, "base_events", base_events_sql(scope.base_filters), scope.base_params)
+            joined = materialize(
+                conn,
+                "joined",
+                f"{latest_results_cte(persons, where, base, scope.date_filters)} SELECT * FROM joined",
+                scope.date_params + where_params,
+            )
+            day_rows = conn.execute(canvass_days_sql(base), [req.tz]).fetchall()
+            stage_rows = conn.execute(stages_sql(joined)).fetchall()
+            response_rows = conn.execute(responses_sql(joined)).fetchall()
+            answered_rows = conn.execute(answered_sql(joined)).fetchall()
 
         return {
             "days": [r[0] for r in day_rows],

--- a/apps/data/src/canvass_events.py
+++ b/apps/data/src/canvass_events.py
@@ -150,10 +150,15 @@ def attempts_cte(persons_fqn: str, where: str, event_filters: list[str]) -> str:
     (person, walk) — joined to the conditioned population. Events
     without a walk_id (pre-stamp clients) group by canvass day in the
     display timezone instead. A person whose scope-wide latest result
-    is a clear contributes no attempts: a clear means the record was a
-    mistake, erasing attempt history too, so attempt-derived counts
-    match the person grain by construction. Queries built on it bind
-    the event params, then the fallback tz, then the criteria params."""
+    is a clear contributes no attempts: a clear is an edit to the
+    turf's shared canvass record — the record was a mistake, erasing
+    attempt history too — so attempt-derived counts match the person
+    grain by construction. Callers pass date-free scope filters: the
+    reduction is global per campaign scope, and date selection happens
+    afterward on the reduced attempts, so a clear erases everywhere
+    rather than resurrecting in historical day views. Queries built on
+    it bind the event params, then the fallback tz, then the criteria
+    params."""
     return f"""
         WITH attempt_latest AS (
             SELECT * FROM (
@@ -240,6 +245,18 @@ def canvasser_stats_sql(rel: str) -> str:
         FROM {rel}
         GROUP BY 1
         """
+
+
+def attempt_days_sql(rel: str) -> str:
+    """Distinct attempt days over a materialized attempt-grain relation,
+    newest first — the reports day picker. Days whose only activity was
+    later cleared or superseded list nothing and are deliberately
+    absent. Binds [tz]."""
+    return f"""
+        SELECT DISTINCT ((created_at AT TIME ZONE ?)::DATE)::VARCHAR AS day
+        FROM {rel}
+        ORDER BY day DESC
+    """
 
 
 def canvass_days_sql(base_filters: list[str]) -> str:

--- a/apps/data/src/canvass_events.py
+++ b/apps/data/src/canvass_events.py
@@ -23,17 +23,15 @@ from src.duckdb import OPERATIONAL_PG_ALIAS
 
 @dataclass
 class EventScope:
-    """Event-log WHERE fragments, split by where they apply: `base` (org
-    + campaigns, `e.`-prefixed) scopes the one Postgres scan that
-    materializes the base relation; `date` (unprefixed) narrows the
-    reductions over that relation. The day list derives from the base
-    relation and must ignore date filters — the picker's options would
-    otherwise collapse to the current pick."""
+    """Event-log WHERE fragments, split in two: `base` (org + campaigns)
+    feeds the canvass-day list, which must ignore date filters — the
+    picker's options would otherwise collapse to the current pick;
+    `event` adds the date window for the reduction itself."""
 
     base_filters: list[str]
     base_params: list[Any]
-    date_filters: list[str]
-    date_params: list[Any]
+    event_filters: list[str]
+    event_params: list[Any]
 
 
 def event_scope(
@@ -49,64 +47,44 @@ def event_scope(
     if campaign_ids:
         base_filters.append("c.campaign_id::VARCHAR IN (SELECT unnest(?))")
         base_params.append(list(campaign_ids))
-    date_filters: list[str] = []
-    date_params: list[Any] = []
+    event_filters = [*base_filters]
+    event_params: list[Any] = [*base_params]
     if start:
-        date_filters.append("created_at >= ?::TIMESTAMPTZ")
-        date_params.append(start)
+        event_filters.append("e.created_at >= ?::TIMESTAMPTZ")
+        event_params.append(start)
     if end:
-        date_filters.append("created_at <= ?::TIMESTAMPTZ")
-        date_params.append(end)
+        event_filters.append("e.created_at <= ?::TIMESTAMPTZ")
+        event_params.append(end)
     if day:
         # Day boundaries in the display timezone so DST can't shift them.
-        date_filters.append("(created_at AT TIME ZONE ?)::DATE = ?::DATE")
-        date_params.extend([tz, day])
-    return EventScope(base_filters, base_params, date_filters, date_params)
+        event_filters.append("(e.created_at AT TIME ZONE ?)::DATE = ?::DATE")
+        event_params.extend([tz, day])
+    return EventScope(base_filters, base_params, event_filters, event_params)
 
 
-def base_events_sql(base_filters: list[str]) -> str:
-    """The one Postgres scan per request: scoped result events joined to
-    their place lookups, with payload fields extracted. Both reductions
-    and the day list derive from its materialization. Binds the base
-    params."""
-    return f"""
-        SELECT
-            e.person_id,
-            e.walk_id::VARCHAR AS walk_id,
-            e.canvasser_name,
-            e.canvasser_phone,
-            json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome') AS outcome,
-            json_extract(CAST(e.payload AS VARCHAR), '$.responses') AS responses,
-            t.zone_id::VARCHAR AS zone_id,
-            t.zone_name,
-            t.name AS turf_name,
-            c.name AS campaign,
-            c.organization_id,
-            e.created_at,
-            e.sequence
-        FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
-        JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
-        JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
-        JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
-            ON o.organization_id = c.organization_id
-        WHERE {" AND ".join(base_filters)}
-    """
-
-
-def latest_results_cte(persons_fqn: str, where: str, rel: str, date_filters: list[str]) -> str:
-    """WITH block reducing the base relation `rel` to each person's
-    latest result within the date window, joined to the conditioned
-    population (`where` over `persons_fqn`; empty = everyone). Queries
-    built on it bind the date params first, then the criteria params."""
-    date_where = f"WHERE {' AND '.join(date_filters)}" if date_filters else ""
+def latest_results_cte(persons_fqn: str, where: str, event_filters: list[str]) -> str:
+    """WITH block reducing events to each person's latest result, joined
+    to the conditioned population (`where` over `persons_fqn`; empty =
+    everyone). Queries built on it bind the event params first, then the
+    criteria params."""
     return f"""
         WITH latest AS (
             SELECT * FROM (
-                SELECT person_id, outcome, responses, zone_id, zone_name, sequence
-                FROM {rel}
-                {date_where}
+                SELECT
+                    e.person_id,
+                    json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome') AS outcome,
+                    json_extract(CAST(e.payload AS VARCHAR), '$.responses') AS responses,
+                    t.zone_id::VARCHAR AS zone_id,
+                    t.zone_name,
+                    e.sequence
+                FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
+                JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
+                JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
+                JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
+                    ON o.organization_id = c.organization_id
+                WHERE {" AND ".join(event_filters)}
                 QUALIFY row_number() OVER (
-                    PARTITION BY person_id ORDER BY sequence DESC
+                    PARTITION BY e.person_id ORDER BY e.sequence DESC
                 ) = 1
             )
         ),
@@ -167,32 +145,46 @@ def answered_sql(rel: str) -> str:
         """
 
 
-def attempts_cte(persons_fqn: str, where: str, rel: str, date_filters: list[str]) -> str:
-    """WITH block reducing the base relation `rel` to attempts — the
-    latest result per (person, walk) within the date window — joined to
-    the conditioned population. Events without a walk_id (pre-stamp
-    clients) group by canvass day in the display timezone instead. A
-    person whose scope-wide latest result is a clear contributes no
-    attempts: a clear means the record was a mistake, erasing attempt
-    history too, so attempt-derived counts match the person grain by
-    construction. Queries built on it bind the date params, then the
-    fallback tz, then the criteria params."""
-    date_where = f"WHERE {' AND '.join(date_filters)}" if date_filters else ""
+def attempts_cte(persons_fqn: str, where: str, event_filters: list[str]) -> str:
+    """WITH block reducing events to attempts — the latest result per
+    (person, walk) — joined to the conditioned population. Events
+    without a walk_id (pre-stamp clients) group by canvass day in the
+    display timezone instead. A person whose scope-wide latest result
+    is a clear contributes no attempts: a clear means the record was a
+    mistake, erasing attempt history too, so attempt-derived counts
+    match the person grain by construction. Queries built on it bind
+    the event params, then the fallback tz, then the criteria params."""
     return f"""
         WITH attempt_latest AS (
             SELECT * FROM (
                 SELECT
-                    b.*,
-                    first_value(outcome)
-                        OVER (PARTITION BY person_id ORDER BY sequence DESC)
+                    e.person_id,
+                    e.walk_id::VARCHAR AS walk_id,
+                    e.canvasser_name,
+                    e.canvasser_phone,
+                    json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome') AS outcome,
+                    json_extract(CAST(e.payload AS VARCHAR), '$.responses') AS responses,
+                    t.zone_id::VARCHAR AS zone_id,
+                    t.zone_name,
+                    t.name AS turf_name,
+                    c.name AS campaign,
+                    c.organization_id,
+                    e.created_at,
+                    e.sequence,
+                    first_value(json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome'))
+                        OVER (PARTITION BY e.person_id ORDER BY e.sequence DESC)
                         AS current_outcome
-                FROM {rel} b
-                {date_where}
+                FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
+                JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
+                JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
+                JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
+                    ON o.organization_id = c.organization_id
+                WHERE {" AND ".join(event_filters)}
                 QUALIFY row_number() OVER (
-                    PARTITION BY person_id, coalesce(
-                        walk_id,
-                        ((created_at AT TIME ZONE ?)::DATE)::VARCHAR)
-                    ORDER BY sequence DESC
+                    PARTITION BY e.person_id, coalesce(
+                        e.walk_id::VARCHAR,
+                        ((e.created_at AT TIME ZONE ?)::DATE)::VARCHAR)
+                    ORDER BY e.sequence DESC
                 ) = 1
             )
         ),
@@ -250,13 +242,17 @@ def canvasser_stats_sql(rel: str) -> str:
         """
 
 
-def canvass_days_sql(rel: str) -> str:
-    """Distinct canvass days in the display timezone over the base
-    relation (date-unfiltered by construction), newest first. Binds
-    [tz]."""
+def canvass_days_sql(base_filters: list[str]) -> str:
+    """Distinct canvass days in the display timezone, newest first.
+    Binds [tz, *base_params]."""
     return f"""
-        SELECT DISTINCT ((created_at AT TIME ZONE ?)::DATE)::VARCHAR AS day
-        FROM {rel}
+        SELECT DISTINCT ((e.created_at AT TIME ZONE ?)::DATE)::VARCHAR AS day
+        FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
+        JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
+        JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
+        JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
+            ON o.organization_id = c.organization_id
+        WHERE {" AND ".join(base_filters)}
         ORDER BY day DESC
     """
 

--- a/apps/data/src/canvass_events.py
+++ b/apps/data/src/canvass_events.py
@@ -1,9 +1,11 @@
 """Read path over the canvass event log (app.canvass_events).
 
 Two reduction rules shared by every reporting surface, both "latest
-result by event sequence within the requested scope": per person (the
-current-state grain behind funnel stages and response counts) and per
-(person, walk) (the attempt grain behind the row-level reports). The
+result by event sequence": per person within the requested date window
+(the current-state grain behind funnel stages and response counts) and
+per (person, walk) over the full campaign scope (the attempt grain
+behind the row-level reports; date filters select among the reduced
+attempts). The
 person grain is the attempt grain reduced once more, so counts derived
 from either reconcile by construction. The `*_cte` builders produce the
 reduction; the aggregate builders read a materialized relation by name
@@ -24,9 +26,10 @@ from src.duckdb import OPERATIONAL_PG_ALIAS
 @dataclass
 class EventScope:
     """Event-log WHERE fragments, split in two: `base` (org + campaigns)
-    feeds the canvass-day list, which must ignore date filters — the
-    picker's options would otherwise collapse to the current pick;
-    `event` adds the date window for the reduction itself."""
+    scopes the attempt-grain reduction, which is deliberately date-free
+    — the day chip selects among reduced attempts afterward; `event`
+    adds the date window for the Results person-grain reduction, whose
+    question is "latest result within this window"."""
 
     base_filters: list[str]
     base_params: list[Any]

--- a/apps/data/src/canvass_events.py
+++ b/apps/data/src/canvass_events.py
@@ -5,10 +5,12 @@ result by event sequence within the requested scope": per person (the
 current-state grain behind funnel stages and response counts) and per
 (person, walk) (the attempt grain behind the row-level reports). The
 person grain is the attempt grain reduced once more, so counts derived
-from either reconcile by construction. Builders name operational
-Postgres through OPERATIONAL_PG_ALIAS, so tests attach a synthetic
-in-memory catalog under the same alias and run the exact production
-SQL.
+from either reconcile by construction. The `*_cte` builders produce the
+reduction; the aggregate builders read a materialized relation by name
+(src.duckdb.materialize), so each request reduces the log once.
+Builders name operational Postgres through OPERATIONAL_PG_ALIAS, so
+tests attach a synthetic in-memory catalog under the same alias and run
+the exact production SQL.
 """
 
 from __future__ import annotations
@@ -21,15 +23,17 @@ from src.duckdb import OPERATIONAL_PG_ALIAS
 
 @dataclass
 class EventScope:
-    """Event-log WHERE fragments, split in two: `base` (org + campaigns)
-    feeds the canvass-day list, which must ignore date filters — the
-    picker's options would otherwise collapse to the current pick;
-    `event` adds the date window for the reduction itself."""
+    """Event-log WHERE fragments, split by where they apply: `base` (org
+    + campaigns, `e.`-prefixed) scopes the one Postgres scan that
+    materializes the base relation; `date` (unprefixed) narrows the
+    reductions over that relation. The day list derives from the base
+    relation and must ignore date filters — the picker's options would
+    otherwise collapse to the current pick."""
 
     base_filters: list[str]
     base_params: list[Any]
-    event_filters: list[str]
-    event_params: list[Any]
+    date_filters: list[str]
+    date_params: list[Any]
 
 
 def event_scope(
@@ -45,44 +49,64 @@ def event_scope(
     if campaign_ids:
         base_filters.append("c.campaign_id::VARCHAR IN (SELECT unnest(?))")
         base_params.append(list(campaign_ids))
-    event_filters = [*base_filters]
-    event_params: list[Any] = [*base_params]
+    date_filters: list[str] = []
+    date_params: list[Any] = []
     if start:
-        event_filters.append("e.created_at >= ?::TIMESTAMPTZ")
-        event_params.append(start)
+        date_filters.append("created_at >= ?::TIMESTAMPTZ")
+        date_params.append(start)
     if end:
-        event_filters.append("e.created_at <= ?::TIMESTAMPTZ")
-        event_params.append(end)
+        date_filters.append("created_at <= ?::TIMESTAMPTZ")
+        date_params.append(end)
     if day:
         # Day boundaries in the display timezone so DST can't shift them.
-        event_filters.append("(e.created_at AT TIME ZONE ?)::DATE = ?::DATE")
-        event_params.extend([tz, day])
-    return EventScope(base_filters, base_params, event_filters, event_params)
+        date_filters.append("(created_at AT TIME ZONE ?)::DATE = ?::DATE")
+        date_params.extend([tz, day])
+    return EventScope(base_filters, base_params, date_filters, date_params)
 
 
-def latest_results_cte(persons_fqn: str, where: str, event_filters: list[str]) -> str:
-    """WITH block reducing events to each person's latest result, joined
-    to the conditioned population (`where` over `persons_fqn`; empty =
-    everyone). Queries built on it bind the event params first, then the
-    criteria params."""
+def base_events_sql(base_filters: list[str]) -> str:
+    """The one Postgres scan per request: scoped result events joined to
+    their place lookups, with payload fields extracted. Both reductions
+    and the day list derive from its materialization. Binds the base
+    params."""
+    return f"""
+        SELECT
+            e.person_id,
+            e.walk_id::VARCHAR AS walk_id,
+            e.canvasser_name,
+            e.canvasser_phone,
+            json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome') AS outcome,
+            json_extract(CAST(e.payload AS VARCHAR), '$.responses') AS responses,
+            t.zone_id::VARCHAR AS zone_id,
+            t.zone_name,
+            t.name AS turf_name,
+            c.name AS campaign,
+            c.organization_id,
+            e.created_at,
+            e.sequence
+        FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
+        JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
+        JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
+        JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
+            ON o.organization_id = c.organization_id
+        WHERE {" AND ".join(base_filters)}
+    """
+
+
+def latest_results_cte(persons_fqn: str, where: str, rel: str, date_filters: list[str]) -> str:
+    """WITH block reducing the base relation `rel` to each person's
+    latest result within the date window, joined to the conditioned
+    population (`where` over `persons_fqn`; empty = everyone). Queries
+    built on it bind the date params first, then the criteria params."""
+    date_where = f"WHERE {' AND '.join(date_filters)}" if date_filters else ""
     return f"""
         WITH latest AS (
             SELECT * FROM (
-                SELECT
-                    e.person_id,
-                    json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome') AS outcome,
-                    json_extract(CAST(e.payload AS VARCHAR), '$.responses') AS responses,
-                    t.zone_id::VARCHAR AS zone_id,
-                    t.zone_name,
-                    e.sequence
-                FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
-                JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
-                JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
-                JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
-                    ON o.organization_id = c.organization_id
-                WHERE {" AND ".join(event_filters)}
+                SELECT person_id, outcome, responses, zone_id, zone_name, sequence
+                FROM {rel}
+                {date_where}
                 QUALIFY row_number() OVER (
-                    PARTITION BY e.person_id ORDER BY e.sequence DESC
+                    PARTITION BY person_id ORDER BY sequence DESC
                 ) = 1
             )
         ),
@@ -95,47 +119,42 @@ def latest_results_cte(persons_fqn: str, where: str, event_filters: list[str]) -
     """
 
 
-def stages_sql(cte: str) -> str:
-    """Per-zone funnel stages over the reduced events."""
-    return (
-        cte
-        + """
+def stages_sql(rel: str) -> str:
+    """Per-zone funnel stages over `rel`, a materialized latest-result
+    relation (see `latest_results_cte` + `materialize`)."""
+    return f"""
         SELECT
             zone_id,
             any_value(zone_name) AS zone_name,
             count(*) FILTER (WHERE outcome IS NOT NULL) AS attempted,
             count(*) FILTER (WHERE outcome = 'canvassed') AS contacted
-        FROM joined
+        FROM {rel}
         GROUP BY zone_id
         """
-    )
 
 
-def responses_sql(cte: str) -> str:
-    """Per-zone option counts among the contacted."""
-    return (
-        cte
-        + """
+def responses_sql(rel: str) -> str:
+    """Per-zone option counts among the contacted, over a materialized
+    latest-result relation."""
+    return f"""
         SELECT zone_id, q.question_id, o.option_id, count(*) AS n
-        FROM joined,
+        FROM {rel},
              UNNEST(json_keys(responses)) AS q(question_id),
              UNNEST(CAST(json_extract(responses,
                  '$."' || q.question_id || '".optionIds') AS VARCHAR[])) AS o(option_id)
         WHERE outcome = 'canvassed'
         GROUP BY 1, 2, 3
         """
-    )
 
 
-def answered_sql(cte: str) -> str:
+def answered_sql(rel: str) -> str:
     """Per-zone count of contacted people who answered each question at
     all — non-empty optionIds or text. The completion stat for questions
-    whose answers aren't option counts (open-ended)."""
-    return (
-        cte
-        + """
+    whose answers aren't option counts (open-ended). Reads a materialized
+    latest-result relation."""
+    return f"""
         SELECT zone_id, q.question_id, count(*) AS n
-        FROM joined,
+        FROM {rel},
              UNNEST(json_keys(responses)) AS q(question_id)
         WHERE outcome = 'canvassed'
           AND (
@@ -146,49 +165,34 @@ def answered_sql(cte: str) -> str:
           )
         GROUP BY 1, 2
         """
-    )
 
 
-def attempts_cte(persons_fqn: str, where: str, event_filters: list[str]) -> str:
-    """WITH block reducing events to attempts — the latest result per
-    (person, walk) — joined to the conditioned population. Events
-    without a walk_id (pre-stamp clients) group by canvass day in the
-    display timezone instead. A person whose scope-wide latest result
-    is a clear contributes no attempts: a clear means the record was a
-    mistake, erasing attempt history too, so attempt-derived counts
-    match the person grain by construction. Queries built on it bind
-    the event params, then the fallback tz, then the criteria params."""
+def attempts_cte(persons_fqn: str, where: str, rel: str, date_filters: list[str]) -> str:
+    """WITH block reducing the base relation `rel` to attempts — the
+    latest result per (person, walk) within the date window — joined to
+    the conditioned population. Events without a walk_id (pre-stamp
+    clients) group by canvass day in the display timezone instead. A
+    person whose scope-wide latest result is a clear contributes no
+    attempts: a clear means the record was a mistake, erasing attempt
+    history too, so attempt-derived counts match the person grain by
+    construction. Queries built on it bind the date params, then the
+    fallback tz, then the criteria params."""
+    date_where = f"WHERE {' AND '.join(date_filters)}" if date_filters else ""
     return f"""
         WITH attempt_latest AS (
             SELECT * FROM (
                 SELECT
-                    e.person_id,
-                    e.walk_id::VARCHAR AS walk_id,
-                    e.canvasser_name,
-                    e.canvasser_phone,
-                    json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome') AS outcome,
-                    json_extract(CAST(e.payload AS VARCHAR), '$.responses') AS responses,
-                    t.zone_id::VARCHAR AS zone_id,
-                    t.zone_name,
-                    t.name AS turf_name,
-                    c.name AS campaign,
-                    c.organization_id,
-                    e.created_at,
-                    e.sequence,
-                    first_value(json_extract_string(CAST(e.payload AS VARCHAR), '$.outcome'))
-                        OVER (PARTITION BY e.person_id ORDER BY e.sequence DESC)
+                    b.*,
+                    first_value(outcome)
+                        OVER (PARTITION BY person_id ORDER BY sequence DESC)
                         AS current_outcome
-                FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
-                JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
-                JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
-                JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
-                    ON o.organization_id = c.organization_id
-                WHERE {" AND ".join(event_filters)}
+                FROM {rel} b
+                {date_where}
                 QUALIFY row_number() OVER (
-                    PARTITION BY e.person_id, coalesce(
-                        e.walk_id::VARCHAR,
-                        ((e.created_at AT TIME ZONE ?)::DATE)::VARCHAR)
-                    ORDER BY e.sequence DESC
+                    PARTITION BY person_id, coalesce(
+                        walk_id,
+                        ((created_at AT TIME ZONE ?)::DATE)::VARCHAR)
+                    ORDER BY sequence DESC
                 ) = 1
             )
         ),
@@ -203,39 +207,35 @@ def attempts_cte(persons_fqn: str, where: str, event_filters: list[str]) -> str:
     """
 
 
-def walk_stats_sql(cte: str) -> str:
-    """Per-walk tallies over the attempt grain (attempts are already
+def walk_stats_sql(rel: str) -> str:
+    """Per-walk tallies over `rel`, a materialized attempt-grain relation
+    (see `attempts_cte` + `materialize`; attempts are already
     outcome-bearing, so attempted = row count). Walkless attempts from
     pre-stamp clients have no walk to attribute to and are absent; walk
     rows and their sign-out lookups join in at the endpoint, so
     sign-outs with no attempts zero-fill there. Activity timestamps
     come back as UTC ISO strings (display-tz formatting is the
     endpoint's job)."""
-    return (
-        cte
-        + """
+    return f"""
         SELECT
             walk_id,
             count(*) AS attempted,
             count(*) FILTER (WHERE outcome = 'canvassed') AS contacted,
             min(created_at)::VARCHAR AS first_activity,
             max(created_at)::VARCHAR AS last_activity
-        FROM attempts
+        FROM {rel}
         WHERE walk_id IS NOT NULL
         GROUP BY walk_id
         """
-    )
 
 
-def canvasser_stats_sql(cte: str) -> str:
-    """Per-canvasser tallies over the attempt grain. Identity is the
-    claimed attestation — phone where present, else name — and the
-    display name is the most recently claimed one. Everything derives
-    from attempts, so a canvasser exists only with ≥1 attempt and
-    sign-outs with no attempts don't count as walks."""
-    return (
-        cte
-        + """
+def canvasser_stats_sql(rel: str) -> str:
+    """Per-canvasser tallies over a materialized attempt-grain relation.
+    Identity is the claimed attestation — phone where present, else name
+    — and the display name is the most recently claimed one. Everything
+    derives from attempts, so a canvasser exists only with ≥1 attempt
+    and sign-outs with no attempts don't count as walks."""
+    return f"""
         SELECT
             coalesce(canvasser_phone, canvasser_name) AS canvasser_key,
             arg_max(canvasser_name, sequence) AS canvasser_name,
@@ -245,23 +245,18 @@ def canvasser_stats_sql(cte: str) -> str:
             count(*) FILTER (WHERE outcome = 'canvassed') AS contacted,
             min(created_at)::VARCHAR AS first_active,
             max(created_at)::VARCHAR AS last_active
-        FROM attempts
+        FROM {rel}
         GROUP BY 1
         """
-    )
 
 
-def canvass_days_sql(base_filters: list[str]) -> str:
-    """Distinct canvass days in the display timezone, newest first.
-    Binds [tz, *base_params]."""
+def canvass_days_sql(rel: str) -> str:
+    """Distinct canvass days in the display timezone over the base
+    relation (date-unfiltered by construction), newest first. Binds
+    [tz]."""
     return f"""
-        SELECT DISTINCT ((e.created_at AT TIME ZONE ?)::DATE)::VARCHAR AS day
-        FROM {OPERATIONAL_PG_ALIAS}.app.canvass_events e
-        JOIN {OPERATIONAL_PG_ALIAS}.app.turfs t ON t.turf_id = e.turf_id
-        JOIN {OPERATIONAL_PG_ALIAS}.app.campaigns c ON c.campaign_id = t.campaign_id
-        JOIN {OPERATIONAL_PG_ALIAS}.app.organizations o
-            ON o.organization_id = c.organization_id
-        WHERE {" AND ".join(base_filters)}
+        SELECT DISTINCT ((created_at AT TIME ZONE ?)::DATE)::VARCHAR AS day
+        FROM {rel}
         ORDER BY day DESC
     """
 

--- a/apps/data/src/duckdb.py
+++ b/apps/data/src/duckdb.py
@@ -262,6 +262,16 @@ def refresh_s3_secret_on_shared_connection(settings: Settings) -> None:
 OPERATIONAL_PG_ALIAS = "operational_pg"
 
 
+def materialize(conn: duckdb.DuckDBPyConnection, name: str, sql: str, params: list | None = None) -> str:
+    """Run `sql` once into a temp table and return its name, so call
+    sites thread the relation from creation to the statements that read
+    it. Temp schemas are per-cursor (verified: isolated between cursors,
+    allowed on read-only connections), so the table lives exactly as
+    long as the request and concurrent requests can't collide."""
+    conn.execute(f"CREATE OR REPLACE TEMP TABLE {name} AS {sql}", params or [])
+    return name
+
+
 def attach_operational_postgres(conn: duckdb.DuckDBPyConnection, settings: Settings) -> None:
     """Install + load DuckDB's `postgres` extension and ATTACH the operational
     Postgres database under `OPERATIONAL_PG_ALIAS`.

--- a/apps/data/src/reports.py
+++ b/apps/data/src/reports.py
@@ -16,8 +16,8 @@ from typing import TYPE_CHECKING, Any
 
 from src.canvass_events import (
     EventScope,
+    attempt_days_sql,
     attempts_cte,
-    canvass_days_sql,
     canvasser_stats_sql,
     event_scope,
     walk_stats_sql,
@@ -100,22 +100,37 @@ def _shared_cols(ctx: ReportCtx) -> str:
     return ", ".join(f"p.{c}" for c in ctx.voter_cols)
 
 
-def _event_days(ctx: ReportCtx) -> tuple[str, list]:
-    return canvass_days_sql(ctx.scope.base_filters), [ctx.tz, *ctx.scope.base_params]
+def _event_days(attempts: str, tz: str) -> tuple[str, list]:
+    return attempt_days_sql(attempts), [tz]
 
 
-def _materialize_attempts(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx, scope: EventScope | None = None) -> str:
+def _materialize_attempts(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> str:
     """One event-log reduction per request: the attempt grain lands in a
     temp table every later statement reads by the returned name, instead
     of each re-running the Postgres scan and persons join as a CTE
-    prefix."""
-    scope = scope or ctx.scope
+    prefix. Always the full campaign scope — date selection happens on
+    the reduced attempts (see attempts_cte), and the day picker reads
+    this relation."""
     with timed("query"):
         return materialize(
             conn,
             "attempts",
-            f"{attempts_cte(ctx.persons, '', scope.event_filters)} SELECT * FROM attempts",
-            [*scope.event_params, ctx.tz],
+            f"{attempts_cte(ctx.persons, '', ctx.scope.base_filters)} SELECT * FROM attempts",
+            [*ctx.scope.base_params, ctx.tz],
+        )
+
+
+def _dated_attempts(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx, attempts: str) -> str:
+    """The day chip selects among finished attempts by their timestamp —
+    a cheap temp-to-temp cut, not a re-reduction."""
+    if not ctx.day:
+        return attempts
+    with timed("query"):
+        return materialize(
+            conn,
+            "attempts_dated",
+            f"SELECT * FROM {attempts} WHERE (created_at AT TIME ZONE ?)::DATE = ?::DATE",
+            [ctx.tz, ctx.day],
         )
 
 
@@ -216,7 +231,8 @@ def people_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """One row per attempted person's current state — the latest
     attempt's snapshot, so this and the attempt grain reconcile — with
     attempt-count rollups and generated question columns."""
-    attempts = _materialize_attempts(conn, ctx)
+    attempts_all = _materialize_attempts(conn, ctx)
+    attempts = _dated_attempts(conn, ctx, attempts_all)
     chain = f"""
         WITH current AS (
             SELECT * FROM {attempts}
@@ -252,7 +268,7 @@ def people_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
             LEFT JOIN qp ON qp.pivot_key = cur.person_id
         )"""
     )
-    days_sql, days_params = _event_days(ctx)
+    days_sql, days_params = _event_days(attempts_all, ctx.tz)
     # No turf/zone: they'd be the latest attempt's — event detail, not
     # person state (the Attempts report answers "where"). Campaign stays:
     # in the all-campaigns view it labels which pass's truth — and which
@@ -290,7 +306,8 @@ def people_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
 def attempts_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """One row per attempt, with the attempt's own snapshot pivoted into
     the generated question columns."""
-    attempts = _materialize_attempts(conn, ctx)
+    attempts_all = _materialize_attempts(conn, ctx)
+    attempts = _dated_attempts(conn, ctx, attempts_all)
     pivot_cte, pivot_cols, question_columns = _question_pivot(conn, ctx.org_slug, "", [], attempts, "sequence")
     body_sql = (
         f"WITH {_pop_cols_sql(ctx)}"
@@ -308,7 +325,7 @@ def attempts_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec
             LEFT JOIN qp ON qp.pivot_key = a.sequence
         )"""
     )
-    days_sql, days_params = _event_days(ctx)
+    days_sql, days_params = _event_days(attempts_all, ctx.tz)
     return ReportSpec(
         body_sql=body_sql,
         params=[ctx.tz],
@@ -341,7 +358,8 @@ def attempts_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec
 def responses_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """One row per answer per canvassed attempt — the history grain.
     Question labels are pinned to the event's own org."""
-    attempts = _materialize_attempts(conn, ctx)
+    attempts_all = _materialize_attempts(conn, ctx)
+    attempts = _dated_attempts(conn, ctx, attempts_all)
     body_sql = f"""
         WITH answer_rows AS (
             SELECT a.*, q.question_id, o.option_id,
@@ -378,7 +396,7 @@ def responses_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpe
             LEFT JOIN {OPERATIONAL_PG_ALIAS}.app.response_options ro
                 ON ro.response_option_id::VARCHAR = ar.option_id
         )"""
-    days_sql, days_params = _event_days(ctx)
+    days_sql, days_params = _event_days(attempts_all, ctx.tz)
     return ReportSpec(
         body_sql=body_sql,
         params=[ctx.tz],
@@ -417,7 +435,6 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     them, and the Canvassers report already counts walks this way. A
     walk is a single outing, so its tallies are its own: the day chip
     filters the sign-out day, not the stats window."""
-    walk_scope = event_scope(ctx.org_slug, ctx.campaign_ids)
     walk_filters = ["o.slug = ?"]
     walk_params: list = [ctx.org_slug]
     if ctx.campaign_ids:
@@ -428,7 +445,7 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     if ctx.day:
         day_filter = "AND (w.opened_at AT TIME ZONE ?)::DATE = ?::DATE"
         day_params = [ctx.tz, ctx.day]
-    attempts = _materialize_attempts(conn, ctx, walk_scope)
+    attempts = _materialize_attempts(conn, ctx)
     body_sql = f"""
         WITH stats AS ({walk_stats_sql(attempts)}),
         walk_rows AS (
@@ -514,7 +531,8 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
 
 def canvassers_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """One row per claimed attestation with ≥1 attempt."""
-    attempts = _materialize_attempts(conn, ctx)
+    attempts_all = _materialize_attempts(conn, ctx)
+    attempts = _dated_attempts(conn, ctx, attempts_all)
     body_sql = f"""
         WITH stats AS ({canvasser_stats_sql(attempts)}),
         report AS (
@@ -528,7 +546,7 @@ def canvassers_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSp
                    canvasser_phone AS phone, first_active, last_active
             FROM stats
         )"""
-    days_sql, days_params = _event_days(ctx)
+    days_sql, days_params = _event_days(attempts_all, ctx.tz)
     return ReportSpec(
         body_sql=body_sql,
         params=[ctx.tz, ctx.tz],

--- a/apps/data/src/reports.py
+++ b/apps/data/src/reports.py
@@ -111,7 +111,7 @@ def _materialize_attempts(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> st
     prefix. Always the full campaign scope — date selection happens on
     the reduced attempts (see attempts_cte), and the day picker reads
     this relation."""
-    with timed("query"):
+    with timed("query"), timed("reduce"):
         return materialize(
             conn,
             "attempts",
@@ -125,7 +125,7 @@ def _dated_attempts(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx, attempts: s
     a cheap temp-to-temp cut, not a re-reduction."""
     if not ctx.day:
         return attempts
-    with timed("query"):
+    with timed("query"), timed("dated"):
         return materialize(
             conn,
             "attempts_dated",
@@ -146,17 +146,18 @@ def _question_pivot(
     and `responses`). Org-pinned: a foreign question id in a payload
     never becomes a column. Returns the pivot CTEs, the quoted column
     refs to splice into the report SELECT, and the display labels."""
-    question_ids = [
-        r[0]
-        for r in conn.execute(
-            chain_sql
-            + f"""
-            SELECT DISTINCT q.question_id
-            FROM {rel}, UNNEST(json_keys(responses)) AS q(question_id)
-            """,
-            chain_params,
-        ).fetchall()
-    ]
+    with timed("pivot"):
+        question_ids = [
+            r[0]
+            for r in conn.execute(
+                chain_sql
+                + f"""
+                SELECT DISTINCT q.question_id
+                FROM {rel}, UNNEST(json_keys(responses)) AS q(question_id)
+                """,
+                chain_params,
+            ).fetchall()
+        ]
     questions: list[tuple[str, str]] = []
     if question_ids:
         questions = conn.execute(
@@ -670,15 +671,20 @@ def preview(
 ) -> dict[str, Any]:
     with timed("query"):
         # The composed report runs once; count, page, and summary read the
-        # materialized rows instead of re-running the chain.
-        report = materialize(conn, "report_rows", f"{spec.body_sql} SELECT * FROM report", spec.params)
-        total_row = conn.execute(f"SELECT count(*) FROM {report}").fetchone()
-        rows = conn.execute(
-            f"SELECT {_select_list(spec)} FROM {report} {_order_sql(spec, sort, dir_)}"
-            f" LIMIT {PAGE_ROWS} OFFSET {int(offset)}"
-        ).fetchall()
-        day_rows = conn.execute(spec.days_sql, spec.days_params).fetchall()
-        summary = _summary(conn, kind, report)
+        # materialized rows instead of re-running the chain. Sub-phases
+        # decompose the query budget in Server-Timing.
+        with timed("report"):
+            report = materialize(conn, "report_rows", f"{spec.body_sql} SELECT * FROM report", spec.params)
+        with timed("page"):
+            total_row = conn.execute(f"SELECT count(*) FROM {report}").fetchone()
+            rows = conn.execute(
+                f"SELECT {_select_list(spec)} FROM {report} {_order_sql(spec, sort, dir_)}"
+                f" LIMIT {PAGE_ROWS} OFFSET {int(offset)}"
+            ).fetchall()
+        with timed("days"):
+            day_rows = conn.execute(spec.days_sql, spec.days_params).fetchall()
+        with timed("summary"):
+            summary = _summary(conn, kind, report)
     return {
         "columns": spec.columns,
         "rows": [list(r) for r in rows],

--- a/apps/data/src/reports.py
+++ b/apps/data/src/reports.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any
 from src.canvass_events import (
     EventScope,
     attempts_cte,
-    base_events_sql,
     canvass_days_sql,
     canvasser_stats_sql,
     event_scope,
@@ -46,8 +45,6 @@ class ReportCtx:
     person_cols: list[str]
     id_cols: list[str]
     scope: EventScope
-    # Materialized base-events relation — the request's one Postgres scan.
-    base: str
 
 
 def build_ctx(
@@ -66,9 +63,6 @@ def build_ctx(
     # and address rather than external ids.
     id_cols = [c for c in voter_cols if c in ("external_id", "external_id_type")]
     person_cols = [c for c in voter_cols if c not in ("external_id", "external_id_type")]
-    scope = event_scope(org_slug, campaign_ids, day=day, tz=tz)
-    with timed("query"):
-        base = materialize(conn, "base_events", base_events_sql(scope.base_filters), scope.base_params)
     return ReportCtx(
         org_slug=org_slug,
         campaign_ids=campaign_ids,
@@ -78,8 +72,7 @@ def build_ctx(
         voter_cols=voter_cols,
         person_cols=person_cols,
         id_cols=id_cols,
-        scope=scope,
-        base=base,
+        scope=event_scope(org_slug, campaign_ids, day=day, tz=tz),
     )
 
 
@@ -108,23 +101,21 @@ def _shared_cols(ctx: ReportCtx) -> str:
 
 
 def _event_days(ctx: ReportCtx) -> tuple[str, list]:
-    return canvass_days_sql(ctx.base), [ctx.tz]
+    return canvass_days_sql(ctx.scope.base_filters), [ctx.tz, *ctx.scope.base_params]
 
 
-def _materialize_attempts(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx, dated: bool = True) -> str:
-    """Reduce the materialized base events to the attempt grain, into a
-    temp table every later statement reads by the returned name. `dated`
-    applies the request's date window; walks passes False — a walk is a
-    single outing, so the day chip filters sign-out days, not its
-    stats."""
-    date_filters = ctx.scope.date_filters if dated else []
-    date_params = ctx.scope.date_params if dated else []
+def _materialize_attempts(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx, scope: EventScope | None = None) -> str:
+    """One event-log reduction per request: the attempt grain lands in a
+    temp table every later statement reads by the returned name, instead
+    of each re-running the Postgres scan and persons join as a CTE
+    prefix."""
+    scope = scope or ctx.scope
     with timed("query"):
         return materialize(
             conn,
             "attempts",
-            f"{attempts_cte(ctx.persons, '', ctx.base, date_filters)} SELECT * FROM attempts",
-            [*date_params, ctx.tz],
+            f"{attempts_cte(ctx.persons, '', scope.event_filters)} SELECT * FROM attempts",
+            [*scope.event_params, ctx.tz],
         )
 
 
@@ -426,6 +417,7 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     them, and the Canvassers report already counts walks this way. A
     walk is a single outing, so its tallies are its own: the day chip
     filters the sign-out day, not the stats window."""
+    walk_scope = event_scope(ctx.org_slug, ctx.campaign_ids)
     walk_filters = ["o.slug = ?"]
     walk_params: list = [ctx.org_slug]
     if ctx.campaign_ids:
@@ -436,7 +428,7 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     if ctx.day:
         day_filter = "AND (w.opened_at AT TIME ZONE ?)::DATE = ?::DATE"
         day_params = [ctx.tz, ctx.day]
-    attempts = _materialize_attempts(conn, ctx, dated=False)
+    attempts = _materialize_attempts(conn, ctx, walk_scope)
     body_sql = f"""
         WITH stats AS ({walk_stats_sql(attempts)}),
         walk_rows AS (

--- a/apps/data/src/reports.py
+++ b/apps/data/src/reports.py
@@ -17,12 +17,13 @@ from typing import TYPE_CHECKING, Any
 from src.canvass_events import (
     EventScope,
     attempts_cte,
+    base_events_sql,
     canvass_days_sql,
     canvasser_stats_sql,
     event_scope,
     walk_stats_sql,
 )
-from src.duckdb import OPERATIONAL_PG_ALIAS
+from src.duckdb import OPERATIONAL_PG_ALIAS, materialize
 from src.models import EXPORT_COLUMNS, EXPORT_OPTIONAL
 from src.timing import timed
 
@@ -45,6 +46,8 @@ class ReportCtx:
     person_cols: list[str]
     id_cols: list[str]
     scope: EventScope
+    # Materialized base-events relation — the request's one Postgres scan.
+    base: str
 
 
 def build_ctx(
@@ -63,6 +66,9 @@ def build_ctx(
     # and address rather than external ids.
     id_cols = [c for c in voter_cols if c in ("external_id", "external_id_type")]
     person_cols = [c for c in voter_cols if c not in ("external_id", "external_id_type")]
+    scope = event_scope(org_slug, campaign_ids, day=day, tz=tz)
+    with timed("query"):
+        base = materialize(conn, "base_events", base_events_sql(scope.base_filters), scope.base_params)
     return ReportCtx(
         org_slug=org_slug,
         campaign_ids=campaign_ids,
@@ -72,14 +78,16 @@ def build_ctx(
         voter_cols=voter_cols,
         person_cols=person_cols,
         id_cols=id_cols,
-        scope=event_scope(org_slug, campaign_ids, day=day, tz=tz),
+        scope=scope,
+        base=base,
     )
 
 
 @dataclass
 class ReportSpec:
     """One report's composed SQL and its presentation contract. body_sql
-    ends with a `report` CTE; params bind it in text order."""
+    reads the `attempts` temp table its builder materialized and ends
+    with a `report` CTE; params bind it in text order."""
 
     body_sql: str
     params: list
@@ -100,7 +108,24 @@ def _shared_cols(ctx: ReportCtx) -> str:
 
 
 def _event_days(ctx: ReportCtx) -> tuple[str, list]:
-    return canvass_days_sql(ctx.scope.base_filters), [ctx.tz, *ctx.scope.base_params]
+    return canvass_days_sql(ctx.base), [ctx.tz]
+
+
+def _materialize_attempts(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx, dated: bool = True) -> str:
+    """Reduce the materialized base events to the attempt grain, into a
+    temp table every later statement reads by the returned name. `dated`
+    applies the request's date window; walks passes False — a walk is a
+    single outing, so the day chip filters sign-out days, not its
+    stats."""
+    date_filters = ctx.scope.date_filters if dated else []
+    date_params = ctx.scope.date_params if dated else []
+    with timed("query"):
+        return materialize(
+            conn,
+            "attempts",
+            f"{attempts_cte(ctx.persons, '', ctx.base, date_filters)} SELECT * FROM attempts",
+            [*date_params, ctx.tz],
+        )
 
 
 def _question_pivot(
@@ -200,20 +225,15 @@ def people_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """One row per attempted person's current state — the latest
     attempt's snapshot, so this and the attempt grain reconcile — with
     attempt-count rollups and generated question columns."""
-    cte = attempts_cte(ctx.persons, "", ctx.scope.event_filters)
-    chain = (
-        cte
-        + """,
-        current AS (
-            SELECT * FROM attempts
+    attempts = _materialize_attempts(conn, ctx)
+    chain = f"""
+        WITH current AS (
+            SELECT * FROM {attempts}
             QUALIFY row_number() OVER (
                 PARTITION BY person_id ORDER BY sequence DESC
             ) = 1
         )"""
-    )
-    pivot_cte, pivot_cols, question_columns = _question_pivot(
-        conn, ctx.org_slug, chain, [*ctx.scope.event_params, ctx.tz], "current", "person_id"
-    )
+    pivot_cte, pivot_cols, question_columns = _question_pivot(conn, ctx.org_slug, chain, [], "current", "person_id")
     body_sql = (
         chain
         + pivot_cte
@@ -224,7 +244,7 @@ def people_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
                    count(*) FILTER (WHERE outcome = 'canvassed') AS contacts,
                    strftime(max(created_at) FILTER (WHERE outcome = 'canvassed')
                        AT TIME ZONE ?, '%Y-%m-%d %H:%M') AS last_contact_at
-            FROM attempts GROUP BY person_id
+            FROM {attempts} GROUP BY person_id
         ),
         {_pop_cols_sql(ctx)},
         report AS (
@@ -248,7 +268,7 @@ def people_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     # script's answers — the row carries.
     return ReportSpec(
         body_sql=body_sql,
-        params=[*ctx.scope.event_params, ctx.tz, ctx.tz, ctx.tz],
+        params=[ctx.tz, ctx.tz],
         columns=[
             *ctx.person_cols,
             "attempts",
@@ -279,15 +299,12 @@ def people_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
 def attempts_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """One row per attempt, with the attempt's own snapshot pivoted into
     the generated question columns."""
-    cte = attempts_cte(ctx.persons, "", ctx.scope.event_filters)
-    pivot_cte, pivot_cols, question_columns = _question_pivot(
-        conn, ctx.org_slug, cte, [*ctx.scope.event_params, ctx.tz], "attempts", "sequence"
-    )
+    attempts = _materialize_attempts(conn, ctx)
+    pivot_cte, pivot_cols, question_columns = _question_pivot(conn, ctx.org_slug, "", [], attempts, "sequence")
     body_sql = (
-        cte
+        f"WITH {_pop_cols_sql(ctx)}"
         + pivot_cte
         + f""",
-        {_pop_cols_sql(ctx)},
         report AS (
             SELECT {_shared_cols(ctx)},
                    a.outcome, a.canvasser_name AS canvasser{pivot_cols},
@@ -295,7 +312,7 @@ def attempts_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec
                        AS attempted_at,
                    a.turf_name AS turf, a.zone_name AS zone, a.campaign,
                    a.walk_id, a.created_at, a.sequence
-            FROM attempts a
+            FROM {attempts} a
             JOIN pop_cols p ON p.external_id = a.person_id
             LEFT JOIN qp ON qp.pivot_key = a.sequence
         )"""
@@ -303,7 +320,7 @@ def attempts_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec
     days_sql, days_params = _event_days(ctx)
     return ReportSpec(
         body_sql=body_sql,
-        params=[*ctx.scope.event_params, ctx.tz, ctx.tz],
+        params=[ctx.tz],
         columns=[
             "attempted_at",
             "outcome",
@@ -333,14 +350,12 @@ def attempts_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec
 def responses_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """One row per answer per canvassed attempt — the history grain.
     Question labels are pinned to the event's own org."""
-    cte = attempts_cte(ctx.persons, "", ctx.scope.event_filters)
-    body_sql = (
-        cte
-        + f""",
-        answer_rows AS (
+    attempts = _materialize_attempts(conn, ctx)
+    body_sql = f"""
+        WITH answer_rows AS (
             SELECT a.*, q.question_id, o.option_id,
                    CAST(NULL AS VARCHAR) AS text_answer
-            FROM attempts a,
+            FROM {attempts} a,
                  UNNEST(json_keys(a.responses)) AS q(question_id),
                  UNNEST(CAST(json_extract(a.responses,
                      '$."' || q.question_id || '".optionIds') AS VARCHAR[])) AS o(option_id)
@@ -348,7 +363,7 @@ def responses_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpe
             UNION ALL
             SELECT a.*, q.question_id, CAST(NULL AS VARCHAR),
                    json_extract_string(a.responses, '$."' || q.question_id || '".text')
-            FROM attempts a, UNNEST(json_keys(a.responses)) AS q(question_id)
+            FROM {attempts} a, UNNEST(json_keys(a.responses)) AS q(question_id)
             WHERE a.outcome = 'canvassed'
               AND coalesce(json_extract_string(a.responses,
                   '$."' || q.question_id || '".text'), '') <> ''
@@ -372,11 +387,10 @@ def responses_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpe
             LEFT JOIN {OPERATIONAL_PG_ALIAS}.app.response_options ro
                 ON ro.response_option_id::VARCHAR = ar.option_id
         )"""
-    )
     days_sql, days_params = _event_days(ctx)
     return ReportSpec(
         body_sql=body_sql,
-        params=[*ctx.scope.event_params, ctx.tz, ctx.tz],
+        params=[ctx.tz],
         columns=[
             *ctx.person_cols,
             "question",
@@ -412,7 +426,6 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     them, and the Canvassers report already counts walks this way. A
     walk is a single outing, so its tallies are its own: the day chip
     filters the sign-out day, not the stats window."""
-    walk_scope = event_scope(ctx.org_slug, ctx.campaign_ids)
     walk_filters = ["o.slug = ?"]
     walk_params: list = [ctx.org_slug]
     if ctx.campaign_ids:
@@ -423,11 +436,9 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     if ctx.day:
         day_filter = "AND (w.opened_at AT TIME ZONE ?)::DATE = ?::DATE"
         day_params = [ctx.tz, ctx.day]
-    cte = attempts_cte(ctx.persons, "", walk_scope.event_filters)
-    body_sql = (
-        cte
-        + f""",
-        stats AS ({walk_stats_sql("")}),
+    attempts = _materialize_attempts(conn, ctx, dated=False)
+    body_sql = f"""
+        WITH stats AS ({walk_stats_sql(attempts)}),
         walk_rows AS (
             SELECT w.walk_id, w.canvasser_name, w.opened_at, w.closed_at,
                    t.turf_code, t.name AS turf, t.zone_name AS zone,
@@ -456,7 +467,6 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
             FROM walk_rows wr
             JOIN stats st ON st.walk_id = wr.walk_id
         )"""
-    )
     days_sql = f"""
         SELECT DISTINCT ((w.opened_at AT TIME ZONE ?)::DATE)::VARCHAR AS day
         FROM {OPERATIONAL_PG_ALIAS}.app.walks w
@@ -473,15 +483,7 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """
     return ReportSpec(
         body_sql=body_sql,
-        params=[
-            *walk_scope.event_params,
-            ctx.tz,
-            *walk_params,
-            *day_params,
-            ctx.tz,
-            ctx.tz,
-            ctx.tz,
-        ],
+        params=[*walk_params, *day_params, ctx.tz, ctx.tz, ctx.tz],
         columns=[
             "turf",
             "turf_code",
@@ -520,11 +522,9 @@ def walks_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
 
 def canvassers_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSpec:
     """One row per claimed attestation with ≥1 attempt."""
-    cte = attempts_cte(ctx.persons, "", ctx.scope.event_filters)
-    body_sql = (
-        cte
-        + f""",
-        stats AS ({canvasser_stats_sql("")}),
+    attempts = _materialize_attempts(conn, ctx)
+    body_sql = f"""
+        WITH stats AS ({canvasser_stats_sql(attempts)}),
         report AS (
             SELECT canvasser_name AS canvasser, walks,
                    attempted AS attempts, contacted AS contacts,
@@ -536,11 +536,10 @@ def canvassers_spec(conn: duckdb.DuckDBPyConnection, ctx: ReportCtx) -> ReportSp
                    canvasser_phone AS phone, first_active, last_active
             FROM stats
         )"""
-    )
     days_sql, days_params = _event_days(ctx)
     return ReportSpec(
         body_sql=body_sql,
-        params=[*ctx.scope.event_params, ctx.tz, ctx.tz, ctx.tz],
+        params=[ctx.tz, ctx.tz],
         columns=[
             "canvasser",
             "walks",
@@ -575,32 +574,37 @@ SPECS = {
 }
 
 
-def _select_sql(spec: ReportSpec, sort: str | None, dir_: str) -> str:
+def _order_sql(spec: ReportSpec, sort: str | None, dir_: str) -> str:
     # User sort leads (allowlisted keys only — nothing user-typed lands
     # in the SQL text); the default order stays as tiebreak so paging is
     # deterministic under equal keys.
     if sort and sort in spec.sortable:
         direction = "DESC" if dir_ == "desc" else "ASC"
         keys = ", ".join(f"{c} {direction} NULLS LAST" for c in spec.sortable[sort])
-        order_sql = f"ORDER BY {keys}, {spec.default_order}"
-    else:
-        order_sql = f"ORDER BY {spec.default_order}"
+        return f"ORDER BY {keys}, {spec.default_order}"
+    return f"ORDER BY {spec.default_order}"
+
+
+def _select_list(spec: ReportSpec) -> str:
     # Column names are quoted: generated question columns carry free
     # text; plain lowercase aliases are unaffected.
-    select_list = ", ".join('"' + c.replace('"', '""') + '"' for c in spec.columns)
-    return spec.body_sql + f"SELECT {select_list} FROM report {order_sql}"
+    return ", ".join('"' + c.replace('"', '""') + '"' for c in spec.columns)
 
 
-def _summary(conn: duckdb.DuckDBPyConnection, kind: str, spec: ReportSpec) -> dict[str, Any]:
+def _select_sql(spec: ReportSpec, sort: str | None, dir_: str) -> str:
+    return spec.body_sql + f"SELECT {_select_list(spec)} FROM report {_order_sql(spec, sort, dir_)}"
+
+
+def _summary(conn: duckdb.DuckDBPyConnection, kind: str, rel: str) -> dict[str, Any]:
+    """Aggregates over `rel`, the materialized report rows, so the
+    summary always groups the same rows as the table."""
     if kind == "walks":
         w = conn.execute(
-            spec.body_sql
-            + """
+            f"""
             SELECT count(DISTINCT canvasser), count(DISTINCT turf_code),
                    coalesce(sum(attempts), 0), coalesce(sum(contacts), 0)
-            FROM report
-            """,
-            spec.params,
+            FROM {rel}
+            """
         ).fetchone()
         return {
             "canvassers": int(w[0]) if w else 0,
@@ -610,13 +614,11 @@ def _summary(conn: duckdb.DuckDBPyConnection, kind: str, spec: ReportSpec) -> di
         }
     if kind == "canvassers":
         c = conn.execute(
-            spec.body_sql
-            + """
+            f"""
             SELECT count(*), coalesce(sum(walks), 0),
                    coalesce(sum(attempts), 0), coalesce(sum(contacts), 0)
-            FROM report
-            """,
-            spec.params,
+            FROM {rel}
+            """
         ).fetchone()
         return {
             "canvassers": int(c[0]) if c else 0,
@@ -625,16 +627,12 @@ def _summary(conn: duckdb.DuckDBPyConnection, kind: str, spec: ReportSpec) -> di
             "contacts": int(c[3]) if c else 0,
         }
     if kind == "responses":
-        people_row = conn.execute(
-            spec.body_sql + "SELECT count(DISTINCT external_id) FROM report", spec.params
-        ).fetchone()
+        people_row = conn.execute(f"SELECT count(DISTINCT external_id) FROM {rel}").fetchone()
         question_rows = conn.execute(
-            spec.body_sql
-            + """
-            SELECT question, count(*) FROM report
+            f"""
+            SELECT question, count(*) FROM {rel}
             GROUP BY question ORDER BY min(question_created), question
-            """,
-            spec.params,
+            """
         ).fetchall()
         return {
             "people": int(people_row[0]) if people_row else 0,
@@ -644,13 +642,11 @@ def _summary(conn: duckdb.DuckDBPyConnection, kind: str, spec: ReportSpec) -> di
     # last_outcome); their headline counts differ (contacted people vs
     # distinct people attempted).
     outcome_col = "last_outcome" if kind == "people" else "outcome"
-    outcome_rows = conn.execute(
-        spec.body_sql + f"SELECT {outcome_col}, count(*) FROM report GROUP BY 1", spec.params
-    ).fetchall()
+    outcome_rows = conn.execute(f"SELECT {outcome_col}, count(*) FROM {rel} GROUP BY 1").fetchall()
     outcomes = {(o or "none"): int(n) for o, n in outcome_rows}
     if kind == "people":
         return {"outcomes": outcomes}
-    people_row = conn.execute(spec.body_sql + "SELECT count(DISTINCT external_id) FROM report", spec.params).fetchone()
+    people_row = conn.execute(f"SELECT count(DISTINCT external_id) FROM {rel}").fetchone()
     return {"people": int(people_row[0]) if people_row else 0, "outcomes": outcomes}
 
 
@@ -663,13 +659,16 @@ def preview(
     dir_: str,
 ) -> dict[str, Any]:
     with timed("query"):
-        total_row = conn.execute(spec.body_sql + "SELECT count(*) FROM report", spec.params).fetchone()
+        # The composed report runs once; count, page, and summary read the
+        # materialized rows instead of re-running the chain.
+        report = materialize(conn, "report_rows", f"{spec.body_sql} SELECT * FROM report", spec.params)
+        total_row = conn.execute(f"SELECT count(*) FROM {report}").fetchone()
         rows = conn.execute(
-            _select_sql(spec, sort, dir_) + f" LIMIT {PAGE_ROWS} OFFSET {int(offset)}",
-            spec.params,
+            f"SELECT {_select_list(spec)} FROM {report} {_order_sql(spec, sort, dir_)}"
+            f" LIMIT {PAGE_ROWS} OFFSET {int(offset)}"
         ).fetchall()
         day_rows = conn.execute(spec.days_sql, spec.days_params).fetchall()
-        summary = _summary(conn, kind, spec)
+        summary = _summary(conn, kind, report)
     return {
         "columns": spec.columns,
         "rows": [list(r) for r in rows],

--- a/apps/data/tests/test_canvass_events.py
+++ b/apps/data/tests/test_canvass_events.py
@@ -18,7 +18,6 @@ from src.canvass_events import (
     answered_sql,
     assemble_zone_rows,
     attempts_cte,
-    base_events_sql,
     canvass_days_sql,
     canvasser_stats_sql,
     event_scope,
@@ -115,29 +114,22 @@ def _seed_attempt_extras(conn) -> None:
     conn.executemany("INSERT INTO persons VALUES (?)", [["p7"], ["p8"]])
 
 
-def _materialize_base(conn, scope) -> str:
-    return materialize(conn, "base_events", base_events_sql(scope.base_filters), scope.base_params)
-
-
 def _materialize_joined(conn, scope, where: str = "", where_params: list | None = None) -> str:
-    """The production shape: one Postgres scan into a base temp table,
-    reduce it into another, aggregate from that."""
-    base = _materialize_base(conn, scope)
+    """The production shape: reduce once into a temp table, aggregate from it."""
     return materialize(
         conn,
         "joined",
-        latest_results_cte("persons", where, base, scope.date_filters) + "SELECT * FROM joined",
-        [*scope.date_params, *(where_params or [])],
+        latest_results_cte("persons", where, scope.event_filters) + "SELECT * FROM joined",
+        [*scope.event_params, *(where_params or [])],
     )
 
 
 def _materialize_attempts(conn, scope) -> str:
-    base = _materialize_base(conn, scope)
     return materialize(
         conn,
         "attempts",
-        attempts_cte("persons", "", base, scope.date_filters) + "SELECT * FROM attempts",
-        [*scope.date_params, TZ],
+        attempts_cte("persons", "", scope.event_filters) + "SELECT * FROM attempts",
+        [*scope.event_params, TZ],
     )
 
 
@@ -157,11 +149,10 @@ def _responses(conn, scope) -> dict:
 
 
 def _attempts(conn, scope, where: str = "", where_params: list | None = None) -> dict:
-    base = _materialize_base(conn, scope)
     rows = conn.execute(
-        attempts_cte("persons", where, base, scope.date_filters)
+        attempts_cte("persons", where, scope.event_filters)
         + "SELECT person_id, walk_id, outcome FROM attempts ORDER BY person_id, sequence",
-        [*scope.date_params, TZ, *(where_params or [])],
+        [*scope.event_params, TZ, *(where_params or [])],
     ).fetchall()
     out: dict = {}
     for person_id, walk_id, outcome in rows:
@@ -300,8 +291,7 @@ def test_canvass_days_bucket_in_display_timezone(operational_conn) -> None:
     # Day list rides the base filters only — a date filter must not
     # collapse the picker's options.
     scope = event_scope("testorg", ["camp1"], day="2026-08-23", tz=TZ)
-    base = _materialize_base(operational_conn, scope)
-    rows = operational_conn.execute(canvass_days_sql(base), [TZ]).fetchall()
+    rows = operational_conn.execute(canvass_days_sql(scope.base_filters), [TZ, *scope.base_params]).fetchall()
     assert [r[0] for r in rows] == ["2026-08-24", "2026-08-23"]
 
 

--- a/apps/data/tests/test_canvass_events.py
+++ b/apps/data/tests/test_canvass_events.py
@@ -18,6 +18,7 @@ from src.canvass_events import (
     answered_sql,
     assemble_zone_rows,
     attempts_cte,
+    base_events_sql,
     canvass_days_sql,
     canvasser_stats_sql,
     event_scope,
@@ -26,7 +27,7 @@ from src.canvass_events import (
     stages_sql,
     walk_stats_sql,
 )
-from src.duckdb import OPERATIONAL_PG_ALIAS
+from src.duckdb import OPERATIONAL_PG_ALIAS, materialize
 
 APP = f"{OPERATIONAL_PG_ALIAS}.app"
 
@@ -114,15 +115,41 @@ def _seed_attempt_extras(conn) -> None:
     conn.executemany("INSERT INTO persons VALUES (?)", [["p7"], ["p8"]])
 
 
+def _materialize_base(conn, scope) -> str:
+    return materialize(conn, "base_events", base_events_sql(scope.base_filters), scope.base_params)
+
+
+def _materialize_joined(conn, scope, where: str = "", where_params: list | None = None) -> str:
+    """The production shape: one Postgres scan into a base temp table,
+    reduce it into another, aggregate from that."""
+    base = _materialize_base(conn, scope)
+    return materialize(
+        conn,
+        "joined",
+        latest_results_cte("persons", where, base, scope.date_filters) + "SELECT * FROM joined",
+        [*scope.date_params, *(where_params or [])],
+    )
+
+
+def _materialize_attempts(conn, scope) -> str:
+    base = _materialize_base(conn, scope)
+    return materialize(
+        conn,
+        "attempts",
+        attempts_cte("persons", "", base, scope.date_filters) + "SELECT * FROM attempts",
+        [*scope.date_params, TZ],
+    )
+
+
 def _stages(conn, scope, where: str = "", where_params: list | None = None) -> dict:
-    cte = latest_results_cte("persons", where, scope.event_filters)
-    rows = conn.execute(stages_sql(cte), [*scope.event_params, *(where_params or [])]).fetchall()
+    joined = _materialize_joined(conn, scope, where, where_params)
+    rows = conn.execute(stages_sql(joined)).fetchall()
     return {zone_id: (att, con) for zone_id, _name, att, con in rows}
 
 
 def _responses(conn, scope) -> dict:
-    cte = latest_results_cte("persons", "", scope.event_filters)
-    rows = conn.execute(responses_sql(cte), scope.event_params).fetchall()
+    joined = _materialize_joined(conn, scope)
+    rows = conn.execute(responses_sql(joined)).fetchall()
     out: dict = {}
     for zone_id, question_id, option_id, n in rows:
         out.setdefault(zone_id, {}).setdefault(question_id, {})[option_id] = n
@@ -130,10 +157,11 @@ def _responses(conn, scope) -> dict:
 
 
 def _attempts(conn, scope, where: str = "", where_params: list | None = None) -> dict:
-    cte = attempts_cte("persons", where, scope.event_filters)
+    base = _materialize_base(conn, scope)
     rows = conn.execute(
-        cte + "SELECT person_id, walk_id, outcome FROM attempts ORDER BY person_id, sequence",
-        [*scope.event_params, TZ, *(where_params or [])],
+        attempts_cte("persons", where, base, scope.date_filters)
+        + "SELECT person_id, walk_id, outcome FROM attempts ORDER BY person_id, sequence",
+        [*scope.date_params, TZ, *(where_params or [])],
     ).fetchall()
     out: dict = {}
     for person_id, walk_id, outcome in rows:
@@ -145,8 +173,8 @@ def test_walk_stats_group_the_attempt_grain(operational_conn) -> None:
     _seed(operational_conn)
     _seed_attempt_extras(operational_conn)
     scope = event_scope("testorg", ["camp1"])
-    cte = attempts_cte("persons", "", scope.event_filters)
-    rows = operational_conn.execute(walk_stats_sql(cte), [*scope.event_params, TZ]).fetchall()
+    rel = _materialize_attempts(operational_conn, scope)
+    rows = operational_conn.execute(walk_stats_sql(rel)).fetchall()
     stats = {walk_id: (att, con) for walk_id, att, con, _first, _last in rows}
     # p8's walkless attempts have no walk to attribute to; p3's history
     # is clear-erased before it can count toward w1.
@@ -157,8 +185,8 @@ def test_canvasser_stats_derive_from_attempts(operational_conn) -> None:
     _seed(operational_conn)
     _seed_attempt_extras(operational_conn)
     scope = event_scope("testorg", ["camp1"])
-    cte = attempts_cte("persons", "", scope.event_filters)
-    rows = operational_conn.execute(canvasser_stats_sql(cte), [*scope.event_params, TZ]).fetchall()
+    rel = _materialize_attempts(operational_conn, scope)
+    rows = operational_conn.execute(canvasser_stats_sql(rel)).fetchall()
     stats = {key: (name, walks, att, con) for key, name, _phone, walks, att, con, _first, _last in rows}
     # Walkless attempts still count as attempts but not as walks; the
     # identity key is the claimed phone.
@@ -256,8 +284,8 @@ def test_population_where_narrows_the_join(operational_conn) -> None:
 def test_answered_counts_any_content(operational_conn) -> None:
     _seed(operational_conn)
     scope = event_scope("testorg", ["camp1"])
-    cte = latest_results_cte("persons", "", scope.event_filters)
-    rows = operational_conn.execute(answered_sql(cte), scope.event_params).fetchall()
+    joined = _materialize_joined(operational_conn, scope)
+    rows = operational_conn.execute(answered_sql(joined)).fetchall()
     answered: dict = {}
     for zone_id, question_id, n in rows:
         answered.setdefault(zone_id, {})[question_id] = n
@@ -272,7 +300,8 @@ def test_canvass_days_bucket_in_display_timezone(operational_conn) -> None:
     # Day list rides the base filters only — a date filter must not
     # collapse the picker's options.
     scope = event_scope("testorg", ["camp1"], day="2026-08-23", tz=TZ)
-    rows = operational_conn.execute(canvass_days_sql(scope.base_filters), [TZ, *scope.base_params]).fetchall()
+    base = _materialize_base(operational_conn, scope)
+    rows = operational_conn.execute(canvass_days_sql(base), [TZ]).fetchall()
     assert [r[0] for r in rows] == ["2026-08-24", "2026-08-23"]
 
 

--- a/apps/data/tests/test_reports.py
+++ b/apps/data/tests/test_reports.py
@@ -178,8 +178,11 @@ def test_sort_and_day_scope(conn) -> None:
     attempts = [r["attempts"] for r in _by_col(result)]
     assert attempts == sorted(attempts, reverse=True)
     day1 = _preview(conn, "attempts", day="2026-08-23")
-    # Day 1: p1, p2, p3 (its clear is day 2), p5, p7 x2, p8 — not p4.
-    assert day1["total"] == 7
+    # Day 1: p1, p2, p5, p7 x2, p8 — not p4 (day 2). Not p3 either: its
+    # day-2 clear erases absolutely — a clear edits the turf's shared
+    # record, so a mistaken attempt stays erased in historical day views
+    # rather than resurrecting when the window predates the clear.
+    assert day1["total"] == 6
     assert day1["days"] == ["2026-08-24", "2026-08-23"]
 
 

--- a/apps/web/src/lib/queries/reports.ts
+++ b/apps/web/src/lib/queries/reports.ts
@@ -33,7 +33,10 @@ export const reportRowsQuery = (
         ...(day ? { day, tz } : {}),
         ...(sort ? { sort: sort.key, dir: sort.dir } : {}),
       }),
-    staleTime: 30_000,
+    // Report data moves only when canvass events sync in; a 5-minute
+    // freshness bound keeps tab-backs from re-running the heavyweight
+    // query (progressTargetsQuery's convention).
+    staleTime: 5 * 60_000,
     // Same-kind scope/sort/page changes swap data in place (the panel
     // dims via isPlaceholderData while the swap is in flight); a kind
     // switch is a different table entirely, so it gets a clean load

--- a/apps/web/src/lib/queries/results.ts
+++ b/apps/web/src/lib/queries/results.ts
@@ -29,7 +29,9 @@ export const resultsAggregateQuery = (
         ...(day ? { day, tz } : {}),
         ...(conditions.length > 0 ? { criteria: conditionsToCriteria(conditions) } : {}),
       }),
-    staleTime: 30_000,
+    // Same heavyweight event reduction as reports; the same 5-minute
+    // freshness bound keeps tab-backs silent.
+    staleTime: 5 * 60_000,
     // Filter/scope changes swap data in place — no suspension, no flash.
     placeholderData: keepPreviousData,
   });

--- a/scripts/bench/bench.ts
+++ b/scripts/bench/bench.ts
@@ -18,11 +18,19 @@
 //   pnpm bench --org <slug> --scenario steps-narrow --scenario burst
 //   pnpm bench --org <slug> --extra my-scenarios.json      # e.g. custom fields
 
-import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import meow from "meow";
+import {
+  type Measurement,
+  type ResultRow,
+  RESULTS_FILE,
+  appendRow,
+  checkHealth,
+  parseServerTiming,
+  printRow,
+  toRow as toSharedRow,
+} from "./lib";
 import { SCENARIOS, type Criteria, type Scenario } from "./scenarios";
 
 const cli = meow(
@@ -62,46 +70,6 @@ const ENDPOINTS = {
 } as const;
 type Endpoint = keyof typeof ENDPOINTS;
 
-type Measurement = {
-  wallMs: number;
-  bytes: number;
-  phases: Record<string, number>; // parsed Server-Timing (query, total, …)
-};
-
-export type ResultRow = {
-  ts: string;
-  env: string;
-  label: string;
-  org: string;
-  url: string;
-  scenario: string;
-  endpoint: string; // count | cascade | points | batch (burst wall)
-  iterations: number;
-  coldMs: number;
-  warmMs: number; // median wall of warm iterations
-  phases: Record<string, number>; // median warm server phases
-  bytes: number;
-};
-
-const RESULTS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "results");
-const RESULTS_FILE = resolve(RESULTS_DIR, "results.jsonl");
-
-function parseServerTiming(header: string | null): Record<string, number> {
-  const phases: Record<string, number> = {};
-  if (!header) return phases;
-  for (const part of header.split(",")) {
-    const m = part.trim().match(/^([\w-]+);dur=([\d.]+)$/);
-    if (m) phases[m[1]!] = Number(m[2]);
-  }
-  return phases;
-}
-
-function median(xs: number[]): number {
-  const s = [...xs].sort((a, b) => a - b);
-  const mid = Math.floor(s.length / 2);
-  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
-}
-
 async function measure(endpoint: Endpoint, criteria: Criteria): Promise<Measurement> {
   const t0 = performance.now();
   const res = await fetch(`${url}${ENDPOINTS[endpoint]}`, {
@@ -122,50 +90,8 @@ async function measure(endpoint: Endpoint, criteria: Criteria): Promise<Measurem
   };
 }
 
-// Median of each phase across warm iterations, keyed by phase name.
-function medianPhases(measurements: Measurement[]): Record<string, number> {
-  const keys = new Set(measurements.flatMap((m) => Object.keys(m.phases)));
-  const out: Record<string, number> = {};
-  for (const key of keys) {
-    const vals = measurements.map((m) => m.phases[key]).filter((v): v is number => v != null);
-    if (vals.length) out[key] = median(vals);
-  }
-  return out;
-}
-
-function toRow(scenario: string, endpoint: string, all: Measurement[]): ResultRow {
-  const warm = all.length > 1 ? all.slice(1) : all;
-  return {
-    ts: new Date().toISOString(),
-    env,
-    label,
-    org,
-    url,
-    scenario,
-    endpoint,
-    iterations: all.length,
-    coldMs: all[0]!.wallMs,
-    warmMs: median(warm.map((m) => m.wallMs)),
-    phases: medianPhases(warm),
-    bytes: all[all.length - 1]!.bytes,
-  };
-}
-
-const fmtMs = (ms: number | undefined) => (ms == null ? chalk.gray("—") : `${ms.toFixed(0)}ms`);
-const fmtBytes = (b: number) =>
-  b >= 1_000_000 ? `${(b / 1_000_000).toFixed(1)}MB` : `${(b / 1_000).toFixed(1)}kB`;
-
-function printRow(row: ResultRow) {
-  const phases = row.phases;
-  console.log(
-    `  ${row.endpoint.padEnd(8)}` +
-      ` warm ${chalk.bold(fmtMs(row.warmMs).padStart(8))}` +
-      `  cold ${fmtMs(row.coldMs).padStart(8)}` +
-      `  query ${fmtMs(phases.query).padStart(8)}` +
-      `  server ${fmtMs(phases.total).padStart(8)}` +
-      `  ${fmtBytes(row.bytes).padStart(8)}`,
-  );
-}
+const toRow = (scenario: string, endpoint: string, all: Measurement[]) =>
+  toSharedRow({ env, label, org, url }, scenario, endpoint, all);
 
 async function runScenario(scenario: Scenario): Promise<ResultRow[]> {
   const endpoints = Object.keys(ENDPOINTS) as Endpoint[];
@@ -191,11 +117,7 @@ async function runScenario(scenario: Scenario): Promise<ResultRow[]> {
 }
 
 async function main() {
-  const health = await fetch(`${url}/healthcheck`).catch(() => null);
-  if (!health?.ok) {
-    console.error(chalk.red(`no data server at ${url} — is it running / tunneled?`));
-    process.exit(1);
-  }
+  await checkHealth(url);
 
   let scenarios = [...SCENARIOS];
   if (cli.flags.extra) {
@@ -213,14 +135,13 @@ async function main() {
     `${chalk.bold(env)} (${url}) org=${org} label=${chalk.bold(label)} iterations=${iterations}\n`,
   );
 
-  mkdirSync(RESULTS_DIR, { recursive: true });
   for (const scenario of scenarios) {
     console.log(`${chalk.cyan(scenario.name)} — ${chalk.gray(scenario.description)}`);
     try {
       const rows = await runScenario(scenario);
       for (const row of rows) {
         printRow(row);
-        appendFileSync(RESULTS_FILE, JSON.stringify(row) + "\n");
+        appendRow(row);
       }
     } catch (err) {
       console.log(`  ${chalk.red("failed")}: ${err instanceof Error ? err.message : String(err)}`);

--- a/scripts/bench/canvass.ts
+++ b/scripts/bench/canvass.ts
@@ -1,0 +1,117 @@
+// Canvass read-path benchmark: the five /reports/* previews and
+// /results/aggregate, org-wide (all campaigns, no filters) — the heaviest
+// shape each endpoint serves and the one the reports page cold-loads.
+// Same measurement conventions as bench.ts; rows append to the shared
+// results.jsonl for before/after comparison via report.ts.
+//
+// Usage (from scripts/)
+//   pnpm exec tsx bench/canvass.ts --org <slug>            # local
+//   pnpm exec tsx bench/canvass.ts --org <slug> --label materialized
+//   pnpm exec tsx bench/canvass.ts --org <slug> --endpoint people
+
+import chalk from "chalk";
+import meow from "meow";
+import {
+  type Measurement,
+  appendRow,
+  checkHealth,
+  parseServerTiming,
+  printRow,
+  toRow,
+} from "./lib";
+
+const cli = meow(
+  `
+  Usage
+    $ pnpm exec tsx bench/canvass.ts --org <slug> [options]
+
+  Options
+    --org         Org slug the data server should resolve (required)
+    --url         Data server base URL (default http://localhost:8000)
+    --env         Environment label for results: local | latitude | do (default local)
+    --label       Code-state label, e.g. main, materialized (default main)
+    --iterations  Requests per endpoint (default 5; first is cold)
+    --endpoint    Only run matching endpoint(s); repeatable
+`,
+  {
+    importMeta: import.meta,
+    flags: {
+      org: { type: "string", isRequired: true },
+      url: { type: "string", default: "http://localhost:8000" },
+      env: { type: "string", default: "local" },
+      label: { type: "string", default: "main" },
+      iterations: { type: "number", default: 5 },
+      endpoint: { type: "string", isMultiple: true },
+    },
+  },
+);
+
+const { org, url, env, label, iterations } = cli.flags;
+const ctx = { env, label, org, url };
+
+const REPORT_KINDS = ["people", "responses", "attempts", "walks", "canvassers"] as const;
+
+type Endpoint = { name: string; path: string; body: Record<string, unknown> };
+
+const ENDPOINTS: Endpoint[] = [
+  ...REPORT_KINDS.map((kind) => ({
+    name: kind,
+    path: `/reports/${kind}`,
+    body: { orgSlug: org, format: "preview" },
+  })),
+  { name: "results", path: "/results/aggregate", body: { orgSlug: org, criteria: { steps: [] } } },
+];
+
+async function measure(endpoint: Endpoint): Promise<Measurement> {
+  const t0 = performance.now();
+  const res = await fetch(`${url}${endpoint.path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(endpoint.body),
+  });
+  const body = await res.arrayBuffer();
+  const wallMs = performance.now() - t0;
+  if (!res.ok) {
+    const text = new TextDecoder().decode(body).slice(0, 200);
+    throw new Error(`${endpoint.path} → ${res.status}: ${text}`);
+  }
+  return {
+    wallMs,
+    bytes: body.byteLength,
+    phases: parseServerTiming(res.headers.get("Server-Timing")),
+  };
+}
+
+async function main() {
+  await checkHealth(url);
+
+  const only = cli.flags.endpoint ?? [];
+  const endpoints = only.length ? ENDPOINTS.filter((e) => only.includes(e.name)) : ENDPOINTS;
+  if (!endpoints.length) {
+    console.error(chalk.red(`no endpoints match ${only.join(", ")}`));
+    process.exit(1);
+  }
+
+  console.log(
+    `${chalk.bold(env)} (${url}) org=${org} label=${chalk.bold(label)} iterations=${iterations}\n`,
+  );
+  console.log(
+    `${chalk.cyan("canvass")} — ${chalk.gray("org-wide report previews + results aggregate")}`,
+  );
+
+  for (const endpoint of endpoints) {
+    try {
+      const measurements: Measurement[] = [];
+      for (let i = 0; i < iterations; i++) measurements.push(await measure(endpoint));
+      const row = toRow(ctx, "canvass", endpoint.name, measurements);
+      printRow(row);
+      appendRow(row);
+    } catch (err) {
+      console.log(
+        `  ${endpoint.name.padEnd(10)} ${chalk.red("failed")}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+await main();

--- a/scripts/bench/lib.ts
+++ b/scripts/bench/lib.ts
@@ -1,0 +1,111 @@
+// Shared measurement plumbing for the bench suites: Server-Timing parsing,
+// medians, the results.jsonl row shape, and console formatting. Suites own
+// their endpoints and request bodies; report.ts pivots the shared rows.
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import chalk from "chalk";
+
+export type Measurement = {
+  wallMs: number;
+  bytes: number;
+  phases: Record<string, number>; // parsed Server-Timing (query, total, …)
+};
+
+export type ResultRow = {
+  ts: string;
+  env: string;
+  label: string;
+  org: string;
+  url: string;
+  scenario: string;
+  endpoint: string;
+  iterations: number;
+  coldMs: number;
+  warmMs: number; // median wall of warm iterations
+  phases: Record<string, number>; // median warm server phases
+  bytes: number;
+};
+
+export type RunContext = { env: string; label: string; org: string; url: string };
+
+const RESULTS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "results");
+export const RESULTS_FILE = resolve(RESULTS_DIR, "results.jsonl");
+
+export function parseServerTiming(header: string | null): Record<string, number> {
+  const phases: Record<string, number> = {};
+  if (!header) return phases;
+  for (const part of header.split(",")) {
+    const m = part.trim().match(/^([\w-]+);dur=([\d.]+)$/);
+    if (m) phases[m[1]!] = Number(m[2]);
+  }
+  return phases;
+}
+
+export function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
+}
+
+// Median of each phase across warm iterations, keyed by phase name.
+export function medianPhases(measurements: Measurement[]): Record<string, number> {
+  const keys = new Set(measurements.flatMap((m) => Object.keys(m.phases)));
+  const out: Record<string, number> = {};
+  for (const key of keys) {
+    const vals = measurements.map((m) => m.phases[key]).filter((v): v is number => v != null);
+    if (vals.length) out[key] = median(vals);
+  }
+  return out;
+}
+
+export function toRow(
+  ctx: RunContext,
+  scenario: string,
+  endpoint: string,
+  all: Measurement[],
+): ResultRow {
+  const warm = all.length > 1 ? all.slice(1) : all;
+  return {
+    ts: new Date().toISOString(),
+    ...ctx,
+    scenario,
+    endpoint,
+    iterations: all.length,
+    coldMs: all[0]!.wallMs,
+    warmMs: median(warm.map((m) => m.wallMs)),
+    phases: medianPhases(warm),
+    bytes: all[all.length - 1]!.bytes,
+  };
+}
+
+export function appendRow(row: ResultRow): void {
+  mkdirSync(RESULTS_DIR, { recursive: true });
+  appendFileSync(RESULTS_FILE, JSON.stringify(row) + "\n");
+}
+
+export const fmtMs = (ms: number | undefined) =>
+  ms == null ? chalk.gray("—") : `${ms.toFixed(0)}ms`;
+export const fmtBytes = (b: number) =>
+  b >= 1_000_000 ? `${(b / 1_000_000).toFixed(1)}MB` : `${(b / 1_000).toFixed(1)}kB`;
+
+export function printRow(row: ResultRow) {
+  const phases = row.phases;
+  console.log(
+    `  ${row.endpoint.padEnd(10)}` +
+      ` warm ${chalk.bold(fmtMs(row.warmMs).padStart(8))}` +
+      `  cold ${fmtMs(row.coldMs).padStart(8)}` +
+      `  query ${fmtMs(phases.query).padStart(8)}` +
+      `  server ${fmtMs(phases.total).padStart(8)}` +
+      `  ${fmtBytes(row.bytes).padStart(8)}`,
+  );
+}
+
+export async function checkHealth(url: string): Promise<void> {
+  const health = await fetch(`${url}/healthcheck`).catch(() => null);
+  if (!health?.ok) {
+    console.error(chalk.red(`no data server at ${url} — is it running / tunneled?`));
+    process.exit(1);
+  }
+}

--- a/scripts/bench/report.ts
+++ b/scripts/bench/report.ts
@@ -9,11 +9,9 @@
 //   pnpm bench:report --label main         # only columns with this label
 
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
 import chalk from "chalk";
 import meow from "meow";
-import type { ResultRow } from "./bench";
+import { type ResultRow, RESULTS_FILE } from "./lib";
 
 const cli = meow(
   `
@@ -28,8 +26,6 @@ const cli = meow(
     },
   },
 );
-
-const RESULTS_FILE = resolve(dirname(fileURLToPath(import.meta.url)), "results", "results.jsonl");
 
 let lines: string[];
 try {


### PR DESCRIPTION
Small PR to improve performance on reports. With this fix, each query materializes per-cursor temporary tables once and reads them, via a materialize() helper that returns the relation name to make the data flow readable. This improved performance 2-3x. It also had one deliberate behavior change: the date selection acts after, not before, the reduction from the events. The effect is that, within the same turf, a person marked with a response followed by a clear on a different date is still considered cleared (with upstream date filtering, that would only happen when the date range included the original event and the clear). Some new scripts helped benchmark the results and can remain here for measuring future potential performance improvements.