### PR TITLE
feat: turf map progress

### DIFF
--- a/apps/web/src/components/map.tsx
+++ b/apps/web/src/components/map.tsx
@@ -148,6 +148,10 @@ type MapProps = {
   cornerUpperLeft?: ReactNode;
   // Lower-left counterpart.
   cornerLowerLeft?: ReactNode;
+  // Symbol fade-in/out duration (ms); MapLibre keys symbols on their
+  // text, so 0 lets a label's text change in place instead of
+  // cross-fading the whole badge.
+  fadeDuration?: number;
   // Suppress every corner inset — for callers that shrink the map to a
   // sliver, where the cards clip and their labels wrap illegibly.
   insetsHidden?: boolean;
@@ -248,6 +252,7 @@ export function Map({
   cornerUpperRight,
   cornerUpperLeft,
   cornerLowerLeft,
+  fadeDuration,
   insetsHidden,
 }: MapProps) {
   const isDark = useAtomValue(darkAtom);
@@ -771,6 +776,7 @@ export function Map({
         initialViewState={{ ...DEFAULT_VIEW, ...initialViewState }}
         mapStyle={getMaptilerStyleUrl(isDark)}
         attributionControl={false}
+        fadeDuration={fadeDuration}
         style={{ width: "100%", height: "100%" }}
         // Every map stays north-up and flat: no rotation, no pitch.
         // touchZoomRotate={false} would kill pinch zoom too, so only its

--- a/apps/web/src/components/map.tsx
+++ b/apps/web/src/components/map.tsx
@@ -148,10 +148,6 @@ type MapProps = {
   cornerUpperLeft?: ReactNode;
   // Lower-left counterpart.
   cornerLowerLeft?: ReactNode;
-  // Symbol fade-in/out duration (ms); MapLibre keys symbols on their
-  // text, so 0 lets a label's text change in place instead of
-  // cross-fading the whole badge.
-  fadeDuration?: number;
   // Suppress every corner inset — for callers that shrink the map to a
   // sliver, where the cards clip and their labels wrap illegibly.
   insetsHidden?: boolean;
@@ -252,7 +248,6 @@ export function Map({
   cornerUpperRight,
   cornerUpperLeft,
   cornerLowerLeft,
-  fadeDuration,
   insetsHidden,
 }: MapProps) {
   const isDark = useAtomValue(darkAtom);
@@ -776,7 +771,6 @@ export function Map({
         initialViewState={{ ...DEFAULT_VIEW, ...initialViewState }}
         mapStyle={getMaptilerStyleUrl(isDark)}
         attributionControl={false}
-        fadeDuration={fadeDuration}
         style={{ width: "100%", height: "100%" }}
         // Every map stays north-up and flat: no rotation, no pitch.
         // touchZoomRotate={false} would kill pinch zoom too, so only its

--- a/apps/web/src/components/map.tsx
+++ b/apps/web/src/components/map.tsx
@@ -146,6 +146,8 @@ type MapProps = {
   cornerUpperRight?: ReactNode;
   // Upper-left counterpart.
   cornerUpperLeft?: ReactNode;
+  // Lower-left counterpart.
+  cornerLowerLeft?: ReactNode;
   // Suppress every corner inset — for callers that shrink the map to a
   // sliver, where the cards clip and their labels wrap illegibly.
   insetsHidden?: boolean;
@@ -245,6 +247,7 @@ export function Map({
   cornerLowerRight,
   cornerUpperRight,
   cornerUpperLeft,
+  cornerLowerLeft,
   insetsHidden,
 }: MapProps) {
   const isDark = useAtomValue(darkAtom);
@@ -916,17 +919,24 @@ export function Map({
                   ["get", "lineColor"],
                   isDark ? "hsl(0, 0%, 95%)" : "hsl(0, 0%, 5%)",
                 ],
-                // Thin and faded by default; the selected zone gets
-                // the heavier stroke at full opacity so it reads as
-                // the active one without disrupting the others.
-                "line-width": ["case", ["==", ["feature-state", "selected"], true], 1.5, 0.75],
+                // Per-feature `lineWidth` / `lineOpacity` overrides, like
+                // `lineColor`; otherwise thin and faded, selected zone heavier.
+                "line-width": [
+                  "coalesce",
+                  ["get", "lineWidth"],
+                  ["case", ["==", ["feature-state", "selected"], true], 1.5, 0.75],
+                ],
                 "line-opacity": [
-                  "case",
-                  ["==", ["feature-state", "selected"], true],
-                  1,
-                  ["!=", ["get", "lineColor"], null],
-                  1,
-                  0.5,
+                  "coalesce",
+                  ["get", "lineOpacity"],
+                  [
+                    "case",
+                    ["==", ["feature-state", "selected"], true],
+                    1,
+                    ["!=", ["get", "lineColor"], null],
+                    1,
+                    0.5,
+                  ],
                 ],
               }}
             />
@@ -1093,6 +1103,17 @@ export function Map({
           }
         >
           {cornerUpperLeft}
+        </div>
+      ) : null}
+
+      {!insetsHidden && cornerLowerLeft ? (
+        <div
+          className={
+            "absolute bottom-3 left-3 z-20 flex flex-col items-stretch " +
+            "rounded-md border border-border bg-background text-sm"
+          }
+        >
+          {cornerLowerLeft}
         </div>
       ) : null}
 

--- a/apps/web/src/routes/$orgSlug/turfs/index.tsx
+++ b/apps/web/src/routes/$orgSlug/turfs/index.tsx
@@ -854,7 +854,7 @@ function ZoneMapDialog({
               streetsAlwaysOn
               onBadgeClick={onSelectTurf}
             />
-            <label className="mt-2.5 flex w-fit cursor-pointer items-center gap-3 text-sm">
+            <label className="mt-2.5 -mb-0.5 flex w-fit cursor-pointer items-center gap-3 text-sm">
               <span>Color by progress</span>
               <Switch checked={byProgress} onCheckedChange={setByProgress} />
             </label>

--- a/apps/web/src/routes/$orgSlug/turfs/index.tsx
+++ b/apps/web/src/routes/$orgSlug/turfs/index.tsx
@@ -15,6 +15,7 @@ import { Page } from "~/components/page";
 import { tintStyle } from "~/components/badge";
 import { BLUE, progressColor } from "~/lib/palette";
 import { Pill } from "~/components/pill";
+import { Switch } from "~/components/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/table";
 import { ToggleGroup, ToggleGroupItem } from "~/components/toggle-group";
 import { formatMonthDay, formatTime } from "~/lib/format";
@@ -713,6 +714,9 @@ function QrDialog({
   );
 }
 
+// Outline weight shared by the zone and single-turf map dialogs.
+const TURF_LINE_WIDTH = 1;
+
 type ZoneMapGroup = {
   campaignId: string;
   zoneId: string | null;
@@ -721,9 +725,10 @@ type ZoneMapGroup = {
 };
 
 // A group's turfs on a map — geometry, number badges, and building
-// dots, colored by the app palette in row order. Scoped to one
-// (campaign, region) by construction, so overlapping campaigns can't
-// collide here the way they can in the full map view.
+// dots, colored by the app palette in row order, or by the board's
+// progress colors on toggle. Scoped to one (campaign, region) by
+// construction, so overlapping campaigns can't collide here the way
+// they can in the full map view.
 function ZoneMapDialog({
   group,
   open,
@@ -736,6 +741,9 @@ function ZoneMapDialog({
   onSelectTurf: (turfId: string) => void;
 }) {
   const isDark = useAtomValue(darkAtom);
+  const [byProgress, setByProgress] = useState(false);
+  const summaries = useWalkSummaries(group?.campaignId ?? null);
+  const progressByTurf = useProgressByTurf(group?.campaignId ?? null);
   const { data: zoneData } = useQuery({
     ...zoneMapDataQuery(group?.campaignId ?? "", group?.zoneId ?? null),
     enabled: group !== null,
@@ -743,25 +751,32 @@ function ZoneMapDialog({
 
   const { shapes, labels, bounds, points, pointColors } = useMemo(() => {
     const turfs = group?.turfs ?? [];
+    // The board's badge rule; null = neutral (theme gray).
+    const progressFill = (t: TurfRow): string | null => {
+      const s = summaries(t.turfId);
+      if (s.live || s.pending) return BLUE;
+      const pct = progressPct(progressByTurf?.get(t.turfId) ?? 0, t.personCount);
+      return pct !== null && pct > 0 ? progressColor(pct) : null;
+    };
+    // Palette mode is index-based, so a turf keeps the color the
+    // cutter's point clouds gave it while it was drawn.
+    const fillFor = (t: TurfRow, i: number) => (byProgress ? progressFill(t) : colorFor(i));
     const geometryByTurf = new Map((zoneData ?? []).map((g) => [g.turfId, g.geometry]));
     const shapeFeatures: Feature[] = [];
     const labelFeatures: Feature[] = [];
     turfs.forEach((t, i) => {
       const geometry = geometryByTurf.get(t.turfId);
       if (!geometry) return;
-      // Index-based palette assignment, so a turf keeps the color the
-      // cutter's point clouds gave it while it was drawn.
+      const color = fillFor(t, i);
       const feature: Feature = {
         type: "Feature",
         geometry,
         properties: {
           zoneId: t.turfId,
-          color: colorFor(i),
-          // Solid same-hue outline; the fill stays light enough that
-          // the dots read on top of it — the dots carry the density
-          // now, the fill just claims area.
-          lineColor: colorFor(i),
-          opacity: 0.4,
+          lineWidth: TURF_LINE_WIDTH,
+          lineOpacity: 1,
+          // Light fills so the dots read on top; neutral matches the single-turf view.
+          ...(color ? { color, lineColor: color, opacity: 0.4 } : { opacity: 0.2 }),
         },
       };
       shapeFeatures.push(feature);
@@ -790,8 +805,11 @@ function ZoneMapDialog({
       const colors = new Uint8Array(total * 3);
       let k = 0;
       turfs.forEach((t, i) => {
-        const [r, g, b] = parseHexRgb(colorFor(i)).map((c) =>
-          Math.round(base + (c - base) * HUE_SHARE),
+        const color = fillFor(t, i);
+        const [r, g, b] = (
+          color
+            ? parseHexRgb(color).map((c) => Math.round(base + (c - base) * HUE_SHARE))
+            : [base, base, base]
         ) as [number, number, number];
         for (const [lng, lat] of coordsByTurf.get(t.turfId) ?? []) {
           deltas[k * 2] = mercatorX(lng) - origin[0];
@@ -813,14 +831,14 @@ function ZoneMapDialog({
       points,
       pointColors,
     };
-  }, [group, zoneData, isDark]);
+  }, [group, zoneData, isDark, byProgress, summaries, progressByTurf]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] md:w-[720px] md:max-w-[720px]">
         {group ? (
           <>
-            <DialogTitle className="text-sm font-normal tracking-normal text-foreground italic">
+            <DialogTitle className="mb-2.5 pr-10 text-sm leading-tight font-normal tracking-normal text-foreground italic">
               {group.name}
             </DialogTitle>
             <DialogCloseX />
@@ -836,6 +854,10 @@ function ZoneMapDialog({
               streetsAlwaysOn
               onBadgeClick={onSelectTurf}
             />
+            <label className="mt-2.5 flex w-fit cursor-pointer items-center gap-3 text-sm">
+              <span>Color by progress</span>
+              <Switch checked={byProgress} onCheckedChange={setByProgress} />
+            </label>
           </>
         ) : null}
       </DialogContent>
@@ -866,11 +888,11 @@ function TurfMapDialog({
       return { shapes: undefined, points: null, bounds: null };
     }
     // Neutral fill (no `color` property falls through to the layer's
-    // theme gray), heavier outline via the selected-zone state.
+    // theme gray), solid outline at the turf maps' shared weight.
     const feature: Feature = {
       type: "Feature",
       geometry: data.geometry,
-      properties: { zoneId: turf.turfId, opacity: 0.2 },
+      properties: { zoneId: turf.turfId, opacity: 0.2, lineWidth: TURF_LINE_WIDTH, lineOpacity: 1 },
     };
     const b = bboxOfFeatures([feature]);
     // fp64 origin at the bbox center + fp32 deltas — the same split the
@@ -897,7 +919,7 @@ function TurfMapDialog({
       <DialogContent className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] md:w-[720px] md:max-w-[720px]">
         {turf ? (
           <>
-            <DialogTitle className="text-sm font-normal tracking-normal text-foreground italic tabular-nums">
+            <DialogTitle className="mb-2.5 pr-10 text-sm leading-tight font-normal tracking-normal text-foreground italic tabular-nums">
               Turf {turfLabel(turf.name)}
               {regionName(turf) ? ` — ${regionName(turf)}` : ""}
             </DialogTitle>
@@ -909,7 +931,6 @@ function TurfMapDialog({
               fitBounds={bounds}
               loading={!data}
               loadingSpinner
-              selectedZoneId={turf.turfId}
               streetsAlwaysOn
             />
           </>
@@ -949,7 +970,7 @@ function WalksDialog({
       <DialogContent className="max-w-[85vw] pb-3 md:max-w-md">
         {turf ? (
           <>
-            <DialogTitle className="text-sm font-normal tracking-normal text-foreground italic tabular-nums">
+            <DialogTitle className="mb-2.5 pr-10 text-sm leading-tight font-normal tracking-normal text-foreground italic tabular-nums">
               Turf {turfLabel(turf.name)} {regionName(turf) ? ` — ${regionName(turf)}` : ""}
             </DialogTitle>
             <DialogCloseX />

--- a/apps/web/src/routes/$orgSlug/turfs/index.tsx
+++ b/apps/web/src/routes/$orgSlug/turfs/index.tsx
@@ -725,10 +725,10 @@ type ZoneMapGroup = {
 };
 
 // A group's turfs on a map — geometry, number badges, and building
-// dots, colored by the app palette in row order, or by the board's
-// progress colors on toggle. Scoped to one (campaign, region) by
-// construction, so overlapping campaigns can't collide here the way
-// they can in the full map view.
+// dots, colored by the app palette in row order. "Show progress" swaps
+// in the board's progress colors and percentages. Scoped to one
+// (campaign, region) by construction, so overlapping campaigns can't
+// collide here the way they can in the full map view.
 function ZoneMapDialog({
   group,
   open,
@@ -741,7 +741,7 @@ function ZoneMapDialog({
   onSelectTurf: (turfId: string) => void;
 }) {
   const isDark = useAtomValue(darkAtom);
-  const [byProgress, setByProgress] = useState(false);
+  const [showProgress, setShowProgress] = useState(false);
   const summaries = useWalkSummaries(group?.campaignId ?? null);
   const progressByTurf = useProgressByTurf(group?.campaignId ?? null);
   const { data: zoneData } = useQuery({
@@ -751,16 +751,19 @@ function ZoneMapDialog({
 
   const { shapes, labels, bounds, points, pointColors } = useMemo(() => {
     const turfs = group?.turfs ?? [];
+    const pctFor = (t: TurfRow) =>
+      progressPct(progressByTurf?.get(t.turfId) ?? 0, t.personCount) ?? 0;
     // The board's badge rule; null = neutral (theme gray).
     const progressFill = (t: TurfRow): string | null => {
       const s = summaries(t.turfId);
       if (s.live || s.pending) return BLUE;
-      const pct = progressPct(progressByTurf?.get(t.turfId) ?? 0, t.personCount);
-      return pct !== null && pct > 0 ? progressColor(pct) : null;
+      const pct = pctFor(t);
+      return pct > 0 ? progressColor(pct) : null;
     };
     // Palette mode is index-based, so a turf keeps the color the
     // cutter's point clouds gave it while it was drawn.
-    const fillFor = (t: TurfRow, i: number) => (byProgress ? progressFill(t) : colorFor(i));
+    const fillFor = (t: TurfRow, i: number) => (showProgress ? progressFill(t) : colorFor(i));
+    const labelFor = (t: TurfRow) => (showProgress ? `${pctFor(t)}%` : turfLabel(t.name));
     const geometryByTurf = new Map((zoneData ?? []).map((g) => [g.turfId, g.geometry]));
     const shapeFeatures: Feature[] = [];
     const labelFeatures: Feature[] = [];
@@ -780,7 +783,7 @@ function ZoneMapDialog({
         },
       };
       shapeFeatures.push(feature);
-      labelFeatures.push(labelPoint(feature, turfLabel(t.name)));
+      labelFeatures.push(labelPoint(feature, labelFor(t)));
     });
     const bounds = bboxOfFeatures(shapeFeatures);
 
@@ -831,7 +834,7 @@ function ZoneMapDialog({
       points,
       pointColors,
     };
-  }, [group, zoneData, isDark, byProgress, summaries, progressByTurf]);
+  }, [group, zoneData, isDark, showProgress, summaries, progressByTurf]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -852,11 +855,12 @@ function ZoneMapDialog({
               loading={!zoneData}
               loadingSpinner
               streetsAlwaysOn
+              fadeDuration={0}
               onBadgeClick={onSelectTurf}
             />
             <label className="mt-2.5 -mb-0.5 flex w-fit cursor-pointer items-center gap-3 text-sm">
-              <span>Color by progress</span>
-              <Switch checked={byProgress} onCheckedChange={setByProgress} />
+              <span>Show progress</span>
+              <Switch checked={showProgress} onCheckedChange={setShowProgress} />
             </label>
           </>
         ) : null}

--- a/apps/web/src/routes/$orgSlug/turfs/index.tsx
+++ b/apps/web/src/routes/$orgSlug/turfs/index.tsx
@@ -725,10 +725,10 @@ type ZoneMapGroup = {
 };
 
 // A group's turfs on a map — geometry, number badges, and building
-// dots, colored by the app palette in row order. "Show progress" swaps
-// in the board's progress colors and percentages. Scoped to one
-// (campaign, region) by construction, so overlapping campaigns can't
-// collide here the way they can in the full map view.
+// dots, colored by the app palette in row order, or by the board's
+// progress colors on toggle. Scoped to one (campaign, region) by
+// construction, so overlapping campaigns can't collide here the way
+// they can in the full map view.
 function ZoneMapDialog({
   group,
   open,
@@ -741,7 +741,7 @@ function ZoneMapDialog({
   onSelectTurf: (turfId: string) => void;
 }) {
   const isDark = useAtomValue(darkAtom);
-  const [showProgress, setShowProgress] = useState(false);
+  const [byProgress, setByProgress] = useState(false);
   const summaries = useWalkSummaries(group?.campaignId ?? null);
   const progressByTurf = useProgressByTurf(group?.campaignId ?? null);
   const { data: zoneData } = useQuery({
@@ -762,8 +762,7 @@ function ZoneMapDialog({
     };
     // Palette mode is index-based, so a turf keeps the color the
     // cutter's point clouds gave it while it was drawn.
-    const fillFor = (t: TurfRow, i: number) => (showProgress ? progressFill(t) : colorFor(i));
-    const labelFor = (t: TurfRow) => (showProgress ? `${pctFor(t)}%` : turfLabel(t.name));
+    const fillFor = (t: TurfRow, i: number) => (byProgress ? progressFill(t) : colorFor(i));
     const geometryByTurf = new Map((zoneData ?? []).map((g) => [g.turfId, g.geometry]));
     const shapeFeatures: Feature[] = [];
     const labelFeatures: Feature[] = [];
@@ -783,7 +782,7 @@ function ZoneMapDialog({
         },
       };
       shapeFeatures.push(feature);
-      labelFeatures.push(labelPoint(feature, labelFor(t)));
+      labelFeatures.push(labelPoint(feature, turfLabel(t.name)));
     });
     const bounds = bboxOfFeatures(shapeFeatures);
 
@@ -834,7 +833,7 @@ function ZoneMapDialog({
       points,
       pointColors,
     };
-  }, [group, zoneData, isDark, showProgress, summaries, progressByTurf]);
+  }, [group, zoneData, isDark, byProgress, summaries, progressByTurf]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -855,12 +854,11 @@ function ZoneMapDialog({
               loading={!zoneData}
               loadingSpinner
               streetsAlwaysOn
-              fadeDuration={0}
               onBadgeClick={onSelectTurf}
             />
             <label className="mt-2.5 -mb-0.5 flex w-fit cursor-pointer items-center gap-3 text-sm">
-              <span>Show progress</span>
-              <Switch checked={showProgress} onCheckedChange={setShowProgress} />
+              <span>Color by progress</span>
+              <Switch checked={byProgress} onCheckedChange={setByProgress} />
             </label>
           </>
         ) : null}


### PR DESCRIPTION
Small PR to add a toggle that colors the turf map modal by progress (using the same progress and status colors from the main turf "board" view). This helps the user see which turfs are complete, which are active, and which sill need to be assigned.