### PR TITLE
feat: dataset filtering on import

### DIFF
--- a/apps/data/src/cli.py
+++ b/apps/data/src/cli.py
@@ -20,6 +20,7 @@ from src.dags import (
 from src.derived import compute_derived_metadata
 from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres, get_connection
 from src.import_progress import NullProgress
+from src.importers.base import ImportFilter
 from src.importers.nys_voter_file import NysVoterFileImporter
 from src.models import TableRef, quote_ident
 from src.perf import TimingHook
@@ -345,10 +346,13 @@ def seed_persons() -> None:
         print(f"  Voter ZIP5 filter (dev scope): {settings.voter_zip5_filter}")
 
     # Import the voter file (source → persons_validated) outside Hamilton, then
-    # run the shared pipeline from that seam. Fixture is already NYC-only so no
-    # county filter; `voter_zip5_filter` scopes dev runs to a small slice.
-    importer = NysVoterFileImporter(zip5_filter=settings.voter_zip5_filter)
-    persons_validated = importer.load(source, args.schema, conn, NullProgress())
+    # run the shared pipeline from that seam. `voter_zip5_filter` scopes dev
+    # runs to a small slice.
+    zip_filter = (
+        ImportFilter(column="res_zip5", values=settings.voter_zip5_filter) if settings.voter_zip5_filter else None
+    )
+    importer = NysVoterFileImporter()
+    persons_validated = importer.load(source, args.schema, conn, NullProgress(), zip_filter)
 
     timing = TimingHook() if args.timing else None
     builder = driver.Builder().with_modules(

--- a/apps/data/src/derived.py
+++ b/apps/data/src/derived.py
@@ -28,7 +28,21 @@ def compute_derived_metadata(conn: duckdb.DuckDBPyConnection, geocoded_fqn: str,
     elections = _read_elections(conn, geocoded_fqn, manifest)
     if elections is not None:
         derived["elections"] = elections
+    bounds = _read_bounds(conn, geocoded_fqn)
+    if bounds is not None:
+        derived["bounds"] = bounds
     return derived
+
+
+def _read_bounds(conn: duckdb.DuckDBPyConnection, geocoded_fqn: str) -> list[float] | None:
+    """`[west, south, east, north]` over the version's geocoded persons — the
+    frame maps open on. None when nothing geocoded."""
+    row = conn.execute(
+        f"SELECT min(longitude), min(latitude), max(longitude), max(latitude) FROM {geocoded_fqn}"
+    ).fetchone()
+    if row is None or any(v is None for v in row):
+        return None
+    return [float(v) for v in row]
 
 
 def _read_elections(

--- a/apps/data/src/import_job.py
+++ b/apps/data/src/import_job.py
@@ -22,6 +22,7 @@ from src.dags import aggregate, assembly, boundaries, geocode, matching, osm, qu
 from src.derived import compute_derived_metadata
 from src.duckdb import OPERATIONAL_PG_ALIAS, attach_operational_postgres, get_connection
 from src.import_progress import ImportProgress, JobLog, ProgressNodeHook
+from src.importers.base import ImportFilter  # noqa: TC001 — pydantic resolves the payload annotation at runtime
 from src.importers.registry import get_importer
 from src.job_runner import IN_PROGRESS, INTERRUPTED_REASON, UNSTARTED, JobContext, job
 from src.quickwit import ensure_index, persons_index_id
@@ -39,6 +40,8 @@ class ImportDatasetVersionPayload(BaseModel):
     # Org that initiated the import — auto-activated onto the new version when it
     # has no active one.
     organization_id: str
+    # The dataset's fixed row filter (see `ImportFilter`); None imports everything.
+    filter: ImportFilter | None = None
 
 
 async def _mark_version_failed(dataset_version_id: str, error: str) -> None:
@@ -158,9 +161,13 @@ def _run(payload: ImportDatasetVersionPayload, job_id: str) -> dict[str, Any]:
         progress.start(importer.PROGRESS_STEPS + dag_steps + len(key_group_sources) + 2)
 
         # Source → persons_validated (importer-specific), then the shared pipeline.
-        persons_validated = importer.load(payload.source, schema, conn, progress)
+        persons_validated = importer.load(payload.source, schema, conn, progress, payload.filter)
         decoded = conn.execute(f"SELECT count(*) FROM {persons_validated.fqn}").fetchone()
         log.write(f"Decoded {decoded[0]:,} people from source" if decoded else "Source decoded")
+        if decoded is not None and decoded[0] == 0 and payload.filter is not None:
+            # A slice that matches nothing is almost always a wrong value; fail
+            # loudly rather than land an empty version.
+            raise ValueError(f"The import filter on {payload.filter.column} matched no rows in the source.")
         result = dr.execute(final_vars=_FINAL_VARS, inputs={"persons_validated": persons_validated, **dag_inputs})
         log.write("Geocoding pipeline complete")
 

--- a/apps/data/src/importers/base.py
+++ b/apps/data/src/importers/base.py
@@ -123,6 +123,20 @@ class Manifest(_CamelModel):
     fields: list[list[FieldDef]]
 
 
+class ImportFilter(_CamelModel):
+    """Row filter applied at import, fixed on the dataset like its importer.
+    `column` is a decoded source column the importer allowlists in
+    `FILTER_COLUMNS`; rows whose value isn't in `values` are dropped before
+    transform, so every version of the dataset is the same slice."""
+
+    column: str
+    values: list[str]
+
+
+class InvalidImportFilterError(ValueError):
+    """The filter names a column the importer doesn't allow. Message is user-facing."""
+
+
 class Progress(Protocol):
     """What `load` reports against — a step counter shared with the DAG. `advance`
     is called once per load stage; the job sizes the total from `PROGRESS_STEPS`
@@ -178,6 +192,9 @@ class Importer(Protocol):
     # Number of times `load` calls `progress.advance()`, so the job can size the
     # progress total (these stages + the DAG's nodes) before running.
     PROGRESS_STEPS: int
+    # Decoded source columns an `ImportFilter` may name. Mirrored by the web's
+    # importer entry so the dialog only offers these.
+    FILTER_COLUMNS: frozenset[str]
 
     def manifest(self) -> Manifest: ...
 
@@ -187,4 +204,5 @@ class Importer(Protocol):
         schema: str,
         conn: duckdb.DuckDBPyConnection,
         progress: Progress,
+        filter: ImportFilter | None = None,
     ) -> TableRef: ...

--- a/apps/data/src/importers/nys_voter_file/importer.py
+++ b/apps/data/src/importers/nys_voter_file/importer.py
@@ -15,7 +15,7 @@ import os
 from typing import TYPE_CHECKING
 
 import duckdb
-from src.importers.base import SourceUnreadableError, redact_source
+from src.importers.base import ImportFilter, InvalidImportFilterError, SourceUnreadableError, redact_source
 from src.importers.nys_voter_file.decode import decode_txt_to_table
 from src.importers.nys_voter_file.manifest import NYS_MANIFEST
 from src.importers.nys_voter_file.transform import nys_sboe_transformation_query
@@ -54,23 +54,15 @@ def register_voting_history_udf(conn: duckdb.DuckDBPyConnection) -> None:
 
 
 class NysVoterFileImporter:
-    """Curated importer for the NYS statewide voter file. Implements `Importer`.
-
-    NYS-specific scoping (county filter, dev ZIP5 slice) is instance config so
-    `load` stays source-agnostic.
-    """
+    """Curated importer for the NYS statewide voter file. Implements `Importer`."""
 
     name = "nys_voter_file"
     PROGRESS_STEPS = 3  # decode, transform, parse+validate
-
-    def __init__(
-        self,
-        *,
-        county_codes: list[str] | None = None,
-        zip5_filter: list[str] | None = None,
-    ) -> None:
-        self._county_codes = county_codes
-        self._zip5_filter = zip5_filter
+    # Geographic slices worth fixing a dataset to. Election district is left
+    # out: it's only unique within a county.
+    FILTER_COLUMNS = frozenset(
+        {"congressional_district", "assembly_district", "senate_district", "county_code", "res_zip5"}
+    )
 
     def manifest(self) -> Manifest:
         return NYS_MANIFEST
@@ -81,6 +73,7 @@ class NysVoterFileImporter:
         schema: str,
         conn: duckdb.DuckDBPyConnection,
         progress: Progress,
+        filter: ImportFilter | None = None,
     ) -> TableRef:
         """Decode/read `source` → transform → parse voting history → validate.
         Returns the `persons_validated` TableRef the shared pipeline reads from.
@@ -89,6 +82,10 @@ class NysVoterFileImporter:
         # would otherwise *deadlock* the fixed-width decode: the transcode feeder
         # can't open the file, so it never opens the FIFO's write end and
         # `read_csv` blocks forever. Fail fast instead. (`://` = object-storage key.)
+        if filter is not None and filter.column not in self.FILTER_COLUMNS:
+            raise InvalidImportFilterError(
+                f"Import filter column {filter.column!r} is not available for this dataset type."
+            )
         source = os.path.expanduser(source)
         if "://" not in source and not os.path.exists(source):
             raise SourceUnreadableError(f"Import source not found: {redact_source(source)!r}")
@@ -116,11 +113,7 @@ class NysVoterFileImporter:
         # 2. Transform to the canonical Person schema (raw NYS codes → canonical
         #    labels, address assembly, etc.). `voter_history` rides through as a
         #    transient raw column for step 3.
-        query = nys_sboe_transformation_query(
-            source_table=raw_fqn,
-            county_codes=self._county_codes,
-            zip5_filter=self._zip5_filter,
-        )
+        query = nys_sboe_transformation_query(source_table=raw_fqn, filter=filter)
         conn.execute(f"CREATE OR REPLACE TABLE {transformed_fqn} AS {query}")
         progress.advance()
 

--- a/apps/data/src/importers/nys_voter_file/transform.py
+++ b/apps/data/src/importers/nys_voter_file/transform.py
@@ -12,6 +12,11 @@ which are filterable. There is no catch-all JSON blob.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.importers.base import ImportFilter
+
 # NYS raw → canonical mappings used by the SQL CASE expressions below.
 # Keys are NYS-specific codes; values are cross-state canonical labels.
 
@@ -89,29 +94,21 @@ def _iso_date_sql(col: str) -> str:
 
 def nys_sboe_transformation_query(
     source_table: str,
-    county_codes: list[str] | None = None,
-    zip5_filter: list[str] | None = None,
+    filter: ImportFilter | None = None,
 ) -> str:
     """SQL transformation from NYS SBOE raw voter file → Person schema.
 
     Args:
         source_table: fully-qualified `persons_raw` table the query reads from,
             aliased to ``raw`` so the column expressions below resolve.
-        county_codes: optional list of NYS BOE county codes (e.g. ``['31']``
-            for Manhattan). When provided, the query restricts to those
-            counties and to active voters (status = 'A').
-        zip5_filter: optional list of residential ZIP5 codes to keep. Used to
-            scope dev runs to a small geographic slice.
+        filter: optional row filter (`raw.<column> IN (values)`), the dataset's
+            fixed import slice. The column must already be allowlisted by the
+            importer; values are compared as the file's own text.
     """
-    where_clauses = []
-    if county_codes:
-        joined = ", ".join(f"'{c}'" for c in county_codes)
-        where_clauses.append(f"raw.county_code IN ({joined})")
-        where_clauses.append("raw.status = 'A'")
-    if zip5_filter:
-        joined = ", ".join(f"'{z}'" for z in zip5_filter)
-        where_clauses.append(f"raw.res_zip5 IN ({joined})")
-    where = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
+    where = ""
+    if filter and filter.values:
+        joined = ", ".join("'" + v.replace("'", "''") + "'" for v in filter.values)
+        where = f"WHERE raw.{filter.column} IN ({joined})"
 
     enrollment_sql = _enrollment_case_sql()
 

--- a/apps/data/tests/test_derived.py
+++ b/apps/data/tests/test_derived.py
@@ -1,0 +1,24 @@
+"""Version-level derived metadata: the bounds box maps open on."""
+
+from __future__ import annotations
+
+from src.derived import compute_derived_metadata
+from src.importers.base import Manifest
+
+EMPTY_MANIFEST = Manifest(fields=[])
+
+
+def test_bounds_span_geocoded_persons(conn) -> None:
+    conn.execute(
+        "CREATE TABLE persons_geocoded AS SELECT * FROM (VALUES "
+        "(-74.0, 40.7), (-73.9, 40.8), (NULL, NULL)) t(longitude, latitude)"
+    )
+    derived = compute_derived_metadata(conn, "persons_geocoded", EMPTY_MANIFEST)
+    assert derived["rowCount"] == 3
+    assert derived["bounds"] == [-74.0, 40.7, -73.9, 40.8]
+
+
+def test_bounds_absent_when_nothing_geocoded(conn) -> None:
+    conn.execute("CREATE TABLE persons_geocoded (longitude DOUBLE, latitude DOUBLE)")
+    derived = compute_derived_metadata(conn, "persons_geocoded", EMPTY_MANIFEST)
+    assert "bounds" not in derived

--- a/apps/data/tests/test_import_filter.py
+++ b/apps/data/tests/test_import_filter.py
@@ -1,0 +1,51 @@
+"""The dataset-level import filter: a fixed `column IN values` slice applied
+before transform. Pins the SQL it compiles to, the allowlist that guards which
+columns a payload may name, and the end-to-end row count on the NYC fixture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.importers.base import ImportFilter, InvalidImportFilterError
+from src.importers.nys_voter_file import NysVoterFileImporter
+from src.importers.nys_voter_file.transform import nys_sboe_transformation_query
+
+FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "ny-voters-2026-03-08-10k-sample.parquet"
+
+
+class _Progress:
+    def advance(self, n: int = 1) -> None:
+        pass
+
+
+def test_no_filter_compiles_to_no_where() -> None:
+    assert "WHERE" not in nys_sboe_transformation_query("raw_t")
+
+
+def test_filter_compiles_to_in_clause_with_quotes_escaped() -> None:
+    sql = nys_sboe_transformation_query("raw_t", ImportFilter(column="congressional_district", values=["13", "1'4"]))
+    assert "WHERE raw.congressional_district IN ('13', '1''4')" in sql
+
+
+def test_empty_values_means_no_filter() -> None:
+    assert "WHERE" not in nys_sboe_transformation_query("raw_t", ImportFilter(column="county_code", values=[]))
+
+
+def test_unlisted_column_is_rejected_before_the_source_is_read() -> None:
+    # No connection needed: the allowlist check precedes the source check.
+    with pytest.raises(InvalidImportFilterError, match="not available"):
+        NysVoterFileImporter().load(
+            "/nope/not-here.parquet", "irrelevant", None, _Progress(), ImportFilter(column="status", values=["A"])
+        )
+
+
+@pytest.mark.skipif(not FIXTURE.exists(), reason="NYC fixture not present")
+def test_fixture_slices_to_one_congressional_district(conn) -> None:
+    nyc13 = ImportFilter(column="congressional_district", values=["13"])
+    table = NysVoterFileImporter().load(str(FIXTURE), "nys_voter_file_v1", conn, _Progress(), nyc13)
+    (count,) = conn.execute(f"SELECT count(*) FROM {table.fqn}").fetchone()
+    (total,) = conn.execute(f"SELECT count(*) FROM '{FIXTURE}' WHERE congressional_district = '13'").fetchone()
+    assert count == total > 0

--- a/apps/web/src/lib/importers.ts
+++ b/apps/web/src/lib/importers.ts
@@ -1,12 +1,38 @@
+import type { ImportFilter } from "@turf-tools/db/schema";
+
+// A source column an import filter may fix a dataset to. Values are the
+// file's own codes.
+export type ImportFilterField = { column: string; label: string };
+
+// Mirrors `NysVoterFileImporter.FILTER_COLUMNS` (decoded source column names).
+const NYS_FILTER_FIELDS: ReadonlyArray<ImportFilterField> = [
+  { column: "congressional_district", label: "Congressional district" },
+  { column: "assembly_district", label: "Assembly district" },
+  { column: "senate_district", label: "Senate district" },
+  { column: "county_code", label: "County" },
+  { column: "res_zip5", label: "ZIP code" },
+];
+
 // Curated importers available in the import picker, mirroring the data-side
 // registry (apps/data/src/importers). Will become an `importers.list` rpc once
 // generic (mapping-driven) importers need runtime config.
 export const AVAILABLE_IMPORTERS = [
-  { name: "nys_voter_file", label: "New York State Voter File" },
+  { name: "nys_voter_file", label: "New York State Voter File", filters: NYS_FILTER_FIELDS },
 ] as const;
 
 export type ImporterName = (typeof AVAILABLE_IMPORTERS)[number]["name"];
 
 export function importerLabel(name: string): string {
   return AVAILABLE_IMPORTERS.find((i) => i.name === name)?.label ?? name;
+}
+
+export function importFilterFields(importer: string): ReadonlyArray<ImportFilterField> {
+  return AVAILABLE_IMPORTERS.find((i) => i.name === importer)?.filters ?? [];
+}
+
+// "Congressional district 13"; null when the dataset imports the whole source.
+export function importFilterLabel(importer: string, filter: ImportFilter | null | undefined) {
+  if (!filter || filter.values.length === 0) return null;
+  const field = importFilterFields(importer).find((f) => f.column === filter.column);
+  return `${field?.label ?? filter.column} ${filter.values.join(", ")}`;
 }

--- a/apps/web/src/routes/$orgSlug/data/$datasetId.tsx
+++ b/apps/web/src/routes/$orgSlug/data/$datasetId.tsx
@@ -38,7 +38,7 @@ import { Pill } from "~/components/pill";
 import { Switch } from "~/components/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/table";
 import { formatDateTime } from "~/lib/format";
-import { importerLabel } from "~/lib/importers";
+import { importerLabel, importFilterLabel } from "~/lib/importers";
 import { useRememberSelection } from "~/lib/last-selected";
 import { GRAY, GREEN, RED, YELLOW } from "~/lib/palette";
 import type { CustomFieldType } from "@turf-tools/db/schema";
@@ -134,7 +134,13 @@ function DatasetPage() {
   return (
     <DatasetEditor
       key={datasetId}
-      dataset={{ datasetId, name: first.name, importer: first.importer, versions }}
+      dataset={{
+        datasetId,
+        name: first.name,
+        importer: first.importer,
+        importFilter: first.importFilter,
+        versions,
+      }}
       orgSlug={orgSlug}
       timezone={timezone}
     />
@@ -146,7 +152,13 @@ function DatasetEditor({
   orgSlug,
   timezone,
 }: {
-  dataset: { datasetId: string; name: string; importer: string; versions: VersionRow[] };
+  dataset: {
+    datasetId: string;
+    name: string;
+    importer: string;
+    importFilter: VersionRow["importFilter"];
+    versions: VersionRow[];
+  };
   orgSlug: string;
   timezone: string;
 }) {
@@ -294,6 +306,8 @@ function DatasetEditor({
         onOpenChange={setUpdateOpen}
         datasetId={dataset.datasetId}
         datasetName={dataset.name}
+        importer={dataset.importer}
+        importFilter={dataset.importFilter}
         hasReadyVersion={readyVersionId != null}
         onUpdated={() => void queryClient.invalidateQueries({ queryKey: ["datasets"] })}
       />
@@ -321,6 +335,8 @@ function DatasetEditor({
         <FieldsCard
           fields={fields}
           baseFields={baseFields}
+          importer={dataset.importer}
+          importFilter={dataset.importFilter}
           hasImport={readyVersionId != null}
           onSelect={(f) => {
             setFieldTarget(f);
@@ -614,11 +630,15 @@ type FieldRow = {
 function FieldsCard({
   fields,
   baseFields,
+  importer,
+  importFilter,
   hasImport,
   onSelect,
 }: {
   fields: FieldRow[];
   baseFields: Array<{ label: string; kind: string }>;
+  importer: string;
+  importFilter: VersionRow["importFilter"];
   // False until a version finishes importing — fields don't exist yet.
   hasImport: boolean;
   onSelect: (f: FieldRow) => void;
@@ -640,6 +660,23 @@ function FieldsCard({
     // header text (border + pt-3 lands 3px below the th's centered text).
     <div className="-mt-[3px] flex min-h-0 w-80 shrink-0 flex-col rounded-md border border-border bg-card">
       <div className="flex flex-1 flex-col overflow-y-auto">
+        <div className="px-3.5 pt-3 pb-2 text-sm text-muted-foreground">Dataset info</div>
+        <div className="flex flex-col gap-1 p-2 pt-1 pb-3">
+          {[
+            { label: "Type", value: importerLabel(importer) },
+            { label: "Filter", value: importFilterLabel(importer, importFilter) },
+          ]
+            .filter((r) => r.value)
+            .map((r) => (
+              <div
+                key={r.label}
+                className="flex items-center justify-between gap-2 rounded-md px-1.5"
+              >
+                <span className="shrink-0 text-sm">{r.label}</span>
+                <span className="min-w-0 truncate text-sm text-muted-foreground">{r.value}</span>
+              </div>
+            ))}
+        </div>
         {sorted.length > 0 ? (
           <div className="px-3.5 pt-3 pb-1 text-sm text-muted-foreground">Custom fields</div>
         ) : null}
@@ -926,6 +963,8 @@ function UpdateDialog({
   onOpenChange,
   datasetId,
   datasetName,
+  importer,
+  importFilter,
   hasReadyVersion,
   onUpdated,
 }: {
@@ -933,9 +972,12 @@ function UpdateDialog({
   onOpenChange: (open: boolean) => void;
   datasetId: string;
   datasetName: string;
+  importer: string;
+  importFilter: VersionRow["importFilter"];
   hasReadyVersion: boolean;
   onUpdated: () => void;
 }) {
+  const filterLabel = importFilterLabel(importer, importFilter);
   const [source, setSource] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -976,7 +1018,9 @@ function UpdateDialog({
               Imports <span className="font-medium text-foreground">{datasetName}</span>. It becomes
               available once the import finishes.
             </>
-          )}
+          )}{" "}
+          Type {importerLabel(importer)}
+          {filterLabel ? <>, filtered to {filterLabel}</> : null}.
         </DialogDescription>
         <form
           onSubmit={(e) => {

--- a/apps/web/src/routes/$orgSlug/data/route.tsx
+++ b/apps/web/src/routes/$orgSlug/data/route.tsx
@@ -13,7 +13,7 @@ import {
 } from "~/components/dialog";
 import { Input } from "~/components/input";
 import { Rail, useShowArchived } from "~/components/rail";
-import { AVAILABLE_IMPORTERS } from "~/lib/importers";
+import { AVAILABLE_IMPORTERS, importFilterFields } from "~/lib/importers";
 import { hasPermission } from "~/lib/permissions";
 import { datasetsListQuery } from "~/lib/queries/datasets";
 import { useDialogMutation } from "~/lib/use-dialog-mutation";
@@ -235,6 +235,11 @@ function CreateDatasetDialog({
   const [name, setName] = useState("");
   const [importer, setImporter] = useState<string>(AVAILABLE_IMPORTERS[0].name);
   const [source, setSource] = useState("");
+  // Optional fixed slice, like type: a field of the selected importer plus the
+  // values to keep, as the file's own codes in comma-separated text, parsed on
+  // submit.
+  const [filterColumn, setFilterColumn] = useState<string | null>(null);
+  const [filterText, setFilterText] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [showDuplicate, setShowDuplicate] = useState(false);
 
@@ -245,14 +250,36 @@ function CreateDatasetDialog({
       setName("");
       setImporter(AVAILABLE_IMPORTERS[0].name);
       setSource("");
+      setFilterColumn(null);
+      setFilterText("");
       setError(null);
       setShowDuplicate(false);
     }
   }
 
+  const filterFields = importFilterFields(importer);
+  const filterField = filterFields.find((f) => f.column === filterColumn) ?? null;
+  const parsedFilterValues = Array.from(
+    new Set(
+      filterText
+        .split(/[,\s]+/)
+        .map((t) => t.trim())
+        .filter(Boolean),
+    ),
+  );
+  const importFilter =
+    filterField && parsedFilterValues.length > 0
+      ? { column: filterField.column, values: parsedFilterValues }
+      : null;
+
   const create = useMutation({
     mutationFn: () =>
-      client.datasets.create({ name: name.trim(), importer, sourceUri: source.trim() }),
+      client.datasets.create({
+        name: name.trim(),
+        importer,
+        sourceUri: source.trim(),
+        importFilter,
+      }),
     onSuccess: (res) => {
       onCreated(res.datasetId);
       onOpenChange(false);
@@ -266,15 +293,18 @@ function CreateDatasetDialog({
   // typing toward "Voter File 2026" passes through "Voter File", and warning
   // on a name that was never going to be submitted is noise.
   const duplicate = takenNames.some((n) => n.trim().toLowerCase() === name.trim().toLowerCase());
-  const valid = name.trim().length > 0 && source.trim().length > 0;
+  const valid =
+    name.trim().length > 0 &&
+    source.trim().length > 0 &&
+    (filterField == null || importFilter != null);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogTitle>Import dataset</DialogTitle>
         <DialogDescription>
-          Import a source file as a new dataset. Type is fixed after creation; use updates
-          afterwards to get newer versions.
+          Import a source file as a new dataset. Dataset type is fixed after creation, as are any
+          optional filters. Use updates afterwards to get newer versions.
         </DialogDescription>
         <form
           onSubmit={(e) => {
@@ -317,7 +347,11 @@ function CreateDatasetDialog({
                   <button
                     type="button"
                     key={imp.name}
-                    onClick={() => setImporter(imp.name)}
+                    onClick={() => {
+                      setImporter(imp.name);
+                      setFilterColumn(null);
+                      setFilterText("");
+                    }}
                     disabled={pending}
                     className={cn(
                       "rounded-md border border-border px-2.5 py-1 text-sm disabled:cursor-not-allowed active:translate-y-px",
@@ -343,6 +377,45 @@ function CreateDatasetDialog({
             />
             <span className="text-sm text-muted-foreground italic">URL of the raw file</span>
           </div>
+          {filterFields.length > 0 ? (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Filter</label>
+              <div className="flex flex-wrap gap-1.5">
+                {[{ column: null, label: "None" }, ...filterFields].map((f) => {
+                  const sel = filterColumn === f.column;
+                  return (
+                    <button
+                      type="button"
+                      key={f.column ?? "none"}
+                      onClick={() => {
+                        setError(null);
+                        setFilterColumn(f.column);
+                        setFilterText("");
+                      }}
+                      disabled={pending}
+                      className={cn(
+                        "rounded-md border border-border px-2.5 py-1 text-sm disabled:cursor-not-allowed active:translate-y-px",
+                        sel ? "bg-foreground/10" : "bg-background hover:bg-muted",
+                      )}
+                    >
+                      {f.label}
+                    </button>
+                  );
+                })}
+              </div>
+              {filterField ? (
+                <Input
+                  value={filterText}
+                  onChange={(e) => {
+                    setError(null);
+                    setFilterText(e.target.value);
+                  }}
+                  placeholder="single or comma-separated"
+                  disabled={pending}
+                />
+              ) : null}
+            </div>
+          ) : null}
           {error ? <DialogError error={error} /> : null}
           <div className="mt-2 flex justify-end gap-2">
             <DialogClose render={<Button variant="outline" type="button" />}>Cancel</DialogClose>

--- a/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
+++ b/apps/web/src/routes/$orgSlug/segments/$segmentId.tsx
@@ -29,6 +29,7 @@ import {
   segmentSampleQuery,
   segmentsListQuery,
 } from "~/lib/queries/segments";
+import { manifestQuery } from "~/lib/queries/manifest";
 import { questionsWithOptionsQuery } from "~/lib/queries/questions";
 import { AddStepMenu, FilterValueEditor } from "~/components/filter-editors";
 import { useFilterCatalog } from "~/lib/manifest";
@@ -70,6 +71,10 @@ function SegmentEditor() {
   // segment-ref filter editor reads this both to populate its dropdown
   // and to detect cycles transitively.
   const { data: allSegments } = useQuery(segmentsListQuery());
+  // Open on the active version's extent (a sliced dataset frames its slice);
+  // null falls back to the map's default view.
+  const { data: manifestData } = useQuery(manifestQuery());
+  const fitBounds = manifestData?.bounds ?? null;
 
   const stepsRaw = (activeSegmentDetail?.criteria as Criteria | null)?.steps ?? [];
   const stepsIdRef = useRef<string[]>([]);
@@ -322,6 +327,7 @@ function SegmentEditor() {
                 className="h-full"
                 points={stablePointsRef.current}
                 loading={pointsLoading && !stablePointsRef.current}
+                fitBounds={fitBounds}
               />
             ) : view === "list" ? (
               <SamplePanel

--- a/apps/web/src/rpc/web/datasets.ts
+++ b/apps/web/src/rpc/web/datasets.ts
@@ -8,9 +8,14 @@ import {
   organizations,
 } from "@turf-tools/db/schema";
 import { z } from "zod";
-import { AVAILABLE_IMPORTERS } from "~/lib/importers";
+import { AVAILABLE_IMPORTERS, importFilterFields } from "~/lib/importers";
 import type { Manifest } from "~/lib/manifest";
 import { webPub as pub } from "../context";
+
+const importFilterSchema = z.object({
+  column: z.string().min(1),
+  values: z.array(z.string().min(1)).min(1),
+});
 
 // Machine identity from the display name — becomes the DuckLake schema prefix
 // (`<slug>_v<n>`). Lowercase alphanumeric + underscores.
@@ -37,6 +42,7 @@ export const list = pub.input(z.object({}).optional()).handler(async ({ context 
       name: datasets.name,
       slug: datasets.slug,
       importer: datasets.importer,
+      importFilter: datasets.importFilter,
       versionId: datasetVersions.datasetVersionId,
       versionNumber: datasetVersions.versionNumber,
       status: datasetVersions.status,
@@ -297,12 +303,21 @@ export const create = pub
       name: z.string().min(1),
       importer: z.enum(AVAILABLE_IMPORTERS.map((i) => i.name) as [string, ...string[]]),
       sourceUri: z.string().min(1),
+      importFilter: importFilterSchema.nullish(),
     }),
   )
   .handler(async ({ context, input }) => {
     const base = slugify(input.name);
     if (!base)
       throw new ORPCError("BAD_REQUEST", { message: "Name must contain letters or numbers." });
+    const importFilter = input.importFilter ?? null;
+    if (
+      importFilter &&
+      !importFilterFields(input.importer).some((f) => f.column === importFilter.column)
+    )
+      throw new ORPCError("BAD_REQUEST", {
+        message: "That filter field isn't available for this dataset type.",
+      });
 
     // A duplicate name *within the org* almost certainly means "update the
     // existing dataset", so reject with that pointer. Name reuse across orgs
@@ -341,7 +356,7 @@ export const create = pub
     return context.db.transaction(async (tx) => {
       const [ds] = await tx
         .insert(datasets)
-        .values({ slug, name: input.name, importer: input.importer })
+        .values({ slug, name: input.name, importer: input.importer, importFilter })
         .returning({ datasetId: datasets.datasetId });
       await tx
         .insert(datasetOrganizations)
@@ -365,6 +380,7 @@ export const create = pub
           dataset_version_id: version!.datasetVersionId,
           source: input.sourceUri,
           organization_id: context.organizationId,
+          filter: importFilter,
         },
       });
       return { datasetId: ds!.datasetId };
@@ -382,7 +398,7 @@ export const update = pub
     return context.db.transaction(async (tx) => {
       // Must be a dataset the org is granted.
       const [grant] = await tx
-        .select({ datasetId: datasets.datasetId })
+        .select({ datasetId: datasets.datasetId, importFilter: datasets.importFilter })
         .from(datasets)
         .innerJoin(datasetOrganizations, eq(datasetOrganizations.datasetId, datasets.datasetId))
         .where(
@@ -467,6 +483,8 @@ export const update = pub
           dataset_version_id: version!.datasetVersionId,
           source: input.sourceUri,
           organization_id: context.organizationId,
+          // The dataset's fixed slice — every version imports the same one.
+          filter: grant.importFilter,
         },
       });
       return { versionId: version!.datasetVersionId };
@@ -481,6 +499,7 @@ export const manifest = pub.input(z.object({}).optional()).handler(async ({ cont
     .select({
       manifest: datasetVersions.manifest,
       versionId: datasetVersions.datasetVersionId,
+      derivedMetadata: datasetVersions.derivedMetadata,
     })
     .from(organizations)
     .innerJoin(
@@ -491,7 +510,12 @@ export const manifest = pub.input(z.object({}).optional()).handler(async ({ cont
     .limit(1);
   const row = rows[0];
   if (!row) return null;
-  return { manifest: row.manifest as Manifest, versionId: row.versionId };
+  return {
+    manifest: row.manifest as Manifest,
+    versionId: row.versionId,
+    // Rides with the manifest: same version, same lifetime.
+    bounds: row.derivedMetadata?.bounds ?? null,
+  };
 });
 
 // Flattened field list from a ready version's manifest — the Data page's

--- a/packages/db/src/schema/datasets.ts
+++ b/packages/db/src/schema/datasets.ts
@@ -21,13 +21,19 @@ export const datasets = app.table(
     // "nys_voter_file"). Fixed at creation — every version is the same kind of
     // data — and resolved to a class through the data-side importer registry.
     importer: text().notNull(),
-    // Pure identity: name + importer + slug, shared across all its versions.
+    // Optional row filter every version's import applies (`column IN values`
+    // over the importer's decoded source columns). Fixed at creation like
+    // `importer`, so a dataset is always the same slice of its source.
+    importFilter: jsonb().$type<ImportFilter>(),
+    // Pure identity: name + importer + slug + filter, shared across all its versions.
     // Which version is *live* is the org's concern (`organizations.activeDatasetVersionId`),
     // not the dataset's — a version can be active for one org and not another.
     createdAt: timestamp({ withTimezone: true }).defaultNow().notNull(),
   },
   (t) => [uniqueIndex("datasets_slug").on(t.slug)],
 );
+
+export type ImportFilter = { column: string; values: string[] };
 
 export type DatasetVersionStatus = "importing" | "ready" | "failed";
 
@@ -40,6 +46,9 @@ export type DatasetVersionStatus = "importing" | "ready" | "failed";
 export type DerivedMetadata = {
   rowCount?: number;
   elections?: { value: string; label: string; bit?: number }[];
+  // `[west, south, east, north]` of the geocoded persons — the frame maps
+  // open on. Absent on versions imported before it was derived.
+  bounds?: [number, number, number, number];
 };
 
 // An immutable, retained version of a dataset. Never deleted, so any pinned
@@ -56,7 +65,7 @@ export const datasetVersions = app.table(
     versionNumber: integer().notNull(),
     manifest: jsonb(),
     // Derived-once-at-import cache (see `DerivedMetadata`); read like `manifest`.
-    // Holds `rowCount` + `elections`.
+    // Holds `rowCount`, `elections`, and `bounds`.
     derivedMetadata: jsonb().$type<DerivedMetadata>(),
     sourceUri: text(),
     // Coarse import progress (step / total), shown as a % while `importing`.


### PR DESCRIPTION
This PR adds the ability to filter a dataset on import. The user case is an org setting up that only needs a particular slice of a larger dataset, for example, a voter file restricted to a district. In these cases, using the full larger dataset confers no utility, and filtering up front will speed up almost every other downstream operation. The implementation is an extra selection of filter alongside type during import, and the filter remains fixed for all versions of that dataset. To make the segment preview bounding smarter, also added an extra "bounds" derived metadata field for each dataset (previously the segment editor's bounds were hardcoded to NYC!).